### PR TITLE
Fixed typo on network-manager-applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pip install pywal desktop_entry_lib
  - Other Dependencies (install it with your distro's package manager)
 ```
 [ Possible package names ]
-bc blueberry bluez coreutils dunst findutils gawk gojq imagemagick light networkmanager networkmanagerapplet pavucontrol plasma-browser-integration playerctl procps pulseaudio ripgrep socat udev upower util-linux wget wireplumber wlogout wofi libqalculate sox nlohmann-json boost boost-libs
+bc blueberry bluez coreutils dunst findutils gawk gojq imagemagick light networkmanager network-manager-applet pavucontrol plasma-browser-integration playerctl procps pulseaudio ripgrep socat udev upower util-linux wget wireplumber wlogout wofi libqalculate sox nlohmann-json boost boost-libs
 [ Command for: Fedora (INCOMPLETE) ]
 sudo dnf install bc blueberry bluez coreutils dunst findutils gawk gojq ImageMagick light NetworkManager network-manager-applet pavucontrol plasma-browser-integration playerctl procps ripgrep socat udev upower util-linux wget wireplumber wlogout wofi qalc sox nlohmann-json-devel
 ```


### PR DESCRIPTION
Changed networkmanagerapplet to the correct package name `network-manager-applet` (Arch Linux)