### PR TITLE
Extend pip install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
  - Python
 ```
 [ Command ]
-pip install pywal desktop_entry_lib
+pip install pywal desktop_entry_lib poetry build
 ```
  - Other Dependencies (install it with your distro's package manager)
 ```


### PR DESCRIPTION
These python dependencies were necessary for me for install `python-material-color-utilities`