### PR TITLE
Extend pip install dependency README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
  - Python
 ```
 [ Command ]
-pip install pywal desktop_entry_lib poetry build
+pip install pywal desktop_entry_lib poetry build pygobject
 ```
  - Other Dependencies (install it with your distro's package manager)
 ```


### PR DESCRIPTION
Extend pip install command with dependency necessary for `.config/eww/scripts/get-icon.py`


Question about the icons from that script, they aren't included in this repository right? 