### PR TITLE
Extend package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pip install pywal desktop_entry_lib poetry build
  - Other Dependencies (install it with your distro's package manager)
 ```
 [ Possible package names ]
-bc blueberry bluez coreutils dunst findutils gawk gojq imagemagick light networkmanager network-manager-applet pavucontrol plasma-browser-integration playerctl procps pulseaudio ripgrep socat udev upower util-linux wget wireplumber wlogout wofi libqalculate sox nlohmann-json boost boost-libs
+bc blueberry bluez cliphist coreutils dunst findutils gawk gojq imagemagick light networkmanager network-manager-applet pavucontrol plasma-browser-integration playerctl procps pulseaudio ripgrep socat udev upower util-linux wget wireplumber wlogout wofi libqalculate sox nlohmann-json boost boost-libs
 [ Command for: Fedora (INCOMPLETE) ]
 sudo dnf install bc blueberry bluez coreutils dunst findutils gawk gojq ImageMagick light NetworkManager network-manager-applet pavucontrol plasma-browser-integration playerctl procps ripgrep socat udev upower util-linux wget wireplumber wlogout wofi qalc sox nlohmann-json-devel
 ```


### PR DESCRIPTION
extend readme packages which need to be installed with `cliphist`, required for: `SUPER, V`