### PR TITLE
Update eww/scripts/memory to work without swap

### DIFF
--- a/.config/eww/scripts/memory
+++ b/.config/eww/scripts/memory
@@ -22,7 +22,7 @@ while true; do
   perc=$(printf '%.1f' "$(free -m | rg Mem | awk '{print ($3/$2)*100}')")
 
   swapfree=$(printf '%.1fG' "$(bc -l <<< "($swapt - $swapu) / 1000")")
-  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print  ($2!=0) ? ($3/$2)*100 : 0)")
+  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print  ($2!=0) ? ($3/$2)*100 : 0}')")
 
   echo '{ "total": "'"$total"'", "used": "'"$used"'", "free": "'"$free"'", "swaptotal": "'"$swaptotal"'", "swapused": "'"$swapused"'", "swappercentage": '"$swapperc"', "swapfree": "'"$swapfree"'", "percentage": '"$perc"' }'
 

--- a/.config/eww/scripts/memory
+++ b/.config/eww/scripts/memory
@@ -22,7 +22,7 @@ while true; do
   perc=$(printf '%.1f' "$(free -m | rg Mem | awk '{print ($3/$2)*100}')")
 
   swapfree=$(printf '%.1fG' "$(bc -l <<< "($swapt - $swapu) / 1000")")
-  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print  ($2!=0) ? ($3/$2)*100 : 0}')")
+  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print ($2!=0) ? ($3/$2)*100 : 0}')")
 
   echo '{ "total": "'"$total"'", "used": "'"$used"'", "free": "'"$free"'", "swaptotal": "'"$swaptotal"'", "swapused": "'"$swapused"'", "swappercentage": '"$swapperc"', "swapfree": "'"$swapfree"'", "percentage": '"$perc"' }'
 

--- a/.config/eww/scripts/memory
+++ b/.config/eww/scripts/memory
@@ -22,7 +22,7 @@ while true; do
   perc=$(printf '%.1f' "$(free -m | rg Mem | awk '{print ($3/$2)*100}')")
 
   swapfree=$(printf '%.1fG' "$(bc -l <<< "($swapt - $swapu) / 1000")")
-  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print ($3/$2)*100}')")
+  swapperc=$(printf '%.1f' "$(free -m | rg Swap | awk '{print  ($2!=0) ? ($3/$2)*100 : 0)")
 
   echo '{ "total": "'"$total"'", "used": "'"$used"'", "free": "'"$free"'", "swaptotal": "'"$swaptotal"'", "swapused": "'"$swapused"'", "swappercentage": '"$swapperc"', "swapfree": "'"$swapfree"'", "percentage": '"$perc"' }'
 


### PR DESCRIPTION
Update script to check or system has swap, if it doesn't it will skip over the calculation to prevent divide by 0 error.


Something else i found, this script only works with locales which uses `.` as decimal separator. Other languages which use a `,` will not work. We could fix this for them by adding `LC_NUMERICAL=en_US.UTF-8` to the script. But i will leave it up to you to decide.  