### PR TITLE
Removing ctrl+c mapping

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -3,9 +3,9 @@ font_family JetBrains Mono Nerd Font
 font_size 12
 confirm_os_window_close 0
 
-map ctrl+c  copy_to_clipboard
-map ctrl+v  paste_from_clipboard
-map ctrl+shift+c send_text all \x03 
+#map ctrl+c  copy_to_clipboard
+#map ctrl+v  paste_from_clipboard
+#map ctrl+shift+c send_text all \x03 
 
 adjust_line_height 0
 cursor #00ccff

--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -3,10 +3,6 @@ font_family JetBrains Mono Nerd Font
 font_size 12
 confirm_os_window_close 0
 
-#map ctrl+c  copy_to_clipboard
-#map ctrl+v  paste_from_clipboard
-#map ctrl+shift+c send_text all \x03 
-
 adjust_line_height 0
 cursor #00ccff
 


### PR DESCRIPTION
Removing ctrl+c mapping because it overrides the real `CTRL+C` purpose that is used for interrupting blocking processes. In case the mapping in the conf file is enabled, if a process is blocked in the terminal, the user cannot interrupt it and take control of the terminal again. `CTRL + Z` is not enough because the blocking process will run in background. Furthermore, `CTRL+C` does not work on apps running in terminal, like nano or vim.  For this reason I suggest to comment/remove those mappings.

The user can still copy the content in the terminal by the default keybinding that is `CTRL+SHIFT+C` (same for paste by CTRL+SHIFT+V) without specifying any mapping.