### PR TITLE
Removing icon_path from dunstrc

### DIFF
--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -25,7 +25,6 @@ stack_duplicates = false
 hide_duplicate_count = yes
 show_indicators = no
 icon_position = left
-icon_path = "/home/end/.config/eww/images/linageOS Icons/1G.png"
 max_icon_size = 48
 sticky_history = no
 history_length = 20


### PR DESCRIPTION
Removing icon_path from dunstrc as requested in https://github.com/end-4/dots-hyprland/pull/20#event-9546981015 because not used