### PR TITLE
eww:mousemode - better mouse detection

### DIFF
--- a/.config/eww/variables.yuck
+++ b/.config/eww/variables.yuck
@@ -134,7 +134,7 @@
 (defpoll langs :initial "[]" :interval "5m" `cat json/langs.json | gojq -c -M`)
 (defpoll colormode   :interval "5m" "cat scripts/workdir/__mode_colors.txt")
 (defpoll coloraccent :initial "#E22369" :interval "5m" "cat css/_iconcolor.txt | head -1")
-(defpoll mousemode :interval "1m" "lsusb | grep -i mouse > /dev/null && echo 1 || echo 0")
+(defpoll mousemode :interval "1m" "lsusb.py -i | grep -i mouse > /dev/null && echo 1 || echo 0")
 
 ; Fetch stuff
 (defpoll distro :initial "EndeavourOS" :interval "5m" "grep -w NAME /etc/os-release | cut -d\" -f2")


### PR DESCRIPTION
Hey there!

I noticed that using just `lsusb` might not guarantee the detection of a mouse. For instance:

```
lsusb                                                
Bus 001 Device 004: ID 0bda:b009 Realtek Semiconductor Corp. Realtek Bluetooth 4.2 Adapter
Bus 001 Device 003: ID 0408:5365 Quanta Computer, Inc. HP TrueVision HD Camera
Bus 001 Device 002: ID 0438:7900 Advanced Micro Devices, Inc. Root Hub
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 003 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 002 Device 002: ID 0b05:1a94 ASUSTek Computer, Inc. ROG HARPE ACE AIM LAB EDITION
Bus 002 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
```

The output from `lsusb` doesn't recognize a device with `ID 0b05:1a94` as a mouse. However, if we use `lsusb.py -i`, it will produce a more detailed output that includes specific device information.

Take a look at the output below from `lsusb.py -i`:

```
lsusb.py -i
usb1              1d6b:0002 09 1IF  [USB 2.00,   480 Mbps,   0mA] (ehci_hcd 0000:00:12.0) hub
  1-1               0438:7900 09 1IF  [USB 2.00,   480 Mbps, 100mA] (Advanced Micro Devices, Inc. Root Hub) hub
    1-1.1             0408:5365 ef 2IFs [USB 2.01,   480 Mbps, 500mA] (SunplusIT Inc HP TrueVision HD Camera)
      1-1.1:1.0         (IF) 0e:01:00 1EP  (Video) uvcvideo video4linux/video1 video4linux/video0 
      1-1.1:1.1         (IF) 0e:02:00 0EPs (Video) uvcvideo 
    1-1.3             0bda:b009 e0 2IFs [USB 1.10,    12 Mbps, 500mA] (Realtek 802.11n WLAN Adapter 00e04c000001)
      1-1.3:1.0         (IF) e0:01:01 3EPs (Bluetooth) btusb bluetooth/hci0 
      1-1.3:1.1         (IF) e0:01:01 2EPs (Bluetooth) btusb 
usb2              1d6b:0002 09 1IF  [USB 2.00,   480 Mbps,   0mA] (xhci-hcd 0000:00:10.0) hub
  2-2               0b05:1a94 00 3IFs [USB 2.00,    12 Mbps, 500mA] (ASUSTeK ROG HARPE ACE AIM LAB EDITION NAMPGDD1274705)
    2-2:1.0           (IF) 03:00:00 2EPs (None) usbhid hidraw0 (hid-generic) 
    2-2:1.1           (IF) 03:01:02 1EP  (Mouse) usbhid hidraw1 (hid-generic) input5 (hid-generic) 
    2-2:1.2           (IF) 03:00:00 1EP  (None) usbhid hidraw2 (hid-generic) input9 input7 input8 input6 (hid-generic) 
usb3              1d6b:0003 09 1IF  [USB 3.00,  5000 Mbps,   0mA] (xhci-hcd 0000:00:10.0) hub
```

As you can see, on line `2-2:1.1 (IF) 03:01:02 1EP (Mouse) usbhid hidraw1 (hid-generic) input5 (hid-generic)`, it successfully detects a mouse. This additional information will allow us to properly detect a mouse using `grep -i mouse`.

`usbutils` should be added as dependencies (for both `lsusb` and `lsusb.py`).

Thank you for considering this pull request!