### PR TITLE
Move blur and it's relevant config paths to subcategory

### DIFF
--- a/.config/eww/scripts/hyprsettings
+++ b/.config/eww/scripts/hyprsettings
@@ -8,10 +8,10 @@ getoptions(){
   input_sensitivity=$(hyprctl getoption input:sensitivity -j | gojq -r -c '.float')
   touchpad_disable_while_typing=$(hyprctl getoption input:touchpad:disable_while_typing -j | gojq -r -c '.int')
   touchpad_clickfinger_behavior=$(hyprctl getoption input:touchpad:clickfinger_behavior -j | gojq -r -c '.int')
-  blur=$(hyprctl getoption decoration:blur -j | gojq -r -c '.int')
-  blur_size=$(hyprctl getoption decoration:blur_size -j | gojq -r -c '.int')
-  blur_passes=$(hyprctl getoption decoration:blur_passes -j | gojq -r -c '.int')
-  blur_xray=$(hyprctl getoption decoration:blur_xray -j | gojq -r -c '.int')
+  blur=$(hyprctl getoption decoration:blur:enabled -j | gojq -r -c '.int')
+  blur_size=$(hyprctl getoption decoration:blur:size -j | gojq -r -c '.int')
+  blur_passes=$(hyprctl getoption decoration:blur:passes -j | gojq -r -c '.int')
+  blur_xray=$(hyprctl getoption decoration:blur:xray -j | gojq -r -c '.int')
   nightlight=$(hyprctl getoption decoration:screen_shader -j | gojq -r -c '.str')
   if [[ "$nightlight" == *"nothing.frag" || "$nightlight" == "[[EMPTY]]" || "$nightlight" == "" ]]; then
     nightlight='false'

--- a/.config/eww/windows/osettings.yuck
+++ b/.config/eww/windows/osettings.yuck
@@ -403,14 +403,14 @@
                       :style "margin-left: 9px;"
                       (button :valign "center" :yalign 0.5
                         :class "osettings-tag"
-                        :onclick "hyprctl keyword decoration:blur false && scripts/hyprsettings tickle &"
+                        :onclick "hyprctl keyword decoration:blur:enabled false && scripts/hyprsettings tickle &"
                         "no blur"
                       )
                       (button :valign "center" :yalign 0.5
                         :class "osettings-tag"
-                        :onclick "hyprctl keyword decoration:blur true && \
-                        hyprctl keyword decoration:blur_size 7 && \
-                        hyprctl keyword decoration:blur_passes 4 && \
+                        :onclick "hyprctl keyword decoration:blur:enabled true && \
+                        hyprctl keyword decoration:blur:size 7 && \
+                        hyprctl keyword decoration:blur:passes 4 && \
                         scripts/hyprsettings tickle &"
                         "intense"
                       )
@@ -428,7 +428,7 @@
                     (box)
                     (checkboxhyprctl
                       :value "${hyprjson.blur}"
-                      :changevalue "decoration:blur"
+                      :changevalue "decoration:blur:enabled"
                     )
                   )
                   (revealer
@@ -448,7 +448,7 @@
                         :class "osettings-slider"
                         :value "${hyprjson.blur_size}"
                         :tooltip "Blur size: ${hyprjson.blur_size}"
-                        :onchange "hyprctl keyword decoration:blur_size {}  && scripts/hyprsettings tickle"
+                        :onchange "hyprctl keyword decoration:blur:size {}  && scripts/hyprsettings tickle"
                       )
                     )
                   )
@@ -469,7 +469,7 @@
                         :class "osettings-slider"
                         :value "${hyprjson.blur_passes * 10}"
                         :tooltip "Blur passes: ${hyprjson.blur_passes}"
-                        :onchange "hyprctl keyword decoration:blur_passes $(({} / 10))  && scripts/hyprsettings tickle"
+                        :onchange "hyprctl keyword decoration:blur:passes $(({} / 10))  && scripts/hyprsettings tickle"
                       )
                     )
                   )
@@ -492,7 +492,7 @@
                         (box)
                         (checkboxhyprctl
                           :value "${hyprjson.blur_xray}"
-                          :changevalue "decoration:blur_xray"
+                          :changevalue "decoration:blur:xray"
                         )
                       )
                     )

--- a/.config/eww/windows/winnews.yuck
+++ b/.config/eww/windows/winnews.yuck
@@ -310,7 +310,7 @@
                     (box)
                     (checkboxhyprctl-win
                       :value "${hyprjson.blur}"
-                      :changevalue "decoration:blur"
+                      :changevalue "decoration:blur:enabled"
                     )
                   )
                   (revealer
@@ -331,7 +331,7 @@
                         :class "winslider winslider-winnews"
                         :value "${hyprjson.blur_size}"
                         :tooltip "Blur size: ${hyprjson.blur_size}"
-                        :onchange "hyprctl keyword decoration:blur_size {}  && scripts/hyprsettings tickle"
+                        :onchange "hyprctl keyword decoration:blur:size {}  && scripts/hyprsettings tickle"
                       )
                     )
                   )
@@ -352,7 +352,7 @@
                         :class "winslider winslider-winnews"
                         :value "${hyprjson.blur_passes * 10}"
                         :tooltip "Blur passes: ${hyprjson.blur_passes}"
-                        :onchange "hyprctl keyword decoration:blur_passes $(({} / 10))  && scripts/hyprsettings tickle"
+                        :onchange "hyprctl keyword decoration:blur:passes $(({} / 10))  && scripts/hyprsettings tickle"
                       )
                     )
                   )
@@ -374,7 +374,7 @@
                         (box)
                         (checkboxhyprctl-win
                           :value "${hyprjson.blur_xray}"
-                          :changevalue "decoration:blur_xray"
+                          :changevalue "decoration:blur:xray"
                         )
                       )
                     )

--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -71,11 +71,13 @@ decoration {
 	rounding = 15
     
     # Blur
-    blur = yes
-    blur_size = 7
-    blur_passes = 4
-    blur_new_optimizations = on
-    blur_ignore_opacity = false
+    blur {
+        enabled = yes
+        size = 7
+        passes = 4
+        new_optimizations = on
+        ignore_opacity = false
+    }
     # Shadow
     drop_shadow = no
     shadow_range = 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-
+.config/eww/images/svg/*.svg
+.config/eww/eww_covers/*
+.config/eww/scripts/cache/*
+.config/eww/tmp/*


### PR DESCRIPTION
Required by hyprland `v0.28.0` as it moved the blur settings from `decorations` to it's own subcategory, `decorations:blur`

Pardon the stray .gitignore though. I don't know how to only make a PR without it.