### PR TITLE
Not able to open sidebars

### DIFF
--- a/.config/eww/scripts/toggle-sideleft.sh
+++ b/.config/eww/scripts/toggle-sideleft.sh
@@ -5,8 +5,8 @@ if [[ "$state" == "true" || "$1" == "--close" ]]; then
     eww update open_sideleft=false
     eww update bar_offset=0
 else
-    eww open sideleft
     eww update open_sideleft=true
     eww update bar_offset=1
     eww update open_sideright=false
+    eww open sideleft
 fi

--- a/.config/eww/scripts/toggle-sideright.sh
+++ b/.config/eww/scripts/toggle-sideright.sh
@@ -6,9 +6,9 @@ if [[ "$state" == "true" || "$1" == "--close" ]]; then
     eww update bar_offset=0
 else
     cd ~/.config/eww || exit
-    eww open sideright
     eww update open_sideright=true
     eww update bar_offset=-1
     eww update open_sideleft=false
     eww update notifications="$(scripts/notifget)"
+    eww open sideright
 fi


### PR DESCRIPTION
I was not able to open the left and right sidebars. I think I am the first to have this problem, but I have partially solved it myself. Please correct me if I am wrong.

If I am correct, the toggle-sideleft and toggle-sideright scripts are responsible for opening the windows after the mouse click. Somehow, by simply moving the command, I managed to get the bar to open. 

The other problem:
Somehow, the sidebar only opens when I run the new script manually. By simply clicking, nothing happens. Even if I restart eww or reboot my system, the sidebars are still only opened by the customized script. Maybe I'm just stupid or something and don't know how to handle an update of the scripts. I am just a beginner

If you still don't understand what I've described here, I've created a video that explains the whole thing. For the right sidebar it's the same, I took the left sidebar as an example.


https://github.com/end-4/dots-hyprland/assets/70955799/2bf15405-5699-45f1-9e8b-e451d5a3bcbd

I also wanted to thank you for making this all open source and taking so much time to do it.