### PR TITLE
remove linux 'date' command from js

### DIFF
--- a/.config/ags/windows/bar/system.js
+++ b/.config/ags/windows/bar/system.js
@@ -2,6 +2,7 @@
 // For the cool memory indicator on the sidebar, see sysinfo.js
 import { Service, Utils, Widget } from '../../imports.js';
 const { exec, execAsync } = Utils;
+const { GLib } = imports.gi;
 import Battery from 'resource:///com/github/Aylur/ags/service/battery.js';
 
 const BATTERY_LOW = 20;
@@ -13,9 +14,7 @@ const barClock = Widget.Box({
         Widget.Label({
             className: 'bar-clock',
             connections: [[5000, label => {
-                execAsync([`date`, "+%H:%M"]).then(timeString => {
-                    label.label = timeString;
-                }).catch(print);
+                label.label = GLib.DateTime.new_now_local().format("%H:%M");
             }]],
         }),
         Widget.Label({
@@ -25,9 +24,7 @@ const barClock = Widget.Box({
         Widget.Label({
             className: 'txt-smallie txt',
             connections: [[5000, label => {
-                execAsync([`date`, "+%A, %d/%m"]).then(dateString => {
-                    label.label = dateString;
-                }).catch(print);
+                label.label = GLib.DateTime.new_now_local().format("%A, %d/%m");
             }]],
         }),
     ],

--- a/.config/ags/windows/sideright/sideright.js
+++ b/.config/ags/windows/sideright/sideright.js
@@ -1,4 +1,4 @@
-const { Gdk, Gtk } = imports.gi;
+const { GLib, Gdk, Gtk } = imports.gi;
 import { Utils, Widget } from '../../imports.js';
 const { execAsync, exec } = Utils;
 const { Box, EventBox } = Widget;
@@ -77,9 +77,7 @@ export default () => Box({
                                         Widget.Label({
                                             className: 'txt-title txt',
                                             connections: [[5000, label => {
-                                                execAsync([`date`, "+%H:%M"]).then(timeString => {
-                                                    label.label = timeString;
-                                                }).catch(print);
+                                                label.label = GLib.DateTime.new_now_local().format("%H:%M");
                                             }]],
                                         }),
                                         Widget.Label({


### PR DESCRIPTION
why use 'date' if there is a 'GLib.DateTime'?