### PR TITLE
Fix CJK copied by Ctrl+C became \uxxxx

### DIFF
--- a/.config/hypr/execs.conf
+++ b/.config/hypr/execs.conf
@@ -15,7 +15,8 @@ exec-once = swayidle -w timeout 450 'pidof java || systemctl suspend' &
 exec-once = sleep 1 && dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP # Some fix idk
 
 # Clipboard: history
-exec-once = wl-paste --watch cliphist store &
+exec-once = wl-paste --type text --watch cliphist store
+exec-once = wl-paste --type image --watch cliphist store
 # Clipboard: disable middle-click paste
 exec-once = wl-paste -p --watch wl-copy -p ""
 


### PR DESCRIPTION
When content copied by Ctrl+C , CJK character becomes `\uxxxx` in `cliphist list`, which reason is actually inside the wl-paste.

You can test this out by adding following to `keybinds.conf` in `~/.config/hypr`:
```conf
bind=,F11,exec, pkill wl-paste && wl-paste --type text --watch cliphist store & wl-paste --type image --watch cliphist store & wl-paste -p --watch wl-copy -p ""
bind=,F12,exec, pkill wl-paste && wl-paste --watch cliphist store & wl-paste -p --watch wl-copy -p ""
```
When you use `F12`, and `Ctrl`+`C` copy this text: `test 测试`, then `cliphist list` in terminal, it becomes `test \u6d4b\u8bd5`.

When you use `F11` (corresponding to the fix included in this PR), and `Ctrl`+`C` copy this text: `test 测试`, then `cliphist list` in terminal, it becomes `test 测试`.