### PR TITLE
New workflow: Supporting bar and overview for Workspaces > 10

### DIFF
--- a/.config/ags/widgets/bar/workspaces_hyprland.js
+++ b/.config/ags/widgets/bar/workspaces_hyprland.js
@@ -8,13 +8,14 @@ import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 const { Box, DrawingArea, EventBox } = Widget;
 import Hyprland from 'resource:///com/github/Aylur/ags/service/hyprland.js';
 
-const NUM_OF_WORKSPACES = 10;
+const NUM_WS_GROUPS = 3;
+const NUM_OF_WORKSPACES_PER_GROUP = 10;
 const dummyWs = Box({ className: 'bar-ws' }); // Not shown. Only for getting size props
 const dummyActiveWs = Box({ className: 'bar-ws bar-ws-active' }); // Not shown. Only for getting size props
 const dummyOccupiedWs = Box({ className: 'bar-ws bar-ws-occupied' }); // Not shown. Only for getting size props
 
 // Font size = workspace id
-const WorkspaceContents = (count = 10) => {
+const WorkspaceContents = (offset = 0, count = 10) => {
     return DrawingArea({
         css: `transition: 90ms cubic-bezier(0.1, 1, 0, 1);`,
         attribute: {
@@ -26,8 +27,8 @@ const WorkspaceContents = (count = 10) => {
                 let workspaceMask = 0;
                 for (let i = 0; i < workspaces.length; i++) {
                     const ws = workspaces[i];
-                    if (ws.id <= 0) continue; // Ignore scratchpads
-                    if (ws.id > count) return; // Not rendered
+                    if (ws.id <= offset) continue; // Ignore scratchpads
+                    if (ws.id > offset + count) continue; // Not rendered
                     if (workspaces[i].windows > 0) {
                         workspaceMask |= (1 << ws.id);
                     }
@@ -42,7 +43,7 @@ const WorkspaceContents = (count = 10) => {
         },
         setup: (area) => area
             .hook(Hyprland.active.workspace, (area) =>
-                area.setCss(`font-size: ${Hyprland.active.workspace.id}px;`)
+                area.setCss(`font-size: ${(Hyprland.active.workspace.id-1) % NUM_OF_WORKSPACES_PER_GROUP + 1}px;`)
             )
             .hook(Hyprland, (self) => self.attribute.updateMask(self), 'notify::workspaces')
             .hook(Hyprland, (self, name) => self.attribute.toggleMask(self, true, name), 'workspace-added')
@@ -86,12 +87,12 @@ const WorkspaceContents = (count = 10) => {
 
                 // Draw workspace numbers
                 for (let i = 1; i <= count; i++) {
-                    if (area.attribute.workspaceMask & (1 << i)) {
+                    if (area.attribute.workspaceMask & (1 << (i + offset))) {
                         // Draw bg highlight
                         cr.setSourceRGBA(occupiedbg.red, occupiedbg.green, occupiedbg.blue, occupiedbg.alpha);
                         const wsCenterX = -(workspaceRadius) + (workspaceDiameter * i);
                         const wsCenterY = height / 2;
-                        if (!(area.attribute.workspaceMask & (1 << (i - 1)))) { // Left
+                        if (!(area.attribute.workspaceMask & (1 << (i + offset - 1))) || i == 1) { // Left
                             cr.arc(wsCenterX, wsCenterY, workspaceRadius, 0.5 * Math.PI, 1.5 * Math.PI);
                             cr.fill();
                         }
@@ -99,7 +100,7 @@ const WorkspaceContents = (count = 10) => {
                             cr.rectangle(wsCenterX - workspaceRadius, wsCenterY - workspaceRadius, workspaceRadius, workspaceRadius * 2)
                             cr.fill();
                         }
-                        if (!(area.attribute.workspaceMask & (1 << (i + 1)))) { // Right
+                        if (!(area.attribute.workspaceMask & (1 << (i + offset + 1))) || i == count) { // Right
                             cr.arc(wsCenterX, wsCenterY, workspaceRadius, -0.5 * Math.PI, 0.5 * Math.PI);
                             cr.fill();
                         }
@@ -130,8 +131,14 @@ const WorkspaceContents = (count = 10) => {
                 cr.fill();
                 // inner decor
                 cr.setSourceRGBA(activefg.red, activefg.green, activefg.blue, activefg.alpha);
-                cr.arc(activeWsCenterX, activeWsCenterY, indicatorRadius * 0.2, 0, 2 * Math.PI);
-                cr.fill();
+                //cr.arc(activeWsCenterX, activeWsCenterY, indicatorRadius * 0.2, 0, 2 * Math.PI);
+                //cr.fill();
+                layout.set_text(`${Hyprland.active.workspace.id}`, -1);
+                const [layoutWidthWSActive, layoutHeightWSActive] = layout.get_pixel_size();
+                const x = activeWsCenterX - (layoutWidthWSActive / 2);
+                const y = activeWsCenterY - (layoutHeightWSActive / 2);
+                cr.moveTo(x, y);
+                PangoCairo.show_layout(cr, layout);
             }))
         ,
     })
@@ -142,16 +149,19 @@ export default () => EventBox({
     onScrollDown: () => Hyprland.sendMessage(`dispatch workspace +1`),
     onMiddleClickRelease: () => App.toggleWindow('overview'),
     onSecondaryClickRelease: () => App.toggleWindow('osk'),
-    attribute: { clicked: false },
+    attribute: {
+      clicked: false,
+      ws_group: 0,
+    },
     child: Box({
         homogeneous: true,
         className: 'bar-group-margin',
         children: [Box({
             className: 'bar-group bar-group-standalone bar-group-pad',
             css: 'min-width: 2px;',
-            children: [
-                WorkspaceContents(10),
-            ]
+            children: Array.from({ length: NUM_WS_GROUPS }, (_, index) =>
+                WorkspaceContents(index*NUM_OF_WORKSPACES_PER_GROUP, NUM_OF_WORKSPACES_PER_GROUP)
+            )
         })]
     }),
     setup: (self) => {
@@ -160,7 +170,7 @@ export default () => EventBox({
             if (!self.attribute.clicked) return;
             const [_, cursorX, cursorY] = event.get_coords();
             const widgetWidth = self.get_allocation().width;
-            const wsId = Math.ceil(cursorX * NUM_OF_WORKSPACES / widgetWidth);
+            const wsId = Math.ceil(cursorX * NUM_OF_WORKSPACES_PER_GROUP / widgetWidth) + self.attribute.ws_group*NUM_OF_WORKSPACES_PER_GROUP;
             Hyprland.sendMessage(`dispatch workspace ${wsId}`)
         })
         self.on('button-press-event', (self, event) => {
@@ -168,9 +178,15 @@ export default () => EventBox({
             self.attribute.clicked = true;
             const [_, cursorX, cursorY] = event.get_coords();
             const widgetWidth = self.get_allocation().width;
-            const wsId = Math.ceil(cursorX * NUM_OF_WORKSPACES / widgetWidth);
+            const wsId = Math.ceil(cursorX * NUM_OF_WORKSPACES_PER_GROUP / widgetWidth) + self.attribute.ws_group*NUM_OF_WORKSPACES_PER_GROUP;
             Hyprland.sendMessage(`dispatch workspace ${wsId}`);
         })
         self.on('button-release-event', (self) => self.attribute.clicked = false);
+        self.hook(Hyprland.active.workspace, (self) => {
+          self.attribute.ws_group = Math.floor((Hyprland.active.workspace.id-1)/NUM_OF_WORKSPACES_PER_GROUP);
+          for (let i = 0; i < self.child.children[0].children.length; i++) {
+            self.child.children[0].children[i].set_visible(self.attribute.ws_group == i);
+          }
+        });
     }
 })

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -26,13 +26,13 @@ bind = Super+Shift, W, exec, wps
 
 # Apps: Settings and config
 bind = Super, I, exec, XDG_CURRENT_DESKTOP="gnome" gnome-control-center
-bind = Control+Super, V, exec, pavucontrol 
+bind = Control+Super, V, exec, pavucontrol
 bind = Control+Shift, Escape, exec, gnome-system-monitor
 
 # Actions
 bind = Super, Period, exec, pkill fuzzel || ~/.local/bin/fuzzel-emoji
 bind = Super, Q, killactive,
-bind = Super+Alt, Space, togglefloating, 
+bind = Super+Alt, Space, togglefloating,
 bind = Shift+Super+Alt, Q, exec, hyprctl kill
 bind = Control+Shift+Alt, Delete, exec, pkill wlogout || wlogout -p layer-shell
 bind = Control+Shift+Alt+Super, Delete, exec, systemctl poweroff
@@ -150,32 +150,32 @@ bind = Super, D, fullscreen, 1
 bind = Super_Alt, F, fakefullscreen, 0
 
 # Switching
-bind = Super, 1, workspace, 1
-bind = Super, 2, workspace, 2
-bind = Super, 3, workspace, 3
-bind = Super, 4, workspace, 4
-bind = Super, 5, workspace, 5
-bind = Super, 6, workspace, 6
-bind = Super, 7, workspace, 7
-bind = Super, 8, workspace, 8
-bind = Super, 9, workspace, 9
-bind = Super, 0, workspace, 10
+bind = Super, 1, exec, ~/.config/hypr/workspace_action.sh workspace 1
+bind = Super, 2, exec, ~/.config/hypr/workspace_action.sh workspace 2
+bind = Super, 3, exec, ~/.config/hypr/workspace_action.sh workspace 3
+bind = Super, 4, exec, ~/.config/hypr/workspace_action.sh workspace 4
+bind = Super, 5, exec, ~/.config/hypr/workspace_action.sh workspace 5
+bind = Super, 6, exec, ~/.config/hypr/workspace_action.sh workspace 6
+bind = Super, 7, exec, ~/.config/hypr/workspace_action.sh workspace 7
+bind = Super, 8, exec, ~/.config/hypr/workspace_action.sh workspace 8
+bind = Super, 9, exec, ~/.config/hypr/workspace_action.sh workspace 9
+bind = Super, 0, exec, ~/.config/hypr/workspace_action.sh workspace 10
 bind = Super, S, togglespecialworkspace,
 bind = Control+Super, S, togglespecialworkspace,
 bind = Alt, Tab, cyclenext
 bind = Alt, Tab, bringactivetotop,   # bring it to the top
 
-# Move window to workspace Super + Alt + [0-9] 
-bind = Super+Alt, 1, movetoworkspacesilent, 1
-bind = Super+Alt, 2, movetoworkspacesilent, 2
-bind = Super+Alt, 3, movetoworkspacesilent, 3
-bind = Super+Alt, 4, movetoworkspacesilent, 4
-bind = Super+Alt, 5, movetoworkspacesilent, 5
-bind = Super+Alt, 6, movetoworkspacesilent, 6
-bind = Super+Alt, 7, movetoworkspacesilent, 7
-bind = Super+Alt, 8, movetoworkspacesilent, 8
-bind = Super+Alt, 9, movetoworkspacesilent, 9
-bind = Super+Alt, 0, movetoworkspacesilent, 10
+# Move window to workspace Super + Alt + [0-9]
+bind = Super+Alt, 1, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 1
+bind = Super+Alt, 2, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 2
+bind = Super+Alt, 3, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 3
+bind = Super+Alt, 4, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 4
+bind = Super+Alt, 5, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 5
+bind = Super+Alt, 6, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 6
+bind = Super+Alt, 7, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 7
+bind = Super+Alt, 8, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 8
+bind = Super+Alt, 9, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 9
+bind = Super+Alt, 0, exec, ~/.config/hypr/workspace_action.sh movetoworkspace 10
 bind = Control+Shift+Super, Up, movetoworkspacesilent, special
 bind = Super+Alt, S, movetoworkspacesilent, special
 
@@ -192,7 +192,7 @@ bindm = Super, mouse:273, resizewindow
 bindm = Super, Z, movewindow
 bind = Control+Super, Backslash, resizeactive, exact 640 480
 
-bindle = Alt, I, exec, ydotool key 103:1 103:0 
+bindle = Alt, I, exec, ydotool key 103:1 103:0
 bindle = Alt, K, exec, ydotool key 108:1 108:0
 bindle = Alt, J, exec, ydotool key 105:1 105:0
 bindle = Alt, L, exec, ydotool key 106:1 106:0

--- a/.config/hypr/workspace_action.sh
+++ b/.config/hypr/workspace_action.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+hyprctl dispatch $1 $((((`hyprctl activeworkspace -j | jq -r .id` - 1)  / 10) * 10 + $2))


### PR DESCRIPTION
First attempt at JS ... wish me luck :(

This feature will be useful for:
- Users like me who shamelessly opens dozen of workspaces and wants a non-cluttered way of navigating through them. 
- Users having multiple monitors and want to have awesome-wm like experience, where each monitors will have its own set of 10 workspaces.
- Multitaskers who want to context-switch to a different task altogether (like office or personal) and don't want to clutter apps or rearrange workspaces.

This will not affect any functionality for users having workspace <= 10

Description:
- The workspaces will be grouped in a set of 10. If we have 30 workspaces then they will be divided into 3 groups (1-10, 11-20 and 21-30). The current focused group will depend upon the active workspace. If active ws is in between 1-10, group 1 (ws 1-10) will be focused, if active ws is in between 11-20, then group 2 will be on focus, and so on.
- The workspace panel in the bar (showing occupied or active status) will change based upon the focused group/ active workspace. Eg. if focused group is 1, it will show the status for workspaces 1-10. Similarly, for focused group being 2, the workspace panel will show the status for 11-20. For identifying the focused workspace group, the ' • ' decoration is replaced with the current workspace ID. I didn't like the workspace panel to be cluttered with 2-digit numbers. 
- The overview panel is also affected in the same way.
- Added support for navigating and moving workspaces in hypr keybinds. Eg. pressing Super+3 will move you to workspace-3 if current workspace is between 1-10, or workspace-13 if current workspace is in between 11-20.
- As of now it supports till 30 workspaces (3 groups of 10 each) but this can be increased by modifying NUM_WS_GROUPS in workspaces_hyprland.js and overview_hyprland.js 

Video:
https://github.com/end-4/dots-hyprland/assets/47367711/a0fc9590-a0bb-409f-ade2-52aad1b601a1

Thanks