### PR TITLE
Remove redundant `cd $(dirname $0)` lines

### DIFF
--- a/scriptdata/functions
+++ b/scriptdata/functions
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # This is NOT a script for execution, but for loading functions, so NOT need execution permission.
 # NOTE that you NOT need to `cd ..' because the `$0' is NOT this file, but the script file which will source this file.
-cd "$(dirname "$0")"
-export base="$(pwd)"
+
+# The script that use this file should have two lines on its top as follows:
+# cd "$(dirname "$0")"
+# export base="$(pwd)"
 
 function try { "$@" || sleep 0; }
 function v() {

--- a/scriptdata/installers
+++ b/scriptdata/installers
@@ -2,8 +2,10 @@
 # This script depends on `functions' .
 # This is NOT a script for execution, but for loading functions, so NOT need execution permission.
 # NOTE that you NOT need to `cd ..' because the `$0' is NOT this file, but the script file which will source this file.
-cd "$(dirname "$0")"
-export base="$(pwd)"
+
+# The script that use this file should have two lines on its top as follows:
+# cd "$(dirname "$0")"
+# export base="$(pwd)"
 
 install-yay() {
   x sudo pacman -Sy --needed --noconfirm base-devel


### PR DESCRIPTION
These extra lines actually caused errors, but they did not stopped the install script because they're sourced before `set -e`, so that the script still ran without problem.

Anyway, it should be fixed though.