### PR TITLE
🚀 Add `anyrun` to dependencies.conf

### DIFF
--- a/scriptdata/dependencies.conf
+++ b/scriptdata/dependencies.conf
@@ -23,7 +23,7 @@ polkit-gnome gnome-keyring gnome-control-center blueberry networkmanager brightn
 
 ### Widgets
 # wayland-idle-inhibitor-git : providing `wayland-idle-inhibitor.py' used by the `Keep system awake' button in `.config/ags/widgets/sideright/quicktoggles.js'.
-wayland-idle-inhibitor-git swayidle swaylock-effects-git wlogout wl-clipboard hyprpicker-git grim tesseract slurp
+wayland-idle-inhibitor-git swayidle swaylock-effects-git wlogout wl-clipboard hyprpicker-git grim tesseract slurp anyrun
 
 ### Fonts and Themes
 adw-gtk3-git gradience-git fontconfig lexend-fonts-git ttf-jetbrains-mono-nerd ttf-material-symbols-variable-git ttf-space-mono-nerd fish foot starship

--- a/scriptdata/dependencies.conf
+++ b/scriptdata/dependencies.conf
@@ -23,7 +23,7 @@ polkit-gnome gnome-keyring gnome-control-center blueberry networkmanager brightn
 
 ### Widgets
 # wayland-idle-inhibitor-git : providing `wayland-idle-inhibitor.py' used by the `Keep system awake' button in `.config/ags/widgets/sideright/quicktoggles.js'.
-wayland-idle-inhibitor-git swayidle swaylock-effects-git wlogout wl-clipboard hyprpicker-git grim tesseract slurp anyrun
+wayland-idle-inhibitor-git swayidle swaylock-effects-git wlogout wl-clipboard hyprpicker-git grim tesseract slurp anyrun-git
 
 ### Fonts and Themes
 adw-gtk3-git gradience-git fontconfig lexend-fonts-git ttf-jetbrains-mono-nerd ttf-material-symbols-variable-git ttf-space-mono-nerd fish foot starship


### PR DESCRIPTION
I have found that `anyrun` was missing after I ran the script, I had to install it manually and I even had to execute `rustup default stable` in order to install `anyrun` 