### PR TITLE
Fix screen snip (grimblast) ags widget

### DIFF
--- a/.config/ags/modules/bar/normal/system.js
+++ b/.config/ags/modules/bar/normal/system.js
@@ -67,7 +67,7 @@ const Utilities = () => Box({
     children: [
         UtilButton({
             name: 'Screen snip', icon: 'screenshot_region', onClicked: () => {
-                Utils.execAsync(`${App.configDir}/scripts/grimblast.sh`)
+                Utils.execAsync(`${App.configDir}/scripts/grimblast.sh copy area`)
                     .catch(print)
             }
         }),


### PR DESCRIPTION
Grimblast is being called without arguments, resulting in a silent error. Functionality becomes the same like it used to when it used slurp > grim > wl-copy.