### PR TITLE
Toggling refresh rate on the basis of battery status.

### DIFF
--- a/Import Manually/togglerefreshrate/toggle.sh
+++ b/Import Manually/togglerefreshrate/toggle.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#!Toggle between 144hz and 60hz refresh rate according to charging status(change values according to your system.)
+
+while true; do
+charger_status=$(acpi -a | cut -d' ' -f3 | cut -d- -f1)
+
+if [ "$charger_status" == "off" ]; then
+    hyprctl keyword monitor eDP-1, 1920x1080@60,0x0,1
+fi
+
+if [ "$charger_status" == "on" ]; then
+    hyprctl keyword monitor eDP-1, 1920x1080@144,0x0,1
+fi
+
+    sleep 5
+done


### PR DESCRIPTION
A simple script to automatically switch your refresh rate on the basis of your battery status.  Install acpi before using the script. Change values according to your system.