### PR TITLE
Update spaceleft.js

### DIFF
--- a/.config/ags/modules/bar/normal/spaceleft.js
+++ b/.config/ags/modules/bar/normal/spaceleft.js
@@ -23,7 +23,15 @@ const WindowTitle = async () => {
                         xalign: 0,
                         className: 'txt txt-smallie',
                         setup: (self) => self.hook(Hyprland.active.client, label => { // Hyprland.active.client
-                            label.label = Hyprland.active.client.title.length === 0 ? `Workspace ${Hyprland.active.workspace.id}` : Hyprland.active.client.title;
+                            if (Hyprland.active.client.title.length === 0) {
+                                label.label = `Workspace ${Hyprland.active.workspace.id}`;
+                                return;
+                            };
+                            if (Hyprland.active.client.title.length > 20){
+                                label.label = Hyprland.active.client.title.substring(0,20) + "...";
+                                return;
+                            };
+                            label.label = Hyprland.active.client.title;
                         }),
                     })
                 ]


### PR DESCRIPTION
Bug:
The Hyprland.active.client.title can be too long to attach closely to the next widget (normally when a browser's tab has too long title).

I just change the substring the long title and let it end with "..."

Should be a more graceful way to handle this. But that's beyond my scope.