### PR TITLE
hypr: update config files to comply with hyprlang

### DIFF
--- a/.config/hypr/custom/env.conf
+++ b/.config/hypr/custom/env.conf
@@ -1,2 +1,2 @@
-## You can put extra environment variables here
-## https://wiki.hyprland.org/Configuring/Environment-variables/
+# You can put extra environment variables here
+# https://wiki.hyprland.org/Configuring/Environment-variables/

--- a/.config/hypr/custom/general.conf
+++ b/.config/hypr/custom/general.conf
@@ -1,2 +1,2 @@
-## Put general config stuff here
-## Here's a list of every variable: https://wiki.hyprland.org/Configuring/Variables/
+# Put general config stuff here
+# Here's a list of every variable: https://wiki.hyprland.org/Configuring/Variables/

--- a/.config/hypr/custom/keybinds.conf
+++ b/.config/hypr/custom/keybinds.conf
@@ -1,2 +1,2 @@
-## You can put your preferred keybinds here
-## https://wiki.hyprland.org/Configuring/Binds/
+# You can put your preferred keybinds here
+# https://wiki.hyprland.org/Configuring/Binds/

--- a/.config/hypr/custom/rules.conf
+++ b/.config/hypr/custom/rules.conf
@@ -1,3 +1,3 @@
-## You can put custom rules here
-## Window/layer rules: https://wiki.hyprland.org/Configuring/Window-Rules/
-## Workspace rules: https://wiki.hyprland.org/Configuring/Workspace-Rules/
+# You can put custom rules here
+# Window/layer rules: https://wiki.hyprland.org/Configuring/Window-Rules/
+# Workspace rules: https://wiki.hyprland.org/Configuring/Workspace-Rules/

--- a/.config/hypr/hyprland/env.conf
+++ b/.config/hypr/hyprland/env.conf
@@ -1,5 +1,5 @@
-########## Input method ########## 
-## See https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland
+# ######### Input method ########## 
+# See https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland
 env = QT_IM_MODULE, fcitx
 env = XMODIFIERS, @im=fcitx
 # env = GTK_IM_MODULE, wayland   # Crashes electron apps in xwayland
@@ -8,14 +8,14 @@ env = SDL_IM_MODULE, fcitx
 env = GLFW_IM_MODULE, ibus
 env = INPUT_METHOD, fcitx
 
-############# Themes #############
+# ############ Themes #############
 env = QT_QPA_PLATFORM, wayland
 env = QT_QPA_PLATFORMTHEME, qt5ct
 # env = QT_STYLE_OVERRIDE,kvantum
 env = WLR_NO_HARDWARE_CURSORS, 1
 
-######### Screen tearing #########
+# ######## Screen tearing #########
 # env = WLR_DRM_NO_ATOMIC, 1
 
-############# Others #############
+# ############ Others #############
 

--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -1,4 +1,4 @@
-#################### It just works™ keybinds ###################
+# ################### It just works™ keybinds ###################
 # Volume
 bindl = ,XF86AudioMute, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 0%
 bindl = Super+Shift,M, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 0%
@@ -10,7 +10,7 @@ bindle=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 #bindle=, XF86MonBrightnessUp, exec, brightnessctl set '12.75+'
 #bindle=, XF86MonBrightnessDown, exec, brightnessctl set '12.75-'
 
-#################################### Applications ###################################
+# ################################### Applications ###################################
 # Apps: just normal apps
 bind = Super, C, exec, code --password-store=gnome --enable-features=UseOzonePlatform --ozone-platform=wayland
 bind = Super, T, exec, foot --override shell=fish
@@ -62,7 +62,7 @@ bindl= Super+Shift, B, exec, playerctl previous
 bindl= Super+Shift, P, exec, playerctl play-pause
 bindl= ,XF86AudioPlay, exec, playerctl play-pause
 
-#Lock screen
+# Lock screen
 bind = Super, L, exec, loginctl lock-session
 bind = Super+Shift, L, exec, loginctl lock-session
 bindl = Super+Shift, L, exec, sleep 0.1 && systemctl suspend
@@ -70,7 +70,7 @@ bindl = Super+Shift, L, exec, sleep 0.1 && systemctl suspend
 # App launcher
 bind = Control+Super, Slash, exec, pkill anyrun || anyrun
 
-###################################### AGS keybinds #####################################
+# ##################################### AGS keybinds #####################################
 bindr = Control+Super, R, exec, killall ags ydotool; ags &
 bindr = Control+Super+Alt, R, exec, hyprctl reload; killall ags ydotool; ags &
 bind = Control+Super, T, exec, ~/.config/ags/scripts/color_generation/switchwall.sh
@@ -93,17 +93,17 @@ bindle=, XF86MonBrightnessDown, exec, ags run-js 'brightness.screen_value -= 0.0
 bindl  = , XF86AudioMute, exec, ags run-js 'indicator.popup(1);'
 bindl  = Super+Shift,M,   exec, ags run-js 'indicator.popup(1);'
 
-###################################### Plugins #########################################
+# ##################################### Plugins #########################################
 bind = Control+Super, P, exec, hyprctl plugin load "~/.config/hypr/plugins/droidbars.so"
 bind = Control+Super, O, exec, hyprctl plugin unload "~/.config/hypr/plugins/droidbars.so"
 
-## Testing
+# Testing
 # bind = SuperAlt, f12, exec, notify-send "Hyprland version: $(hyprctl version | head -2 | tail -1 | cut -f2 -d ' ')" "owo" -a 'Hyprland keybind'
 # bind = Super+Alt, f12, exec, notify-send "Millis since epoch" "$(date +%s%N | cut -b1-13)" -a 'Hyprland keybind'
 bind = Super+Alt, f12, exec, notify-send 'Test notification' "Here's a really long message to test truncation and wrapping\nYou can middle click or flick this notification to dismiss it!" -a 'Shell' -A "Test1=I got it!" -A "Test2=Another action" -t 5000
 bind = Super+Alt, Equal, exec, notify-send "Urgent notification" "Ah hell no" -u critical -a 'Hyprland keybind'
 
-############################ Keybinds for Hyprland ############################
+# ########################### Keybinds for Hyprland ############################
 # Swap windows
 bind = Super+Shift, left, movewindow, l
 bind = Super+Shift, right, movewindow, r

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -1,4 +1,4 @@
-######## Window rules ########
+# ####### Window rules ########
 windowrule = noblur,.*  # Disables blur for windows. Substantially improves performance.
 
 # windowrule = opacity 0.89 override 0.89 override, .* # Applies transparency to EVERY WINDOW
@@ -16,7 +16,7 @@ windowrule=float,title:^(Open Folder)(.*)$
 windowrule=float,title:^(Save As)(.*)$
 windowrule=float,title:^(Library)(.*)$ 
 
-######## Layer rules ########
+# ####### Layer rules ########
 layerrule = xray 1, .*
 #layerrule = noanim, .*
 layerrule = noanim, selection


### PR DESCRIPTION
Hyprlang is in use since commit https://github.com/hyprwm/Hyprland/commit/13f6f0b923ff3ec94a3bec886c28b90402ceef91 which changes how comments are parsed. Comments of the type `############# Tearing #############`  or `## Tearing` are no longer valid. This wasn't an observed issue until commit https://github.com/hyprwm/Hyprland/commit/66330281ff19e84c986c5ce639b670929e5dadd6 landed (sourced files weren't taken into consideration till then). 

I just removed any double `#` and added a space after the first `#` on any longer strings. An explanation to this can be found under https://github.com/hyprwm/Hyprland/commit/fae47ef462d1d7969afe001070839391ba6dbaa8. 

Any feedback appreciated.  