### PR TITLE
Fix `>dark` `>light` actions for multimonitors

### DIFF
--- a/.config/ags/scripts/color_generation/switchwall.sh
+++ b/.config/ags/scripts/color_generation/switchwall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$1" == "--noswitch" ]; then
-    imgpath=$(swww query | awk -F 'image: ' '{print $2}')
+    imgpath=$(swww query | awk -F 'image: ' '{print $2}'| head -n 1)
     # imgpath=$(ags run-js 'wallpaper.get(0)')
 else
     # Select and set image (hyprland)


### PR DESCRIPTION
When using multi-monitors, `swww query | awk -F 'image: ' '{print $2}'` gives N lines, where N is the number of monitors.

As the result, actions `>dark` and `>light` cause AGS styles totally broken.

This commit specifies only the first line to fix the problem.