### PR TITLE
Add config for brightness control

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -22,7 +22,7 @@ let configOptions = {
         'critical': 10,
     },
     'brightness': {
-      'device': '', // `-d` param passed to brightnessctl, leave empty to use brightnessctl default
+      'device': '', // `-d` param passes to brightnessctl, leave it empty to use brightnessctl default
       'minPercent': 0, // Lowest brightness (0-100)
     },
     'music': {

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -21,6 +21,10 @@ let configOptions = {
         'low': 20,
         'critical': 10,
     },
+    'brightness': {
+      'device': '', // `-d` param passed to brightnessctl, leave empty to use brightnessctl default
+      'minPercent': 0, // Lowest brightness (0-100)
+    },
     'music': {
         'preferredPlayer': "plasma-browser-integration",
     },

--- a/.config/ags/services/brightness.js
+++ b/.config/ags/services/brightness.js
@@ -20,10 +20,10 @@ class BrightnessService extends Service {
 
     // the setter has to be in snake_case too
     set screen_value(percent) {
-        percent = clamp(percent, 0, 1);
+        percent = clamp(percent, this._minValue, 1);
         this._screenValue = percent;
 
-        Utils.execAsync(`brightnessctl s ${percent * 100}% -q`)
+        Utils.execAsync(`${this._brightnessctlCmd} s ${percent * 100}% -q`)
             .then(() => {
                 // signals has to be explicity emitted
                 this.emit('screen-changed', percent);
@@ -37,8 +37,12 @@ class BrightnessService extends Service {
 
     constructor() {
         super();
-        const current = Number(exec('brightnessctl g'));
-        const max = Number(exec('brightnessctl m'));
+        const device = userOptions.brightness.device;
+        this._brightnessctlCmd = `brightnessctl ${device ? `-d ${device}` : ''}`
+        this._minValue = clamp((userOptions.brightness.minPercent || 0)/100, 0, 1);
+
+        const current = Number(exec(`${this._brightnessctlCmd} g`));
+        const max = Number(exec(`${this._brightnessctlCmd} m`));
         this._screenValue = current / max;
     }
 


### PR DESCRIPTION
Hi, thank you for your awesome project! I've encountered two issues while using it on my ASUS G14 laptop:

 1.  The default brightnessCtl command controls the wrong device, so I need to pass -d amdgpu_bl1 to make it work correctly.
 2.  The G14 uses an OLED display. I inadvertently set the brightness to 0 several times, rendering it totally unusable. I think it would be better to have a brightness configuration to prevent this situation from happening again.

I have added some configuration to solve these problems, brightness.device and brightness.minPercent.