### PR TITLE
Add HIDPI variables and auto-scale feature for cheatsheet

### DIFF
--- a/.config/ags/modules/cheatsheet/main.js
+++ b/.config/ags/modules/cheatsheet/main.js
@@ -4,6 +4,7 @@ import Service from 'resource:///com/github/Aylur/ags/service.js';
 import { Keybinds } from "./keybinds.js";
 import { setupCursorHover } from "../.widgetutils/cursorhover.js";
 import PopupWindow from '../.widgethacks/popupwindow.js';
+import { SCREEN_REAL_WIDTH } from '../../variables.js';
 
 const cheatsheetHeader = () => Widget.CenterBox({
     vertical: false,
@@ -69,23 +70,34 @@ const clickOutsideToClose = Widget.EventBox({
     onMiddleClick: () => App.closeWindow('cheatsheet'),
 });
 
-export default () => PopupWindow({
-    name: 'cheatsheet',
-    exclusivity: 'ignore',
-    keymode: 'exclusive',
-    visible: false,
-    child: Widget.Box({
-        vertical: true,
-        children: [
-            clickOutsideToClose,
-            Widget.Box({
-                vertical: true,
-                className: "cheatsheet-bg spacing-v-15",
-                children: [
-                    cheatsheetHeader(),
-                    Keybinds(),
-                ]
-            }),
-        ],
-    })
-});
+export default () => {
+    // values from ags inspector
+    const cheatsheetWidth = 1588;
+    const defaultDPI = 96;
+
+    let scale_factor = 1;
+    if (cheatsheetWidth > SCREEN_REAL_WIDTH) {
+        scale_factor = SCREEN_REAL_WIDTH / cheatsheetWidth;
+    }
+    return PopupWindow({
+        name: 'cheatsheet',
+        exclusivity: 'ignore',
+        keymode: 'exclusive',
+        visible: false,
+        child: Widget.Box({
+            vertical: true,
+            children: [
+                clickOutsideToClose,
+                Widget.Box({
+                    vertical: true,
+                    className: "cheatsheet-bg spacing-v-15",
+                    css: `${scale_factor < 1 ? `-gtk-dpi: ${defaultDPI * scale_factor}` : ''}`,
+                    children: [
+                        cheatsheetHeader(),
+                        Keybinds(),
+                    ]
+                }),
+            ],
+        })
+    });
+}

--- a/.config/ags/modules/cheatsheet/main.js
+++ b/.config/ags/modules/cheatsheet/main.js
@@ -73,11 +73,12 @@ const clickOutsideToClose = Widget.EventBox({
 export default () => {
     // values from ags inspector
     const cheatsheetWidth = 1588;
+    const targetWidth = SCREEN_REAL_WIDTH * 0.85;
     const defaultDPI = 96;
 
     let scale_factor = 1;
-    if (cheatsheetWidth > SCREEN_REAL_WIDTH) {
-        scale_factor = SCREEN_REAL_WIDTH / cheatsheetWidth;
+    if (cheatsheetWidth > targetWidth) {
+        scale_factor = targetWidth / cheatsheetWidth;
     }
     return PopupWindow({
         name: 'cheatsheet',

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -17,6 +17,17 @@ globalThis['mpris'] = Mpris;
 export const SCREEN_WIDTH = Number(exec(`bash -c "xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f1 | head -1" | awk '{print $1}'`));
 export const SCREEN_HEIGHT = Number(exec(`bash -c "xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f2 | head -1" | awk '{print $1}'`));
 
+// Caculated scaled size 
+let scale_factor = 1;
+try {
+    scale_factor = JSON.parse(exec('hyprctl monitors -j'))
+        .filter(monitor => monitor.focused)[0]
+        .scale;
+} catch {}
+export const SCALE_FACTOR = scale_factor;
+export const SCREEN_REAL_WIDTH = SCREEN_WIDTH / SCALE_FACTOR;
+export const SCREEN_REAL_HEIGHT = SCREEN_HEIGHT / SCALE_FACTOR;
+
 // Mode switching
 export const currentShellMode = Variable('normal', {}) // normal, focus
 globalThis['currentMode'] = currentShellMode;


### PR DESCRIPTION
This PR adds some HIDPI variables and uses them to automatically scale down the cheatsheet, making it usable on scaled screens. Takes effect on Hyprland.

Solves https://github.com/end-4/dots-hyprland/issues/283. 

Tested 2880x1800, 2x scaled:
![图片](https://github.com/end-4/dots-hyprland/assets/4048787/0ce776c6-229e-46f7-92b9-9b8114bf08c5)

1920x1080, 2x:
![图片](https://github.com/end-4/dots-hyprland/assets/4048787/25997d58-f256-470e-b0f6-1f9b6f5cb8cd)

