### PR TITLE
Fix full-screen recording for multimonitors

### DIFF
--- a/.config/ags/scripts/record-script.sh
+++ b/.config/ags/scripts/record-script.sh
@@ -6,6 +6,9 @@ getdate() {
 getaudiooutput() {
     pactl list sources | grep 'Name' | grep 'monitor' | cut -d ' ' -f2
 }
+getactivemonitor() {
+    hyprctl monitors -j | gojq -r '.[] | select(.focused == true) | .name'
+}
 
 cd ~/Videos || exit
 if pgrep wf-recorder > /dev/null; then
@@ -16,10 +19,10 @@ else
     if [[ "$1" == "--sound" ]]; then
         wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$(slurp)" --audio="$(getaudiooutput)" & disown
     elif [[ "$1" == "--fullscreen-sound" ]]; then
-        wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --audio="$(getaudiooutput)" & disown
+        wf-recorder -o $(getactivemonitor) --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --audio="$(getaudiooutput)" & disown
     elif [[ "$1" == "--fullscreen" ]]; then
-        wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t & disown
-    else 
+        wf-recorder -o $(getactivemonitor) --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t & disown
+    else
         wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$(slurp)" & disown
     fi
 fi


### PR DESCRIPTION
If multiple monitors are present, the wf-recorder command will require to select the monitor on stdin. This overcomes that by specifying the monitor on '-o' or '--output' flag.