### PR TITLE
update dock

### DIFF
--- a/.config/ags/config.js
+++ b/.config/ags/config.js
@@ -54,7 +54,7 @@ const Windows = () => [
     SideRight(),
     forMonitors(Osk),
     Session(),
-    ...(userOptions.dock.enabled ? [forMonitors(Dock)] : []),
+    userOptions.dock.enabled ? forMonitors(Dock) : null,
     // forMonitors(Bar),
     ...(userOptions.appearance.fakeScreenRounding ? [
         forMonitors((id) => Corner(id, 'top left', true)),

--- a/.config/ags/config.js
+++ b/.config/ags/config.js
@@ -11,7 +11,7 @@ import { firstRunWelcome } from './services/messages.js';
 import { Bar, BarCornerTopleft, BarCornerTopright } from './modules/bar/main.js';
 import Cheatsheet from './modules/cheatsheet/main.js';
 // import DesktopBackground from './modules/desktopbackground/main.js';
-// import Dock from './modules/dock/main.js';
+import Dock from './modules/dock/main.js';
 import Corner from './modules/screencorners/main.js';
 import Indicator from './modules/indicators/main.js';
 import Osk from './modules/onscreenkeyboard/main.js';
@@ -50,6 +50,7 @@ const Windows = () => [
     Overview(),
     forMonitors(Indicator),
     forMonitors(Cheatsheet),
+    forMonitors(Dock),
     SideLeft(),
     SideRight(),
     forMonitors(Osk),

--- a/.config/ags/config.js
+++ b/.config/ags/config.js
@@ -50,11 +50,11 @@ const Windows = () => [
     Overview(),
     forMonitors(Indicator),
     forMonitors(Cheatsheet),
-    forMonitors(Dock),
     SideLeft(),
     SideRight(),
     forMonitors(Osk),
     Session(),
+    ...(userOptions.dock.enabled ? [forMonitors(Dock)] : []),
     // forMonitors(Bar),
     ...(userOptions.appearance.fakeScreenRounding ? [
         forMonitors((id) => Corner(id, 'top left', true)),
@@ -83,4 +83,3 @@ App.config({
 // Stuff that don't need to be toggled. And they're async so ugh...
 forMonitorsAsync(Bar);
 // Bar().catch(print); // Use this to debug the bar. Single monitor only.
-

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -82,14 +82,9 @@ let configOptions = {
         'pinnedApps': ['firefox', 'org.gnome.Nautilus'],
         'layer': 'top',
         'monitorExclusivity': true, // Dock will move to other monitor along with focus if enabled
-        // It's useful to keep the icons consistent, which is useful if you're OCD :)
-        'searchPinnedAppIcons': false,
-        // available: client_added, client_move, workspace_active, client_active
-        'trigger': ['client-added', 'client-removed'],
-        // Automatically hide dock after a period of time
-        // after a trigger has been triggered.
-        // Time in milliseconds. empty if always displays.
-        // { 'trigger': 'client-added', interval: 1000, }
+        'searchPinnedAppIcons': false, // Try to search for the correct icon if the app class isn't an icon name
+        'trigger': ['client-added', 'client-removed'], // client_added, client_move, workspace_active, client_active
+        // Automatically hide dock after `interval` ms since trigger
         'autoHide': [
             {
                 'trigger': 'client-added',
@@ -104,10 +99,9 @@ let configOptions = {
     // Longer stuff
     'icons': {
         // Find the window's icon by its class with levenshteinDistance
-        // All file paths are preprocessed and stored at ags startup, so if there
-        // are so many files under the path it will affect performance
-        // Maybe you need a comprehensive icon theme
-        // Example: ['/usr/share/icons/Tela-nord/scalable/apps', 'others...']
+        // The file names are processed at startup, so if there
+        // are too many files in the search path it'll affect performance
+        // Example: ['/usr/share/icons/Tela-nord/scalable/apps']
         'searchPaths': [''],
 
         substitutions: {

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -78,8 +78,7 @@ let configOptions = {
     },
     'dock': {
         'enabled': true,
-        // Threshold for hover to trigger dock display
-        'hoverMinHeight': 5,
+        'hiddenThickness': 5,
         'pinnedApps': ['firefox', 'org.gnome.Nautilus'],
         'layer': 'top',
         'monitorExclusivity': true, // Dock will move to other monitor along with focus if enabled

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -71,7 +71,7 @@ let configOptions = {
         'dateFormat': "%d/%m", // On notif time
     },
     'weather': {
-        'city': "Chengdu",
+        'city': "",
     },
     'workspaces': {
         'shown': 10,
@@ -83,12 +83,6 @@ let configOptions = {
         'pinnedApps': ['firefox', 'org.gnome.Nautilus'],
         // top or bottom
         'layer': 'top',
-        // Find the window's icon by its class with levenshteinDistance
-        // All file paths are preprocessed and stored at ags startup, so if there
-        // are so many files under the path it will affect performance
-        // Maybe you need a comprehensive icon theme
-        // Example: ['/usr/share/icons/Tela-nord-dark/scalable/apps', 'others...']
-        'iconSearchPaths': [''],
         // Dock will move to other monitor along with focus if enabled
         'monitorExclusivity': true,
         // It's useful to keep the icons consistent, which is useful if you're OCD :)
@@ -113,6 +107,13 @@ let configOptions = {
     },
     // Longer stuff
     'icons': {
+        // Find the window's icon by its class with levenshteinDistance
+        // All file paths are preprocessed and stored at ags startup, so if there
+        // are so many files under the path it will affect performance
+        // Maybe you need a comprehensive icon theme
+        // Example: ['/usr/share/icons/Tela-nord/scalable/apps', 'others...']
+        'searchPaths': [''],
+
         substitutions: {
             'code-url-handler': "visual-studio-code",
             'Code': "visual-studio-code",

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -77,24 +77,21 @@ let configOptions = {
         'shown': 10,
     },
     'dock': {
-        'enabled': false,
+        'enabled': true,
         // Threshold for hover to trigger dock display
         'hoverMinHeight': 5,
         'pinnedApps': ['firefox', 'org.gnome.Nautilus'],
-        // top or bottom
         'layer': 'top',
-        // Dock will move to other monitor along with focus if enabled
-        'monitorExclusivity': true,
+        'monitorExclusivity': true, // Dock will move to other monitor along with focus if enabled
         // It's useful to keep the icons consistent, which is useful if you're OCD :)
         'searchPinnedAppIcons': false,
         // available: client_added, client_move, workspace_active, client_active
-        'trigger': ['client-added', 'client-removed',
-            'workspace-active'],
+        'trigger': ['client-added', 'client-removed'],
         // Automatically hide dock after a period of time
         // after a trigger has been triggered.
         // Time in milliseconds. empty if always displays.
         // { 'trigger': 'client-added', interval: 1000, }
-        'autoHidden': [
+        'autoHide': [
             {
                 'trigger': 'client-added',
                 'interval': 2000,

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -94,11 +94,11 @@ let configOptions = {
         'autoHide': [
             {
                 'trigger': 'client-added',
-                'interval': 2000,
+                'interval': 1000,
             },
             {
                 'trigger': 'client-removed',
-                'interval': 2000,
+                'interval': 1000,
             },
         ],
     },

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -71,10 +71,45 @@ let configOptions = {
         'dateFormat': "%d/%m", // On notif time
     },
     'weather': {
-        'city': "",
+        'city': "Chengdu",
     },
     'workspaces': {
         'shown': 10,
+    },
+    'dock': {
+        'enabled': false,
+        // Threshold for hover to trigger dock display
+        'hoverMinHeight': 5,
+        'pinnedApps': ['firefox', 'org.gnome.Nautilus'],
+        // top or bottom
+        'layer': 'top',
+        // Find the window's icon by its class with levenshteinDistance
+        // All file paths are preprocessed and stored at ags startup, so if there
+        // are so many files under the path it will affect performance
+        // Maybe you need a comprehensive icon theme
+        // Example: ['/usr/share/icons/Tela-nord-dark/scalable/apps', 'others...']
+        'iconSearchPaths': [''],
+        // Dock will move to other monitor along with focus if enabled
+        'monitorExclusivity': true,
+        // It's useful to keep the icons consistent, which is useful if you're OCD :)
+        'searchPinnedAppIcons': false,
+        // available: client_added, client_move, workspace_active, client_active
+        'trigger': ['client-added', 'client-removed',
+            'workspace-active'],
+        // Automatically hide dock after a period of time
+        // after a trigger has been triggered.
+        // Time in milliseconds. empty if always displays.
+        // { 'trigger': 'client-added', interval: 1000, }
+        'autoHidden': [
+            {
+                'trigger': 'client-added',
+                'interval': 2000,
+            },
+            {
+                'trigger': 'client-removed',
+                'interval': 2000,
+            },
+        ],
     },
     // Longer stuff
     'icons': {

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -327,7 +327,7 @@ export default (monitor = 0) => {
 
                 const hidden = userOptions
                     .dock
-                    .autoHidden.find(e => e["trigger"] === trigger)
+                    .autoHide.find(e => e["trigger"] === trigger)
 
                 if (hidden) {
                     let id = Utils.timeout(hidden.interval, () => {

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -77,7 +77,7 @@ const PinButton = () => {
             child: Widget.Box({
                 homogeneous: true,
                 className: 'dock-app-icon',
-                child: MaterialIcon('Lock', 'larger')
+                child: MaterialIcon('push_pin', 'hugeass')
             }),
             overlays: [Widget.Box({
                 class_name: 'indicator',

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -158,6 +158,7 @@ const Taskbar = (monitor) => Widget.Box({
                     path = searchIcons(appClass.toLowerCase(), icon_files)
                     cachePath[appClassLower] = path
                 }
+                if (path === '') { path = appClass }
                 const newButton = AppButton({
                     icon: path,
                     tooltipText: `${client.title} (${appClass})`,
@@ -186,6 +187,7 @@ const Taskbar = (monitor) => Widget.Box({
                 path = searchIcons(appClassLower, icon_files)
                 cachePath[appClassLower] = path
             }
+            if (path === '') { path = substitute(appClassLower) }
             const newButton = AppButton({
                 icon: path,
                 tooltipText: `${newClient.title} (${appClass})`,

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -348,7 +348,7 @@ export default (monitor = 0) => {
         },
         child: Box({
             homogeneous: true,
-            css: `min-height: ${userOptions.dock.hoverMinHeight}px;`,
+            css: `min-height: ${userOptions.dock.hiddenThickness}px;`,
             children: [
                 dockRevealer,
             ]

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -12,12 +12,7 @@ import { setupCursorHover } from '../.widgetutils/cursorhover.js';
 import { getAllFiles, searchIcons } from './icons.js'
 import { MaterialIcon } from '../.commonwidgets/materialicon.js';
 
-const icon_files = userOptions.dock.iconSearchPaths.map(e => getAllFiles(e)).flat(1)
-
-const pinnedApps = [
-    'firefox',
-    'org.gnome.Nautilus',
-];
+const icon_files = userOptions.icon.searchPaths.map(e => getAllFiles(e)).flat(1)
 
 let isPinned = false
 let cachePath = new Map()
@@ -147,10 +142,10 @@ const Taskbar = (monitor) => Widget.Box({
                 const client = Hyprland.clients[i];
                 if (client["pid"] == -1) return;
                 const appClass = substitute(client.class);
-                for (const appName of pinnedApps) {
-                    if (appClass.includes(appName.toLowerCase()))
-                        return null;
-                }
+                // for (const appName of userOptions.dock.pinnedApps) {
+                //     if (appClass.includes(appName.toLowerCase()))
+                //         return null;
+                // }
                 let appClassLower = appClass.toLowerCase()
                 let path = ''
                 if (cachePath[appClassLower]) { path = cachePath[appClassLower] }
@@ -222,14 +217,14 @@ const Taskbar = (monitor) => Widget.Box({
 const PinnedApps = () => Widget.Box({
     class_name: 'dock-apps',
     homogeneous: true,
-    children: pinnedApps
+    children: userOptions.dock.pinnedApps
         .map(term => ({ app: Applications.query(term)?.[0], term }))
         .filter(({ app }) => app)
         .map(({ app, term = true }) => {
             const newButton = AppButton({
                 // different icon, emm...
                 icon: userOptions.dock.searchPinnedAppIcons ?
-                    searchIcons(app.icon_name, icon_files) :
+                    searchIcons(app.name, icon_files) :
                     app.icon_name,
                 onClicked: () => {
                     for (const client of Hyprland.clients) {
@@ -367,8 +362,6 @@ export default (monitor = 0) => {
         setup: self => self.on("leave-notify-event", () => {
             if (!isPinned) dockRevealer.revealChild = false;
             clearTimes()
-        }).on('key-press-event', (self, event) => {
-            console.log(self, event)
         })
     })
 }

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -2,18 +2,25 @@ const { Gtk } = imports.gi;
 import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../../variables.js';
 import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 import * as Utils from 'resource:///com/github/Aylur/ags/utils.js';
-const { EventBox } = Widget;
+const { EventBox, Button } = Widget;
 
 import Hyprland from 'resource:///com/github/Aylur/ags/service/hyprland.js';
 import Applications from 'resource:///com/github/Aylur/ags/service/applications.js';
 const { execAsync, exec } = Utils;
 const { Box, Revealer } = Widget;
 import { setupCursorHover } from '../.widgetutils/cursorhover.js';
+import { getAllFiles, searchIcons } from './icons.js'
+import { MaterialIcon } from '../.commonwidgets/materialicon.js';
+
+const icon_files = getAllFiles("/usr/share/icons/Tela-nord-dark/scalable/apps")
 
 const pinnedApps = [
     'firefox',
     'org.gnome.Nautilus',
 ];
+
+let isPinned = false
+let cachePath = new Map()
 
 function substitute(str) {
     const subs = [
@@ -34,11 +41,48 @@ function substitute(str) {
     return str;
 }
 
+function ExclusiveWindow(client) {
+    const fn = [
+        (client) => !(client !== null && client !== undefined),
+        // Jetbrains
+        (client) => client.title.includes("win"),
+        // Vscode
+        (client) => client.title === '' && client.class === ''
+    ]
+
+    for (const item of fn) { if (item(client)) { return true } }
+    return false
+}
+
 const focus = ({ address }) => Utils.execAsync(`hyprctl dispatch focuswindow address:${address}`).catch(print);
+
+const activeMonitorId = () => {
+    let monitors = JSON.parse(exec('hyprctl monitors -j'))
+    let activeMonitor = monitors.find((e) => e["focused"] === true)
+    return activeMonitor["id"]
+}
 
 const DockSeparator = (props = {}) => Box({
     ...props,
     className: 'dock-separator',
+})
+
+const PinButton = () => Widget.Button({
+    className: 'dock-app-btn',
+    tooltipText: 'Pin Dock',
+    child: Widget.Overlay({
+        child: Widget.Box({
+            homogeneous: true,
+            className: 'dock-app-icon',
+            child: MaterialIcon('Lock', 'larger')
+        }),
+        overlays: [Widget.Box({
+            class_name: 'indicator',
+            vpack: 'end',
+            hpack: 'center',
+        })],
+    }),
+    onClicked: () => isPinned = !isPinned
 })
 
 const AppButton = ({ icon, ...rest }) => Widget.Revealer({
@@ -73,14 +117,15 @@ const AppButton = ({ icon, ...rest }) => Widget.Revealer({
     })
 });
 
-const Taskbar = () => Widget.Box({
+const Taskbar = (monitor) => Widget.Box({
     className: 'dock-apps',
     attribute: {
+        monitor: monitor,
         'map': new Map(),
         'clientSortFunc': (a, b) => {
             return a.attribute.workspace > b.attribute.workspace;
         },
-        'update': (box) => {
+        'update': (box, monitor) => {
             for (let i = 0; i < Hyprland.clients.length; i++) {
                 const client = Hyprland.clients[i];
                 if (client["pid"] == -1) return;
@@ -89,8 +134,15 @@ const Taskbar = () => Widget.Box({
                     if (appClass.includes(appName.toLowerCase()))
                         return null;
                 }
+                let appClassLower = appClass.toLowerCase()
+                let path = ''
+                if (cachePath[appClassLower]) { path = cachePath[appClassLower] }
+                else {
+                    path = searchIcons(appClass.toLowerCase(), icon_files)
+                    cachePath[appClassLower] = path
+                }
                 const newButton = AppButton({
-                    icon: appClass,
+                    icon: path,
                     tooltipText: `${client.title} (${appClass})`,
                     onClicked: () => focus(client),
                 });
@@ -100,7 +152,7 @@ const Taskbar = () => Widget.Box({
             }
             box.children = Array.from(box.attribute.map.values());
         },
-        'add': (box, address) => {
+        'add': (box, address, monitor) => {
             if (!address) { // First active emit is undefined
                 box.attribute.update(box);
                 return;
@@ -108,10 +160,17 @@ const Taskbar = () => Widget.Box({
             const newClient = Hyprland.clients.find(client => {
                 return client.address == address;
             });
-            const appClass = substitute(newClient.class);
-
+            if (ExclusiveWindow(newClient)) { return }
+            let appClass = newClient.class
+            let appClassLower = appClass.toLowerCase()
+            let path = ''
+            if (cachePath[appClassLower]) { path = cachePath[appClassLower] }
+            else {
+                path = searchIcons(appClassLower, icon_files)
+                cachePath[appClassLower] = path
+            }
             const newButton = AppButton({
-                icon: appClass,
+                icon: path,
                 tooltipText: `${newClient.title} (${appClass})`,
                 onClicked: () => focus(newClient),
             })
@@ -135,8 +194,8 @@ const Taskbar = () => Widget.Box({
         },
     },
     setup: (self) => {
-        self.hook(Hyprland, (box, address) => box.attribute.add(box, address), 'client-added')
-            .hook(Hyprland, (box, address) => box.attribute.remove(box, address), 'client-removed')
+        self.hook(Hyprland, (box, address) => box.attribute.add(box, address, self.monitor), 'client-added')
+            .hook(Hyprland, (box, address) => box.attribute.remove(box, address, self.monitor), 'client-removed')
         Utils.timeout(100, () => self.attribute.update(self));
     },
 });
@@ -149,6 +208,7 @@ const PinnedApps = () => Widget.Box({
         .filter(({ app }) => app)
         .map(({ app, term = true }) => {
             const newButton = AppButton({
+                // different icon, emm...
                 icon: app.icon_name,
                 onClicked: () => {
                     for (const client of Hyprland.clients) {
@@ -177,82 +237,87 @@ const PinnedApps = () => Widget.Box({
         }),
 });
 
-export default () => {
+export default (monitor = 0) => {
     const dockContent = Box({
         className: 'dock-bg spacing-h-5',
         children: [
             PinnedApps(),
             DockSeparator(),
-            Taskbar(),
+            Taskbar(monitor),
+            PinButton(),
         ]
     })
     const dockRevealer = Revealer({
         attribute: {
             'updateShow': self => { // I only use mouse to resize. I don't care about keyboard resize if that's a thing
-                const dockSize = [
-                    dockContent.get_allocated_width(),
-                    dockContent.get_allocated_height()
-                ]
-                const dockAt = [
-                    SCREEN_WIDTH / 2 - dockSize[0] / 2,
-                    SCREEN_HEIGHT - dockSize[1],
-                ];
-                const dockLeft = dockAt[0];
-                const dockRight = dockAt[0] + dockSize[0];
-                const dockTop = dockAt[1];
-                const dockBottom = dockAt[1] + dockSize[1];
-
-                const currentWorkspace = Hyprland.active.workspace.id;
-                var toReveal = true;
-                const hyprlandClients = JSON.parse(exec('hyprctl clients -j'));
-                for (const index in hyprlandClients) {
-                    const client = hyprlandClients[index];
-                    const clientLeft = client.at[0];
-                    const clientRight = client.at[0] + client.size[0];
-                    const clientTop = client.at[1];
-                    const clientBottom = client.at[1] + client.size[1];
-
-                    if (client.workspace.id == currentWorkspace) {
-                        if (
-                            clientLeft < dockRight &&
-                            clientRight > dockLeft &&
-                            clientTop < dockBottom &&
-                            clientBottom > dockTop
-                        ) {
-                            self.revealChild = false;
-                            return;
-                        }
-                    }
-                }
-                self.revealChild = true;
+                // const dockSize = [
+                //     dockContent.get_allocated_width(),
+                //     dockContent.get_allocated_height()
+                // ]
+                // const dockAt = [
+                //     SCREEN_WIDTH / 2 - dockSize[0] / 2,
+                //     SCREEN_HEIGHT - dockSize[1],
+                // ];
+                // const dockLeft = dockAt[0];
+                // const dockRight = dockAt[0] + dockSize[0];
+                // const dockTop = dockAt[1];
+                // const dockBottom = dockAt[1] + dockSize[1];
+                //
+                // const currentWorkspace = Hyprland.active.workspace.id;
+                // var toReveal = true;
+                // const hyprlandClients = JSON.parse(exec('hyprctl clients -j'));
+                // for (const index in hyprlandClients) {
+                //     const client = hyprlandClients[index];
+                //     const clientLeft = client.at[0];
+                //     const clientRight = client.at[0] + client.size[0];
+                //     const clientTop = client.at[1];
+                //     const clientBottom = client.at[1] + client.size[1];
+                //
+                //     if (client.workspace.id == currentWorkspace) {
+                //         if (
+                //             // clientLeft < dockRight &&
+                //             // clientRight > dockLeft &&
+                //             // clientTop < dockBottom &&
+                //             // clientBottom > dockTop
+                //         ) {
+                //             self.revealChild = false;
+                //             return;
+                //         }
+                //     }
+                // }
+                // // if (currentWorkspace === client.workspace.id) {
+                // self.revealChild = true;
+                // // }
+                self.revealChild = activeMonitorId() === monitor
             }
         },
         revealChild: false,
         transition: 'slide_up',
         transitionDuration: userOptions.animations.durationLarge,
         child: dockContent,
-        // setup: (self) => self
-        //     .hook(Hyprland, (self) => self.attribute.updateShow(self))
-        //     .hook(Hyprland.active.workspace, (self) => self.attribute.updateShow(self))
-        //     .hook(Hyprland.active.client, (self) => self.attribute.updateShow(self))
-        //     .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-added')
-        //     .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-removed')
-        // ,
+        setup: (self) => self
+            .hook(Hyprland, (self) => self.attribute.updateShow(self))
+            .hook(Hyprland.active.workspace, (self) => self.attribute.updateShow(self))
+            .hook(Hyprland.active.client, (self) => self.attribute.updateShow(self))
+            .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-added')
+            .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-removed')
+        ,
     })
     return EventBox({
         onHover: () => {
             dockRevealer.revealChild = true;
         },
-        onHoverLost: () => {
-            if (Hyprland.active.client.attribute.class.length === 0) return;
-            dockRevealer.revealChild = false;
-        },
+        // onHoverLost: () => {
+        //     if (Hyprland.active.client.attribute.class.length === 0) { return }
+        //     dockRevealer.revealChild = false;
+        // },
         child: Box({
             homogeneous: true,
-            css: 'min-height: 2px;',
+            css: 'min-height: 20px;',
             children: [
                 dockRevealer,
             ]
         }),
+        setup: self => self.on("leave-notify-event", () => { if (!isPinned) dockRevealer.revealChild = false })
     })
 }

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -63,33 +63,27 @@ const DockSeparator = (props = {}) => Box({
     className: 'dock-separator',
 })
 
-const PinButton = () => {
-    let botton = Widget.Button({
-        className: 'dock-app-btn dock-app-btn-animate',
-        tooltipText: 'Pin Dock',
-        child: Widget.Overlay({
-            child: Widget.Box({
-                homogeneous: true,
-                className: 'dock-app-icon',
-                child: MaterialIcon('push_pin', 'hugeass')
-            }),
-            overlays: [Widget.Box({
-                class_name: 'indicator',
-                vpack: 'end',
-                hpack: 'center',
-            })],
+const PinButton = () => Widget.Button({
+    className: 'dock-app-btn dock-app-btn-animate',
+    tooltipText: 'Pin Dock',
+    child: Widget.Overlay({
+        child: Widget.Box({
+            homogeneous: true,
+            className: 'dock-app-icon',
+            child: MaterialIcon('push_pin', 'hugeass')
         }),
-        onClicked: () => {
-            isPinned = !isPinned
-            botton.className = `${isPinned ? "pinned-dock-app-btn" : "dock-app-btn animate"} dock-app-btn-animate`
-        },
-        setup: (button) => {
-            setupCursorHover(button);
-        }
-    })
-
-    return botton
-}
+        overlays: [Widget.Box({
+            class_name: 'indicator',
+            vpack: 'end',
+            hpack: 'center',
+        })],
+    }),
+    onClicked: (self) => {
+        isPinned = !isPinned
+        self.className = `${isPinned ? "pinned-dock-app-btn" : "dock-app-btn animate"} dock-app-btn-animate`
+    },
+    setup: setupCursorHover,
+})
 
 const AppButton = ({ icon, ...rest }) => Widget.Revealer({
     attribute: {
@@ -299,11 +293,10 @@ export default (monitor = 0) => {
                 // self.revealChild = true;
                 // // }
 
-                if (userOptions.dock.monitorExclusivity) {
-                    self.revealChild = Hyprland.active.monitor.id === monitor
-                } else {
+                if (userOptions.dock.monitorExclusivity)
+                    self.revealChild = Hyprland.active.monitor.id === monitor;
+                else
                     self.revealChild = true;
-                }
 
                 return self.revealChild
             }
@@ -317,11 +310,9 @@ export default (monitor = 0) => {
                 if (!userOptions.dock.trigger.includes(trigger)) return
                 const flag = self.attribute.updateShow(self)
 
-                if (flag) { clearTimes() }
+                if (flag) clearTimes();
 
-                const hidden = userOptions
-                    .dock
-                    .autoHide.find(e => e["trigger"] === trigger)
+                const hidden = userOptions.dock.autoHide.find(e => e["trigger"] === trigger)
 
                 if (hidden) {
                     let id = Utils.timeout(hidden.interval, () => {
@@ -338,8 +329,7 @@ export default (monitor = 0) => {
                 .hook(Hyprland.active.client, self => callback(self, "client-active"))
                 .hook(Hyprland, self => callback(self, "client-added"), "client-added")
                 .hook(Hyprland, self => callback(self, "client-removed"), "client-removed")
-            }
-        ,
+        },
     })
     return EventBox({
         onHover: () => {
@@ -349,9 +339,7 @@ export default (monitor = 0) => {
         child: Box({
             homogeneous: true,
             css: `min-height: ${userOptions.dock.hiddenThickness}px;`,
-            children: [
-                dockRevealer,
-            ]
+            children: [dockRevealer],
         }),
         setup: self => self.on("leave-notify-event", () => {
             if (!isPinned) dockRevealer.revealChild = false;

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -117,15 +117,14 @@ const AppButton = ({ icon, ...rest }) => Widget.Revealer({
     })
 });
 
-const Taskbar = (monitor) => Widget.Box({
+const Taskbar = () => Widget.Box({
     className: 'dock-apps',
     attribute: {
-        monitor: monitor,
         'map': new Map(),
         'clientSortFunc': (a, b) => {
             return a.attribute.workspace > b.attribute.workspace;
         },
-        'update': (box, monitor) => {
+        'update': (box) => {
             for (let i = 0; i < Hyprland.clients.length; i++) {
                 const client = Hyprland.clients[i];
                 if (client["pid"] == -1) return;
@@ -152,7 +151,7 @@ const Taskbar = (monitor) => Widget.Box({
             }
             box.children = Array.from(box.attribute.map.values());
         },
-        'add': (box, address, monitor) => {
+        'add': (box, address) => {
             if (!address) { // First active emit is undefined
                 box.attribute.update(box);
                 return;
@@ -194,7 +193,7 @@ const Taskbar = (monitor) => Widget.Box({
         },
     },
     setup: (self) => {
-        self.hook(Hyprland, (box, address) => box.attribute.add(box, address, self.monitor), 'client-added')
+        self.hook(Hyprland, (box, address) => box.attribute.add(box, address), 'client-added')
             .hook(Hyprland, (box, address) => box.attribute.remove(box, address, self.monitor), 'client-removed')
         Utils.timeout(100, () => self.attribute.update(self));
     },
@@ -243,7 +242,7 @@ export default (monitor = 0) => {
         children: [
             PinnedApps(),
             DockSeparator(),
-            Taskbar(monitor),
+            Taskbar(),
             PinButton(),
         ]
     })

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -58,12 +58,6 @@ function ExclusiveWindow(client) {
 
 const focus = ({ address }) => Utils.execAsync(`hyprctl dispatch focuswindow address:${address}`).catch(print);
 
-const activeMonitorId = () => {
-    let monitors = JSON.parse(exec('hyprctl monitors -j'))
-    let activeMonitor = monitors.find((e) => e["focused"] === true)
-    return activeMonitor["id"]
-}
-
 const DockSeparator = (props = {}) => Box({
     ...props,
     className: 'dock-separator',
@@ -306,7 +300,7 @@ export default (monitor = 0) => {
                 // // }
 
                 if (userOptions.dock.monitorExclusivity) {
-                    self.revealChild = activeMonitorId() === monitor
+                    self.revealChild = Hyprland.active.monitor.id === monitor
                 } else {
                     self.revealChild = true;
                 }

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -12,7 +12,7 @@ import { setupCursorHover } from '../.widgetutils/cursorhover.js';
 import { getAllFiles, searchIcons } from './icons.js'
 import { MaterialIcon } from '../.commonwidgets/materialicon.js';
 
-const icon_files = userOptions.icon.searchPaths.map(e => getAllFiles(e)).flat(1)
+const icon_files = userOptions.icons.searchPaths.map(e => getAllFiles(e)).flat(1)
 
 let isPinned = false
 let cachePath = new Map()

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -296,9 +296,9 @@ export default (monitor = 0) => {
         transitionDuration: userOptions.animations.durationLarge,
         child: dockContent,
         setup: (self) => self
-            .hook(Hyprland, (self) => self.attribute.updateShow(self))
+            // .hook(Hyprland, (self) => self.attribute.updateShow(self))
             .hook(Hyprland.active.workspace, (self) => self.attribute.updateShow(self))
-            .hook(Hyprland.active.client, (self) => self.attribute.updateShow(self))
+            // .hook(Hyprland.active.client, (self) => self.attribute.updateShow(self))
             .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-added')
             .hook(Hyprland, (self) => self.attribute.updateShow(self), 'client-removed')
         ,

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -158,7 +158,7 @@ const Taskbar = (monitor) => Widget.Box({
                     path = searchIcons(appClass.toLowerCase(), icon_files)
                     cachePath[appClassLower] = path
                 }
-                if (path === '') { path = appClass }
+                if (path === '') { path = substitute(appClass) }
                 const newButton = AppButton({
                     icon: path,
                     tooltipText: `${client.title} (${appClass})`,
@@ -187,7 +187,7 @@ const Taskbar = (monitor) => Widget.Box({
                 path = searchIcons(appClassLower, icon_files)
                 cachePath[appClassLower] = path
             }
-            if (path === '') { path = substitute(appClassLower) }
+            if (path === '') { path = substitute(appClass) }
             const newButton = AppButton({
                 icon: path,
                 tooltipText: `${newClient.title} (${appClass})`,

--- a/.config/ags/modules/dock/icons.js
+++ b/.config/ags/modules/dock/icons.js
@@ -1,0 +1,60 @@
+const { Gio, GLib } = imports.gi
+import { lookUpIcon, timeout } from 'resource:///com/github/Aylur/ags/utils.js';
+import Applications from 'resource:///com/github/Aylur/ags/service/applications.js';
+
+const exists = (path) => Gio.File.new_for_path(path).query_exists(null);
+
+export const levenshteinDistance = (a, b) => {
+    if (!a.length) { return b.length }
+    if (!b.length) { return a.length }
+
+    let f = Array.from(new Array(a.length + 1),
+        () => new Array(b.length + 1).fill(0))
+
+    for (let i = 0; i <= b.length; i++) { f[0][i] = i; }
+    for (let i = 0; i <= a.length; i++) { f[i][0] = i; }
+
+    for (let i = 1; i <= a.length; i++) {
+        for (let j = 1; j <= b.length; j++) {
+            if (a.charAt(i - 1) === b.charAt(j - 1)) {
+                f[i][j] = f[i-1][j-1]
+            } else {
+                f[i][j] = Math.min(f[i-1][j-1], Math.min(f[i][j-1], f[i-1][j])) + 1
+            }
+        }
+    }
+
+    return f[a.length][b.length]
+}
+
+export const getAllFiles = (dir, files = []) => {
+    const file = Gio.File.new_for_path(dir);
+    const enumerator = file.enumerate_children('standard::name,standard::type',
+        Gio.FileQueryInfoFlags.NONE, null);
+
+    for (const info of enumerator) {
+        if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+            files.push(getAllFiles(`${dir}/${info.get_name()}`))
+        } else {
+            files.push(`${dir}/${info.get_name()}`)
+        }
+    }
+
+    return files.flat(1);
+}
+
+export const searchIcons = (appClass, files) => {
+    let appro = 0x3f3f3f3f
+    let path = ""
+
+    for (const item of files) {
+        let score = levenshteinDistance(item.split("/").pop(), appClass)
+
+        if (score < appro) {
+            appro = score
+            path = item
+        }
+    }
+
+    return path
+}

--- a/.config/ags/modules/dock/icons.js
+++ b/.config/ags/modules/dock/icons.js
@@ -1,6 +1,4 @@
 const { Gio, GLib } = imports.gi
-import { lookUpIcon, timeout } from 'resource:///com/github/Aylur/ags/utils.js';
-import Applications from 'resource:///com/github/Aylur/ags/service/applications.js';
 
 const exists = (path) => Gio.File.new_for_path(path).query_exists(null);
 
@@ -45,13 +43,15 @@ export const getAllFiles = (dir, files = []) => {
 }
 
 export const searchIcons = (appClass, files) => {
+    appClass = appClass.toLowerCase()
+
     if (!files.length) { return "" }
 
     let appro = 0x3f3f3f3f
     let path = ""
 
     for (const item of files) {
-        let score = levenshteinDistance(item.split("/").pop(), appClass)
+        let score = levenshteinDistance(item.split("/").pop().toLowerCase().split(".")[0], appClass)
 
         if (score < appro) {
             appro = score

--- a/.config/ags/modules/dock/icons.js
+++ b/.config/ags/modules/dock/icons.js
@@ -28,6 +28,7 @@ export const levenshteinDistance = (a, b) => {
 }
 
 export const getAllFiles = (dir, files = []) => {
+    if (!exists(dir)) { return [] }
     const file = Gio.File.new_for_path(dir);
     const enumerator = file.enumerate_children('standard::name,standard::type',
         Gio.FileQueryInfoFlags.NONE, null);
@@ -44,6 +45,8 @@ export const getAllFiles = (dir, files = []) => {
 }
 
 export const searchIcons = (appClass, files) => {
+    if (!files.length) { return "" }
+
     let appro = 0x3f3f3f3f
     let path = ""
 

--- a/.config/ags/modules/dock/main.js
+++ b/.config/ags/modules/dock/main.js
@@ -1,11 +1,12 @@
 import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 import Dock from './dock.js';
 
-export default () => Widget.Window({
-    name: 'dock',
-    layer: 'bottom',
+export default (monitor = 0) => Widget.Window({
+    monitor,
+    name: `dock${monitor}`,
+    layer: 'top',
     anchor: ['bottom'],
     exclusivity: 'normal',
     visible: true,
-    child: Dock(),
+    child: Dock(monitor),
 });

--- a/.config/ags/modules/dock/main.js
+++ b/.config/ags/modules/dock/main.js
@@ -4,7 +4,7 @@ import Dock from './dock.js';
 export default (monitor = 0) => Widget.Window({
     monitor,
     name: `dock${monitor}`,
-    layer: 'top',
+    layer: userOptions.dock.layer,
     anchor: ['bottom'],
     exclusivity: 'normal',
     visible: true,

--- a/.config/ags/scss/_dock.scss
+++ b/.config/ags/scss/_dock.scss
@@ -5,9 +5,20 @@
     padding: 0.682rem;
 }
 
+.dock-app-btn-animate {
+    transition-property: background-color;
+    transition-duration: 0.5s;
+}
+
 .dock-app-btn {
     @include normal-rounding;
     padding: 0.273rem;
+}
+
+.pinned-dock-app-btn {
+    @include normal-rounding;
+    padding: 0.273rem;
+    background-color: $layer0Hover;
 }
 
 .dock-app-btn:hover,


### PR DESCRIPTION
I'm used to dock so I updated the `dock` in the `modules`, I don't know why it's not being used.
![图片](https://github.com/end-4/dots-hyprland/assets/95210542/54b9d0d0-8e43-4d0e-85a9-f13057fbef93)
It generally continues the design from the dock, but it is always placed at the top level and only exists on one monitor at most. When focusing on another monitor, the dock will move to that monitor. It also hides itself when `onHoverLost` is triggered, and there is a button to hold the dock in place.
For the missing icons, I do a recursive search in the system's icon path, preprocessing the path of each image under the path and storing it in an array at ags startup. When an icon is needed use `Levenshtein Distance` to find the closest string according to the class of the window. In my tests it seems that a lot of all icons can be corresponded to. However, there are requirements for the search path: if there are too many images there is an expensive performance hit, if there are too few images there may be missing icons, so I chose `tela-icon-theme`.
If you have suggestions or complaints please let me know.