### PR TITLE
Use `GDK` to determine the monitor geometry.

### DIFF
--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -16,8 +16,21 @@ globalThis['openColorScheme'] = showColorScheme;
 globalThis['mpris'] = Mpris;
 
 // Screen size
-export const SCREEN_WIDTH = Number(exec(`bash -c "xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f1 | head -1" | awk '{print $1}'`));
-export const SCREEN_HEIGHT = Number(exec(`bash -c "xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f2 | head -1" | awk '{print $1}'`));
+const getMonitorGeometry = () => {
+    const display = Gdk.Display.get_default();
+    const monitor = display.get_monitor(0);
+    const monitorGeometry = monitor.get_geometry();
+
+    return {
+        width: monitorGeometry.width,
+        height: monitorGeometry.height,
+    }
+}
+
+const monitorGeometry = getMonitorGeometry();
+
+export const SCREEN_WIDTH = monitorGeometry.width;
+export const SCREEN_HEIGHT = monitorGeometry.height;
 
 // Mode switching
 export const currentShellMode = Variable('normal', {}) // normal, focus


### PR DESCRIPTION
With GDK the screen height and width can be determined. This has the added benefit that if scaling is applied, it reports the final screen width and height after scaling. This solves various scaling issues, as reported in https://github.com/end-4/dots-hyprland/issues/424 and https://github.com/end-4/dots-hyprland/issues/417. I also had some ideas on how to consider different screen sizes for multiple monitors in https://github.com/end-4/dots-hyprland/issues/424#issuecomment-2067395463.