### PR TITLE
fix multi-monitor widgets

### DIFF
--- a/.config/ags/modules/cheatsheet/main.js
+++ b/.config/ags/modules/cheatsheet/main.js
@@ -70,7 +70,7 @@ const CheatsheetHeader = () => Widget.CenterBox({
     }),
 });
 
-const sheetContents = {};
+const sheetContents = [];
 const SheetContent = (id) => {
     sheetContents[id] = ExpandingIconTabContainer({
         tabsHpack: 'center',

--- a/.config/ags/modules/cheatsheet/main.js
+++ b/.config/ags/modules/cheatsheet/main.js
@@ -10,12 +10,12 @@ const cheatsheets = [
     {
         name: 'Keybinds',
         materialIcon: 'keyboard',
-        contentWidget: Keybinds(),
+        contentWidget: Keybinds,
     },
     {
         name: 'Periodic table',
         materialIcon: 'experiment',
-        contentWidget: PeriodicTable(),
+        contentWidget: PeriodicTable,
     },
 ];
 
@@ -70,20 +70,24 @@ const CheatsheetHeader = () => Widget.CenterBox({
     }),
 });
 
-export const sheetContent = ExpandingIconTabContainer({
-    tabsHpack: 'center',
-    tabSwitcherClassName: 'sidebar-icontabswitcher',
-    transitionDuration: userOptions.animations.durationLarge * 1.4,
-    icons: cheatsheets.map((api) => api.materialIcon),
-    names: cheatsheets.map((api) => api.name),
-    children: cheatsheets.map((api) => api.contentWidget),
-    onChange: (self, id) => {
-        self.shown = cheatsheets[id].name;
-        if (cheatsheets[id].onFocus) cheatsheets[id].onFocus();
-    }
-});
+const sheetContents = {};
+const SheetContent = (id) => {
+    sheetContents[id] = ExpandingIconTabContainer({
+        tabsHpack: 'center',
+        tabSwitcherClassName: 'sidebar-icontabswitcher',
+        transitionDuration: userOptions.animations.durationLarge * 1.4,
+        icons: cheatsheets.map((api) => api.materialIcon),
+        names: cheatsheets.map((api) => api.name),
+        children: cheatsheets.map((api) => api.contentWidget()),
+        onChange: (self, id) => {
+            self.shown = cheatsheets[id].name;
+        }
+    });
+    return sheetContents[id];
+}
 
 export default (id) => PopupWindow({
+    monitor: id,
     name: `cheatsheet${id}`,
     layer: 'overlay',
     keymode: 'on-demand',
@@ -96,15 +100,15 @@ export default (id) => PopupWindow({
                 className: "cheatsheet-bg spacing-v-5",
                 children: [
                     CheatsheetHeader(),
-                    sheetContent,
+                    SheetContent(id),
                 ]
             }),
         ],
         setup: (self) => self.on('key-press-event', (widget, event) => { // Typing
             if (checkKeybind(event, userOptions.keybinds.cheatsheet.nextTab))
-                sheetContent.nextTab();
+                sheetContents[id].nextTab();
             else if (checkKeybind(event, userOptions.keybinds.cheatsheet.prevTab))
-                sheetContent.prevTab();
+                sheetContents[id].prevTab();
         })
     })
 });

--- a/.config/ags/modules/onscreenkeyboard/main.js
+++ b/.config/ags/modules/onscreenkeyboard/main.js
@@ -2,6 +2,7 @@ import PopupWindow from '../.widgethacks/popupwindow.js';
 import OnScreenKeyboard from "./onscreenkeyboard.js";
 
 export default (id) => PopupWindow({
+    monitor: id,
     anchor: ['bottom'],
     name: `osk${id}`,
     showClassName: 'osk-show',

--- a/.config/ags/modules/onscreenkeyboard/onscreenkeyboard.js
+++ b/.config/ags/modules/onscreenkeyboard/onscreenkeyboard.js
@@ -14,7 +14,7 @@ const keyboardJson = oskLayouts[keyboardLayout];
 
 async function startYdotoolIfNeeded() {
     const running = exec('pidof ydotool')
-    if(!running) execAsync(['ydotoold']).catch(print);
+    if (!running) execAsync(['ydotoold']).catch(print);
 }
 
 function releaseAllKeys() {
@@ -72,7 +72,7 @@ const KeyboardControls = () => Box({
             className: 'osk-control-button txt-norm icon-material',
             onClicked: () => {
                 releaseAllKeys();
-                App.toggleWindowOnAllMonitors('osk');
+                toggleWindowOnAllMonitors('osk');
             },
             label: 'keyboard_hide',
         }),
@@ -213,7 +213,7 @@ const KeyboardWindow = () => Box({
         })
     ],
     setup: (self) => self.hook(App, (self, name, visible) => { // Update on open
-        if(!name) return;
+        if (!name) return;
         if (name.startsWith('osk') && visible) {
             self.setCss(`margin-bottom: -0px;`);
         }

--- a/.config/ags/modules/session/main.js
+++ b/.config/ags/modules/session/main.js
@@ -3,6 +3,7 @@ import SessionScreen from "./sessionscreen.js";
 import PopupWindow from '../.widgethacks/popupwindow.js';
 
 export default (id = 0) => PopupWindow({ // On-screen keyboard
+    monitor: id,
     name: `session${id}`,
     visible: false,
     keymode: 'on-demand',

--- a/.config/ags/modules/session/sessionscreen.js
+++ b/.config/ags/modules/session/sessionscreen.js
@@ -61,14 +61,14 @@ const SessionButton = (name, icon, command, props = {}, colorid = 0) => {
 
 export default ({ id = 0 }) => {
     // lock, logout, sleep
-    const lockButton = SessionButton('Lock', 'lock', () => { App.closeWindow(`session${id}`); execAsync(['loginctl', 'lock-session']).catch(print) }, {}, 1);
-    const logoutButton = SessionButton('Logout', 'logout', () => { App.closeWindow(`session${id}`); execAsync(['bash', '-c', 'pkill Hyprland || pkill sway || pkill niri || loginctl terminate-user $USER']).catch(print) }, {}, 2);
-    const sleepButton = SessionButton('Sleep', 'sleep', () => { App.closeWindow(`session${id}`); execAsync(['bash', '-c', 'systemctl suspend || loginctl suspend']).catch(print) }, {}, 3);
+    const lockButton = SessionButton('Lock', 'lock', () => { closeWindowOnAllMonitors('session'); execAsync(['loginctl', 'lock-session']).catch(print) }, {}, 1);
+    const logoutButton = SessionButton('Logout', 'logout', () => { closeWindowOnAllMonitors('session'); execAsync(['bash', '-c', 'pkill Hyprland || pkill sway || pkill niri || loginctl terminate-user $USER']).catch(print) }, {}, 2);
+    const sleepButton = SessionButton('Sleep', 'sleep', () => { closeWindowOnAllMonitors('session'); execAsync(['bash', '-c', 'systemctl suspend || loginctl suspend']).catch(print) }, {}, 3);
     // hibernate, shutdown, reboot
-    const hibernateButton = SessionButton('Hibernate', 'downloading', () => { App.closeWindow(`session${id}`); execAsync(['bash', '-c', 'systemctl hibernate || loginctl hibernate']).catch(print) }, {}, 4);
-    const shutdownButton = SessionButton('Shutdown', 'power_settings_new', () => { App.closeWindow(`session${id}`); execAsync(['bash', '-c', 'systemctl poweroff || loginctl poweroff']).catch(print) }, {}, 5);
-    const rebootButton = SessionButton('Reboot', 'restart_alt', () => { App.closeWindow(`session${id}`); execAsync(['bash', '-c', 'systemctl reboot || loginctl reboot']).catch(print) }, {}, 6);
-    const cancelButton = SessionButton('Cancel', 'close', () => App.closeWindow(`session${id}`), { className: 'session-button-cancel' }, 7);
+    const hibernateButton = SessionButton('Hibernate', 'downloading', () => { closeWindowOnAllMonitors('session'); execAsync(['bash', '-c', 'systemctl hibernate || loginctl hibernate']).catch(print) }, {}, 4);
+    const shutdownButton = SessionButton('Shutdown', 'power_settings_new', () => { closeWindowOnAllMonitors('session'); execAsync(['bash', '-c', 'systemctl poweroff || loginctl poweroff']).catch(print) }, {}, 5);
+    const rebootButton = SessionButton('Reboot', 'restart_alt', () => { closeWindowOnAllMonitors('session'); execAsync(['bash', '-c', 'systemctl reboot || loginctl reboot']).catch(print) }, {}, 6);
+    const cancelButton = SessionButton('Cancel', 'close', () => closeWindowOnAllMonitors('session'), { className: 'session-button-cancel' }, 7);
 
     const sessionDescription = Widget.Box({
         vertical: true,
@@ -104,9 +104,9 @@ export default ({ id = 0 }) => {
         vertical: true,
         children: [
             Widget.EventBox({
-                onPrimaryClick: () => App.closeWindow(`session${id}`),
-                onSecondaryClick: () => App.closeWindow(`session${id}`),
-                onMiddleClick: () => App.closeWindow(`session${id}`),
+                onPrimaryClick: () => closeWindowOnAllMonitors('session'),
+                onSecondaryClick: () => closeWindowOnAllMonitors('session'),
+                onMiddleClick: () => closeWindowOnAllMonitors('session'),
             }),
             Widget.Box({
                 hpack: 'center',

--- a/.config/ags/scripts/color_generation/switchwall.sh
+++ b/.config/ags/scripts/color_generation/switchwall.sh
@@ -5,11 +5,13 @@ if [ "$1" == "--noswitch" ]; then
     # imgpath=$(ags run-js 'wallpaper.get(0)')
 else
     # Select and set image (hyprland)
-    cd "$HOME/Pictures"
+    cd "$(xdg-user-dir PICTURES)"
     imgpath=$(yad --width 1200 --height 800 --file --title='Choose wallpaper' --add-preview --large-preview)
-    screensizey=$(xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f2 | head -1)
+    read scale screenx screeny screensizey < <(hyprctl monitors -j | jq '.[] | select(.focused) | .scale, .x, .y, .height' | xargs)
     cursorposx=$(hyprctl cursorpos -j | gojq '.x' 2>/dev/null) || cursorposx=960
+    cursorposx=$(bc <<< "scale=0; ($cursorposx - $screenx) * $scale / 1")
     cursorposy=$(hyprctl cursorpos -j | gojq '.y' 2>/dev/null) || cursorposy=540
+    cursorposy=$(bc <<< "scale=0; ($cursorposy - $screeny) * $scale / 1")
     cursorposy_inverted=$(( screensizey - cursorposy ))
 
     if [ "$imgpath" == '' ]; then

--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -81,15 +81,15 @@ bind = Control+Super, T, exec, ~/.config/ags/scripts/color_generation/switchwall
 bind = Control+Alt, Slash, exec, ags run-js 'cycleMode();'
 bindir = Super, Super_L, exec, ags -t 'overview'
 bind = Super, Tab, exec, ags -t 'overview'
-bind = Super, Slash, exec, for ((i=0; i<$(xrandr --listmonitors | grep -c 'Monitor'); i++)); do ags -t "cheatsheet""$i"; done
+bind = Super, Slash, exec, for ((i=0; i<$(hyprctl monitors -j | jq length); i++)); do ags -t "cheatsheet""$i"; done
 bind = Super, B, exec, ags -t 'sideleft'
 bind = Super, A, exec, ags -t 'sideleft'
 bind = Super, O, exec, ags -t 'sideleft'
 bind = Super, N, exec, ags -t 'sideright'
 bind = Super, M, exec, ags run-js 'openMusicControls.value = (!mpris.getPlayer() ? false : !openMusicControls.value);'
 bind = Super, Comma, exec, ags run-js 'openColorScheme.value = true; Utils.timeout(2000, () => openColorScheme.value = false);'
-bind = Super, K, exec, for ((i=0; i<$(xrandr --listmonitors | grep -c 'Monitor'); i++)); do ags -t "osk""$i"; done
-bind = Control+Alt, Delete, exec, for ((i=0; i<$(xrandr --listmonitors | grep -c 'Monitor'); i++)); do ags -t "session""$i"; done
+bind = Super, K, exec, for ((i=0; i<$(hyprctl monitors -j | jq length); i++)); do ags -t "osk""$i"; done
+bind = Control+Alt, Delete, exec, for ((i=0; i<$(hyprctl monitors -j | jq length); i++)); do ags -t "session""$i"; done
 bindle = , XF86AudioRaiseVolume, exec, ags run-js 'indicator.popup(1);'
 bindle = , XF86AudioLowerVolume, exec, ags run-js 'indicator.popup(1);'
 bindle=, XF86MonBrightnessUp, exec, ags run-js 'brightness.screen_value += 0.05; indicator.popup(1);'
@@ -206,6 +206,3 @@ bindle = Alt, L, exec, ydotool key 106:1 106:0
 # Control + Side mouse btn for switching tabs (Ctrl+PgUp/PgDn)
 # bind = Control, mouse:275, exec, ydotool key 29:1 104:1 104:0 29:0
 # bind = Control, mouse:276, exec, ydotool key 29:1 109:1 109:0 29:0
-
-
-

--- a/scriptdata/dependencies.conf
+++ b/scriptdata/dependencies.conf
@@ -16,7 +16,6 @@ tinyxml2 gtkmm3 gtksourceviewmm cairomm
 python-build python-pillow python-pywal python-setuptools-scm python-wheel
 
 ### Basic graphic env
-xorg-xrandr
 xdg-desktop-portal xdg-desktop-portal-gtk xdg-desktop-portal-hyprland-git
 
 ### Player and Audio


### PR DESCRIPTION
these widgets were declared for each monitor but never triggered due to:
```
╰─ xrandr --listmonitors
Monitors: 2
 0: +DP-1 3840/600x2160/340+0+0  DP-1
 1: +DP-2 3840/530x2160/300+7680+0  DP-2

╰─ xrandr --listmonitors | grep -c 'Monitor'
1
```

this pr fixes keybinds and widget implementations for the second monitor