### PR TITLE
ags: fix systray icon warning

### DIFF
--- a/.config/ags/modules/bar/normal/tray.js
+++ b/.config/ags/modules/bar/normal/tray.js
@@ -5,11 +5,7 @@ const { Gravity } = imports.gi.Gdk;
 
 const SysTrayItem = (item) => Button({
     className: 'bar-systray-item',
-    child: Icon({
-        hpack: 'center',
-        icon: `${item.icon}`,
-        setup: (self) => self.hook(item, (self) => self.icon = item.icon),
-    }),
+    child: Icon({hpack: 'center'}).bind('icon', item, 'icon'),
     setup: (self) => self
         .hook(item, (self) => self.tooltipMarkup = item['tooltip-markup'])
     ,


### PR DESCRIPTION
take code snippet from ags wiki to fix:
```
(com.github.Aylur.ags:748022): Gjs-Console-WARNING **: 21:42:04.733: Error: can't assign "[object instance wrapper GIName:GdkPixbuf.Pixbuf jsobj@0x37f2745abd08 native@0x62e804712490]" as icon, it is not a file nor a named icon
```