### PR TITLE
[Feature] Added not found status in waifu.js

### DIFF
--- a/.config/ags/modules/sideleft/apis/waifu.js
+++ b/.config/ags/modules/sideleft/apis/waifu.js
@@ -127,6 +127,7 @@ const WaifuImage = (taglist) => {
             'download': ImageState('downloading', 'Downloading image'),
             'done': ImageState('done', 'Finished!'),
             'error': ImageState('error', 'Error'),
+            'notfound': ImageState('error', 'Not found!'),
         },
     });
     const downloadIndicator = MarginRevealer({
@@ -204,6 +205,10 @@ const WaifuImage = (taglist) => {
                 thisBlock.attribute.imageData = imageData;
                 const { status, signature, url, extension, source, dominant_color, is_nsfw, width, height, tags } = thisBlock.attribute.imageData;
                 thisBlock.attribute.isNsfw = is_nsfw;
+                if (status == 404) {
+                    downloadState.shown = 'notfound';
+                    return;
+                }
                 if (status != 200) {
                     downloadState.shown = 'error';
                     return;


### PR DESCRIPTION
Since I was confused, why the waifu.js api showed an error after entering various tags (cough* just for research purposes of course), I checked and debugged just to find out, that I just was out of luck with the tags, lol. Always 404.
To prevent confusion I added the notfound state.