### PR TITLE
Update rules.conf to fix wps office

### DIFF
--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -4,7 +4,6 @@ windowrule = noblur,.*
 windowrule = float, ^(blueberry.py)$
 windowrule = float, ^(steam)$
 windowrule = float, ^(guifetch)$ # FlafyDev/guifetch
-windowrulev2 = tile,class:(wps)
 windowrulev2 = tile,class:(dev.warp.Warp)
 
 # Dialogs


### PR DESCRIPTION
Context menus (Right-Click) of wps office applications are treated like windows and therefore tiled with this rule. This leads to an unwanted snapping of the menu next to the active window.
![image](https://github.com/end-4/dots-hyprland/assets/45454768/8cb6bf37-6219-4c47-9c9e-325947698896)

