### PR TITLE
Renamed Wolfram to Tungsten in the periodic table

### DIFF
--- a/.config/ags/modules/cheatsheet/data_periodictable.js
+++ b/.config/ags/modules/cheatsheet/data_periodictable.js
@@ -107,7 +107,7 @@ export const periodicTable = [
         { name: 'Lanthanum', symbol: 'La', number: 57, weight: 138.91, type: 'lanthanum' },
         { name: 'Hafnium', symbol: 'Hf', number: 72, weight: 178.49, type: 'metal' },
         { name: 'Tantalum', symbol: 'Ta', number: 73, weight: 180.95, type: 'metal' },
-        { name: 'Wolfram', symbol: 'W', number: 74, weight: 183.84, type: 'metal' },
+        { name: 'Tungsten', symbol: 'W', number: 74, weight: 183.84, type: 'metal' },
         { name: 'Rhenium', symbol: 'Re', number: 75, weight: 186.21, type: 'metal' },
         { name: 'Osmium', symbol: 'Os', number: 76, weight: 190.23, type: 'metal' },
         { name: 'Iridium', symbol: 'Ir', number: 77, weight: 192.22, type: 'metal' },


### PR DESCRIPTION
Renamed Wolfram to Tungsten in the periodic table, Tungsten is the more commonly used name. (Even Wikipedia uses Tungsten https://en.wikipedia.org/wiki/Tungsten)

I was trying to find Tungsten on the table but couldn't find it, ended up wasting me 10 minutes. I am submitting this pr to prevent anyone in the future to suffer the same fate as me.