### PR TITLE
fix: truncate if offscreen

### DIFF
--- a/.config/ags/modules/overview/overview_hyprland.js
+++ b/.config/ags/modules/overview/overview_hyprland.js
@@ -61,7 +61,7 @@ export default (overviewMonitor = 0) => {
         if (y + h <= 0) x += (Math.floor(y / monitors[monitor].height) * monitors[monitor].height);
         else if (y < 0) { h = y + h; y = 0; }
         // Truncate if offscreen
-        if (x + w > monitors[monitor]) w = monitors[monitor] - x;
+        if (x + w > monitors[monitor].width) w = monitors[monitor].width - x;
         if (y + h > monitors[monitor].height) h = monitors[monitor].height - y;
 
         const iconName = substitute(c);


### PR DESCRIPTION
Fix a bug in the overview module where the width of window element was not properly truncated.