### PR TITLE
ags: use system-wide icon theme for systray

### DIFF
--- a/.config/ags/scss/_bar.scss
+++ b/.config/ags/scss/_bar.scss
@@ -346,7 +346,6 @@ $bar_ws_width_focus_active: 2.045rem;
 .bar-systray-item {
     @include full-rounding;
     @include element_decel;
-    @include symbolic-icon;
     min-height: 1.032rem;
     min-width: 1.032rem;
     font-size: 1.032rem;


### PR DESCRIPTION
The system-wide gtk icon theme can be set by:

    gsettings set org.gnome.desktop.interface icon-theme icon_theme_name

Don't mess up user's preference.