### PR TITLE
Audio popups also showing up if the volume changes e.g. by keys

### DIFF
--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -59,6 +59,7 @@ export default (monitor = 0) => {
         }, 'notify::screen-value'),
         progressSetup: (self) => self.hook(Brightness[monitor], (progress) => {
             const updateValue = Brightness[monitor].screen_value;
+            if (updateValue != progress.value) Indicator.popup(1);
             progress.value = updateValue;
         }, 'notify::screen-value'),
     });

--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -63,12 +63,11 @@ export default (monitor = 0) => {
             progress.value = updateValue;
         }, 'notify::screen-value'),
     });
-
     const volumeIndicator = OsdValue({
         name: 'Volume',
         extraClassName: 'osd-volume',
         extraProgressClassName: 'osd-volume-progress',
-        attribute: { headphones: undefined },
+        attribute: { headphones: undefined , device: undefined},
         nameSetup: (self) => Utils.timeout(1, () => {
             const updateAudioDevice = (self) => {
                 const usingHeadphones = (Audio.speaker?.stream?.port)?.toLowerCase().includes('headphone');
@@ -87,8 +86,14 @@ export default (monitor = 0) => {
         }),
         progressSetup: (self) => self.hook(Audio, (progress) => {
             const updateValue = Audio.speaker?.volume;
+            const newDevice = (Audio.speaker?.name);
+            // print(newDevice, device);
             if (!isNaN(updateValue)) {
-                if (updateValue !== progress.value) Indicator.popup(1);
+                if ((volumeIndicator.attribute.device === undefined || newDevice === volumeIndicator.attribute.device)
+                    && updateValue !== progress.value) {
+                    Indicator.popup(1);
+                }
+                volumeIndicator.attribute.device = newDevice;
                 progress.value = updateValue;
             }
         }),

--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -63,6 +63,7 @@ export default (monitor = 0) => {
             progress.value = updateValue;
         }, 'notify::screen-value'),
     });
+
     const volumeIndicator = OsdValue({
         name: 'Volume',
         extraClassName: 'osd-volume',
@@ -87,15 +88,13 @@ export default (monitor = 0) => {
         progressSetup: (self) => self.hook(Audio, (progress) => {
             const updateValue = Audio.speaker?.volume;
             const newDevice = (Audio.speaker?.name);
-            // print(newDevice, device);
             if (!isNaN(updateValue)) {
-                if ((volumeIndicator.attribute.device === undefined || newDevice === volumeIndicator.attribute.device)
-                    && updateValue !== progress.value) {
-                    Indicator.popup(1);
-                }
-                volumeIndicator.attribute.device = newDevice;
+                if (newDevice === volumeIndicator.attribute.device && updateValue !== progress.value) {
+                        Indicator.popup(1);
+                    }
                 progress.value = updateValue;
             }
+            volumeIndicator.attribute.device = newDevice;
         }),
     });
     return MarginRevealer({

--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -59,7 +59,7 @@ export default (monitor = 0) => {
         }, 'notify::screen-value'),
         progressSetup: (self) => self.hook(Brightness[monitor], (progress) => {
             const updateValue = Brightness[monitor].screen_value;
-            if (updateValue != progress.value) Indicator.popup(1);
+            if (updateValue !== progress.value) Indicator.popup(1);
             progress.value = updateValue;
         }, 'notify::screen-value'),
     });
@@ -88,7 +88,7 @@ export default (monitor = 0) => {
         progressSetup: (self) => self.hook(Audio, (progress) => {
             const updateValue = Audio.speaker?.volume;
             if (!isNaN(updateValue)) {
-                if (updateValue != progress.value) Indicator.popup(1);
+                if (updateValue !== progress.value) Indicator.popup(1);
                 progress.value = updateValue;
             }
         }),

--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -86,7 +86,10 @@ export default (monitor = 0) => {
         }),
         progressSetup: (self) => self.hook(Audio, (progress) => {
             const updateValue = Audio.speaker?.volume;
-            if (!isNaN(updateValue)) progress.value = updateValue;
+            if (!isNaN(updateValue)) {
+                if (updateValue != progress.value) Indicator.popup(1);
+                progress.value = updateValue;
+            }
         }),
     });
     return MarginRevealer({


### PR DESCRIPTION
The audio popup now works as in most setups and shows up if the volume changes. It does not if you skip a song etc.

I implemented it for backlight as well, but its not working. The hook doesn't trigger if I change the brightness via keybinds. I assume the service doesnt check for that? Didn't check yet.