### PR TITLE
Only show 1 digit after decimal point for battry percentage

### DIFF
--- a/.config/ags/modules/bar/normal/system.js
+++ b/.config/ags/modules/bar/normal/system.js
@@ -99,7 +99,7 @@ const BarBattery = () => Box({
         Label({
             className: 'txt-smallie',
             setup: (self) => self.hook(Battery, label => {
-                label.label = `${Battery.percent.toFixed(1)}%`;
+                label.label = `${Number.parseFloat(Battery.percent.toFixed(1))}%`;
             }),
         }),
         Overlay({

--- a/.config/ags/modules/bar/normal/system.js
+++ b/.config/ags/modules/bar/normal/system.js
@@ -99,7 +99,7 @@ const BarBattery = () => Box({
         Label({
             className: 'txt-smallie',
             setup: (self) => self.hook(Battery, label => {
-                label.label = `${Battery.percent}%`;
+                label.label = `${Battery.percent.toFixed(1)}%`;
             }),
         }),
         Overlay({


### PR DESCRIPTION
Keep only one digit after the dots on the battery icon.

Before:
![swappy-20240604-180026](https://github.com/end-4/dots-hyprland/assets/94928179/dec38b27-65c2-4a1a-88e5-783a336ef665)
After:
![swappy-20240604-180038](https://github.com/end-4/dots-hyprland/assets/94928179/f395e7f7-5443-4f54-ae74-44cb6a37d5d6)
