### PR TITLE
Update thorium-flags.conf to use gnome-libsecret

### DIFF
--- a/.config/thorium-flags.conf
+++ b/.config/thorium-flags.conf
@@ -1,5 +1,5 @@
---password-store=gnome 
---ozone-platform-hint=wayland 
---gtk-version=4 
---ignore-gpu-blocklist 
+--password-store=gnome-libsecret
+--ozone-platform-hint=wayland
+--gtk-version=4
+--ignore-gpu-blocklist
 --enable-features=TouchpadOverscrollHistoryNavigation


### PR DESCRIPTION
Updates thorium-flags.conf as `--password-store=gnome` should now be `--password-store=gnome-libsecret` (see https://www.reddit.com/r/archlinux/comments/15sse7i/psa_chromium_dropped_gnomekeyring_support_use/ ) 

I noticed Visual Studio Code automatically changes its flags file to `--password-store=gnome-libsecret` and even edits it if it said `--password-store=gnome` previously, so this would suggest this new flag is probably the recommended one going forward for electron/chromium based apps.