### PR TITLE
Arrays in user options don't throw an error anymore

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -198,7 +198,7 @@ function overrideConfigRecursive(userOverrides, configOptions = {}, check = true
         if (configOptions[key] === undefined && check) {
             optionsOkay = false;
         }
-        else if (typeof value === 'object') {
+        else if (typeof value === 'object' && !(value instanceof Array)) {
             if (key === "substitutions" || key === "regexSubstitutions") {
                 overrideConfigRecursive(value, configOptions[key], false);
             } else overrideConfigRecursive(value, configOptions[key]);


### PR DESCRIPTION
Whenever you changed an array in the user_config it threw an error because it would check all the entries with the template user_config and not find the new ones.

Example: `'excludedSites': ["quora.com", "reddit.com"],`
