### PR TITLE
Search customizing

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -93,6 +93,12 @@ let configOptions = {
 
     },
     'search': {
+        'enableActions': true,
+        'enableCommands': true,
+        'enableMathResults': true,
+        'enableDirectorySearch': true,
+        'enableAiSearch': true,
+        'enableWebSearch': true,
         'engineBaseUrl': "https://www.google.com/search?q=",
         'excludedSites': ["quora.com"],
     },

--- a/.config/ags/modules/overview/searchbuttons.js
+++ b/.config/ags/modules/overview/searchbuttons.js
@@ -7,6 +7,15 @@ import { searchItem } from './searchitem.js';
 import { execAndClose, couldBeMath, launchCustomCommand } from './miscfunctions.js';
 import GeminiService from '../../services/gemini.js';
 
+export const NoResultButton = () => searchItem({
+    materialIconName: 'Error',
+    name: "Search invalid",
+    content: "No results found!",
+    onActivate: () => {
+        App.closeWindow('overview');
+    },
+});
+
 export const DirectoryButton = ({ parentPath, name, type, icon }) => {
     const actionText = Widget.Revealer({
         revealChild: false,

--- a/.config/ags/modules/overview/searchbuttons.js
+++ b/.config/ags/modules/overview/searchbuttons.js
@@ -159,7 +159,11 @@ export const SearchButton = ({ text = '' }) => searchItem({
     content: `${text}`,
     onActivate: () => {
         App.closeWindow('overview');
-        execAsync(['bash', '-c', `xdg-open '${userOptions.search.engineBaseUrl}${text} ${['', ...userOptions.search.excludedSites].join(' -site:')}' &`]).catch(print);
+        let search = userOptions.search.engineBaseUrl + text;
+        for (let site of userOptions.search.excludedSites) {
+            if (site) search += ` -site:${site}`;
+        }
+        execAsync(['bash', '-c', `xdg-open '${search}' &`]).catch(print);
     },
 });
 

--- a/.config/ags/modules/overview/windowcontent.js
+++ b/.config/ags/modules/overview/windowcontent.js
@@ -94,57 +94,7 @@ export const SearchAndWindows = () => {
         className: 'overview-search-box txt-small txt',
         hpack: 'center',
         onAccept: (self) => { // This is when you hit Enter
-            const text = self.text;
-            if (text.length == 0) return;
-            const isAction = text.startsWith('>');
-            const isDir = (['/', '~'].includes(entry.text[0]));
-
-            if (userOptions.search.enableMathResults && couldBeMath(text)) { // Eval on typing is dangerous, this is a workaround
-                try {
-                    const fullResult = eval(text.replace(/\^/g, "**"));
-                    // copy
-                    execAsync(['wl-copy', `${fullResult}`]).catch(print);
-                    App.closeWindow('overview');
-                    return;
-                } catch (e) {
-                    // console.log(e);
-                }
-            }
-            if (userOptions.search.enableDirectorySearch && isDir) {
-                App.closeWindow('overview');
-                execAsync(['bash', '-c', `xdg-open "${expandTilde(text)}"`, `&`]).catch(print);
-                return;
-            }
-            if (_appSearchResults.length > 0) {
-                App.closeWindow('overview');
-                _appSearchResults[0].launch();
-                return;
-            }
-            else if (userOptions.search.enableActions && text[0] == '>') { // Custom commands
-                App.closeWindow('overview');
-                launchCustomCommand(text);
-                return;
-            }
-            // Fallback: Execute command
-            if (userOptions.search.enableCommands && !isAction && exec(`bash -c "command -v ${text.split(' ')[0]}"`) != '') {
-                if (text.startsWith('sudo'))
-                    execAndClose(text, true);
-                else
-                    execAndClose(text, false);
-            }
-            else if (userOptions.search.enableAiSearch) {
-                GeminiService.send(text);
-                App.closeWindow('overview');
-                App.openWindow('sideleft');
-            }
-            else if (userOptions.search.enableWebSearch) {
-                App.closeWindow('overview');
-                let search = userOptions.search.engineBaseUrl + text;
-                for (let site of userOptions.search.excludedSites) {
-                    if (site) search += ` -site:${site}`;
-                }
-                execAsync(['bash', '-c', `xdg-open '${search}' &`]).catch(print);
-            }
+            resultsBox.children[0].onClicked();
         },
         onChange: (entry) => { // this is when you type
             const isAction = entry.text[0] == '>';


### PR DESCRIPTION
One bugfix: if the blocked website array is empty there is no `-site:` anymore

And added user options to turn search features on and off.
Also there is a new NoResultsButton (maybe it shouldn't be a button lol) so the search result list is never completly empty.

Also I'm wondering whether the Buttons could be changed so they can also be used when pressing enter, so all the conditions in onAccept could be skipped. Might try some stuff tomorrow (its 3:46am)
