### PR TITLE
Window rules fixes/additions

### DIFF
--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -13,6 +13,7 @@ windowrule=float,title:^(Choose wallpaper)(.*)$
 windowrule=float,title:^(Open Folder)(.*)$
 windowrule=float,title:^(Save As)(.*)$
 windowrule=float,title:^(Library)(.*)$
+windowrule=float,title:^(File Upload)(.*)$
 
 # Tearing
 windowrule=immediate,.*\.exe

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -5,6 +5,7 @@ windowrule = float, ^(blueberry.py)$
 windowrule = float, ^(steam)$
 windowrule = float, ^(guifetch)$ # FlafyDev/guifetch
 windowrulev2 = tile,class:(dev.warp.Warp)
+windowrulev2 = float,title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 
 # Dialogs
 windowrule=float,title:^(Open File)(.*)$


### PR DESCRIPTION
Two changes to rules.conf:

ADD:
```windowrule=float,title:^(File Upload)(.*)$```
- When browsing the web if there is a prompt to upload a file (like a "browse" or "select file" button) these prompts often come up with a file picker window titled "File Upload" - so they should be floated too.

ADD:
```windowrulev2 = float,title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$```
- When playing back video (e.g YouTube) many browsers (Firefox, Edge, Chrome probably) have a picture in picture mode, currently it is tiled, but it makes much more sense to float it. 
- I tested Firefox (which simply titles its windows "Picture-in-Picture" with no extra info) and Edge (which titles its windows "Picture in picture" with no extra info).
- Hyprland's regex syntax is weird (probs based on C++ modified ECMA syntax or sth) and doesn't support much, so I did what I could with the regex, I added the (.*) as well in case other browsers might append stuff to the title, feel free to test in other browsers if you desire.

\- Joel <3