### PR TITLE
Adding mute indicator to ags

### DIFF
--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -84,7 +84,7 @@ export default (monitor = 0) => {
         }),
         labelSetup: (self) => self.hook(Audio, (label) => {
             const newDevice = (Audio.speaker?.name);
-            const updateValue = Math.round(Audio.speaker?.volume * 100);
+            const updateValue = Audio.speaker?.is_muted ? label.label = `󰖁` : label.label = `${Math.round(Audio.speaker?.volume * 100)}`;
             if (!isNaN(updateValue)) {
                 if (newDevice === volumeIndicator.attribute.device && updateValue != label.label) {
                     Indicator.popup(1);


### PR DESCRIPTION
It's already present in the hyprland config, but right now it hidden by the indicator. Really small fix. I included the icon in the text, but I guess it could also be added to assets and be handled from there, if it causes issues. On my machine it works fine, though