### PR TITLE
hypridle: fix monitor not turning off after manual lock

### DIFF
--- a/.config/hypr/hypridle.conf
+++ b/.config/hypr/hypridle.conf
@@ -3,12 +3,12 @@ $suspend_cmd = pidof steam || systemctl suspend || loginctl suspend # fuck nvidi
 
 general {
     lock_cmd = $lock_cmd
-    before_sleep_cmd = $lock_cmd
+    before_sleep_cmd = loginctl lock-session
 }
 
 listener {
     timeout = 180 # 3mins
-    on-timeout = $lock_cmd
+    on-timeout = loginctl lock-session
 }
 
 listener {


### PR DESCRIPTION
The dpms off timer is not triggering for me after manually locking the screen via Win+L shortcut, and this commit magically fixes it. It just works, dunno why.

Derived from the example at the bottom of https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/