### PR TITLE
Add Dependency to Build hyprlock-git

### DIFF
--- a/arch-packages/illogical-impulse-widgets/PKGBUILD
+++ b/arch-packages/illogical-impulse-widgets/PKGBUILD
@@ -9,6 +9,7 @@ depends=(
 	python-pywayland
 	python-psutil
 	hypridle-git
+ 	hyprutils-git
 	hyprlock-git
 	wlogout
 	wl-clipboard


### PR DESCRIPTION
Hyprlock-git won't build without hyprutils, which is first built in line 141 of `install.sh`:
```bash
v yay $hyprland_installflags --asdeps hyprutils-git hyprlang-git hyprcursor-git hyprwayland-scanner-git
```
This occurs after the hyprlock installation.
[Link to line 141 in install.sh](../blob/main/install.sh#L141)

Is there a reason to keep the installation on line 141 after the change?