### PR TITLE
fixed uptime in AGS sideright module for non-Arch distros

### DIFF
--- a/.config/ags/modules/sideright/sideright.js
+++ b/.config/ags/modules/sideright/sideright.js
@@ -66,14 +66,47 @@ const timeRow = Box({
         Widget.Label({
             hpack: 'center',
             className: 'txt-small txt',
-            setup: (self) => self
-                .poll(5000, label => {
-                    execAsync(['bash', '-c', `uptime -p | sed -e 's/...//;s/ day\\| days/d/;s/ hour\\| hours/h/;s/ minute\\| minutes/m/;s/,[^,]*//2'`])
-                        .then(upTimeString => {
-                            label.label = `Uptime ${upTimeString}`;
-                        }).catch(print);
-                })
-            ,
+            setup: (self) => {
+            	const getUptime = async () => {
+                	try {
+                    	await execAsync(['bash', '-c', 'uptime -p']);
+                        return execAsync(['bash', '-c', `uptime -p | sed -e 's/...//;s/ day\\| days/d/;s/ hour\\| hours/h/;s/ minute\\| minutes/m/;s/,[^,]*//2'`]);
+                    } catch {
+                        return execAsync(['bash', '-c', 'uptime']).then(output => {
+                        	const uptimeRegex = /up\s+((\d+)\s+days?,\s+)?((\d+):(\d+)),/;
+                        	const matches = uptimeRegex.exec(output);
+            
+                            if (matches) {
+                            	const days = matches[2] ? parseInt(matches[2]) : 0;
+                                const hours = matches[4] ? parseInt(matches[4]) : 0;
+                                const minutes = matches[5] ? parseInt(matches[5]) : 0;
+            
+                                let formattedUptime = '';
+            
+                                if (days > 0) {
+                                	formattedUptime += `${days} d `;
+                                }
+                                if (hours > 0) {
+                                	formattedUptime += `${hours} h `;
+                                }
+                                formattedUptime += `${minutes} m`;
+            
+                                return formattedUptime;
+                            } else {
+                            	throw new Error('Failed to parse uptime output');
+                            }
+                        });
+                    }
+                };
+            
+                self.poll(5000, label => {
+                	getUptime().then(upTimeString => {
+                    	label.label = `Uptime: ${upTimeString}`;
+                    }).catch(err => {
+                    	console.error(`Failed to fetch uptime: ${err}`);
+                    });
+                });
+            },
         }),
         Widget.Box({ hexpand: true }),
         // ModuleEditIcon({ hpack: 'end' }), // TODO: Make this work


### PR DESCRIPTION
I installed the dotfiles on OpenSUSE Tumbleweed. When opening the dropdown on the right side of the bar, it wasn't showing me the uptime. Tumbleweed doesn't have "uptime -p" as an option. 

 [@nullptroma mentions this issue on the OpenSUSE install discussion](https://github.com/end-4/dots-hyprland/discussions/485#discussioncomment-9394056)

I modified the code, making it attempt to run "uptime -p", and if it fails, it parses the output of "uptime" to display on the panel. 