### PR TITLE
changed cheatsheet to appear only on active workspace

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -154,7 +154,7 @@ bindr = Ctrl+Super+Alt, R, exec, hyprctl reload; killall ags ydotool; ags & # [h
 bind = Ctrl+Alt, Slash, exec, ags run-js 'cycleMode();' # Cycle bar mode (normal, focus)
 bindir = Super, Super_L, exec, ags -t 'overview' # Toggle overview/launcher
 bind = Super, Tab, exec, ags -t 'overview' # [hidden]
-bind = Super, Slash, exec, for ((i=0; i<$(hyprctl monitors -j | jq length); i++)); do ags -t "cheatsheet""$i"; done # Show cheatsheet
+bind = Super, Slash, exec, ags -t "cheatsheet$(hyprctl activeworkspace -j | jq -r '.monitorID')" # Show cheatsheet
 bind = Super, B, exec, ags -t 'sideleft' # Toggle left sidebar
 bind = Super, A, exec, ags -t 'sideleft' # [hidden]
 bind = Super, O, exec, ags -t 'sideleft' # [hidden]


### PR DESCRIPTION
When the cheat sheet is on multiple monitors, using the PgUp and PgDn keys to cycle through the pages doesn't behave as expected. The page switch is sent to the different monitors randomly, and I have to spam the key until it happens to flip the page on the active workspace.

Another possible solution is making the AGS script switch pages on all monitors whenever the keys are pressed.