### PR TITLE
get_keybinds.py now only checks for "bind="

### DIFF
--- a/.config/ags/scripts/hyprland/get_keybinds.py
+++ b/.config/ags/scripts/hyprland/get_keybinds.py
@@ -195,7 +195,7 @@ def get_binds_recursive(current_content, scope):
             if(keybind != None):
                 current_content["keybinds"].append(keybind)
 
-        elif line == "" or line.startswith("$") or line.startswith("#"): # Comment, ignore
+        elif line == "" or not line.lstrip().startswith("bind"): # Comment, ignore
             pass
 
         else: # Normal keybind


### PR DESCRIPTION
I tried to make a submap in my config and ags didn't work anymore since the python script couldn't handle the submap rule. This should fix any configs where there is not only keybind rules in the file. Also works with whitespace in front of the line.

Are there any other rules than "bind" that need to be parsed by the script as well?