### PR TITLE
overview-tasks-workspace alignment fixes

### DIFF
--- a/.config/ags/modules/overview/overview_hyprland.js
+++ b/.config/ags/modules/overview/overview_hyprland.js
@@ -230,7 +230,7 @@ export default (overviewMonitor = 0) => {
         const widget = Widget.Box({
             className: 'overview-tasks-workspace',
             vpack: 'center',
-            // Adding 1px to minimum width/height to accomodate 1px padding space for contents:
+            // Rounding and adding 1px to minimum width/height to work around scaling inaccuracy:
             css: `
                 min-width: ${1 + Math.round(monitors[overviewMonitor].width * userOptions.overview.scale)}px;
                 min-height: ${1 + Math.round(monitors[overviewMonitor].height * userOptions.overview.scale)}px;

--- a/.config/ags/modules/overview/overview_hyprland.js
+++ b/.config/ags/modules/overview/overview_hyprland.js
@@ -230,9 +230,10 @@ export default (overviewMonitor = 0) => {
         const widget = Widget.Box({
             className: 'overview-tasks-workspace',
             vpack: 'center',
+            // Adding 1px to minimum width/height to accomodate 1px padding space for contents:
             css: `
-                min-width: ${monitors[overviewMonitor].width * userOptions.overview.scale}px;
-                min-height: ${monitors[overviewMonitor].height * userOptions.overview.scale}px;
+                min-width: ${1 + Math.round(monitors[overviewMonitor].width * userOptions.overview.scale)}px;
+                min-height: ${1 + Math.round(monitors[overviewMonitor].height * userOptions.overview.scale)}px;
             `,
             children: [Widget.EventBox({
                 hexpand: true,
@@ -412,6 +413,8 @@ export default (overviewMonitor = 0) => {
 
     return Widget.Revealer({
         revealChild: true,
+        // hpack to prevent unneeded expansion in overview-tasks-workspace:
+        hpack: 'center',
         transition: 'slide_down',
         transitionDuration: userOptions.animations.durationLarge,
         child: Widget.Box({


### PR DESCRIPTION
PR for issue #690

### hpack:

The addition of `hpack` to Widget.Revealer seems to fix the horizontal over-expansion issue.

While testing possible fixes, removing `hexpand` from `overview-tasks-workspace` and setting the size of the children also fixed over-expansion, but during animation (such as switching from overview to search results) the unbounded horizontal expansion would trigger and make the animation look bad.

I couldn't find any animation or sizing issues with the `hpack` solution at any scale or size, including very tiny overviews with few windows and large overviews with many windows.

### overview-tasks-workspace min width/height to fix right and bottom edges:

This might not be the "most correct" fix from a math or simplicity perspective, because there might be values somewhere else not being floored or rounded causing the windows inside overview to sometimes overlap the right and bottom edges.

In spite of that, rounding the multiplication and then adding one single pixel appeared to get it to line up precisely at various scales. I was never able to catch it landing +/- 1px in either incorrect direction, and I peeped a lot of pixels while testing this.

<details>
<summary>Sample screencaps from issue:</summary>

### hpack issue:
![hexpand-issue](https://github.com/user-attachments/assets/90b159d8-92d1-4db9-a6ab-384c7988d1d6)

### overview-tasks-workspace min width/height issue:
![edge-issue](https://github.com/user-attachments/assets/7a788d1d-56d3-45a1-a931-e803c766c697)

### Fixes applied:
![fixed](https://github.com/user-attachments/assets/aa3a429a-f309-4872-8986-44dbc8ad82d2)

</details>