### PR TITLE
booru: fix pixiv source link

### DIFF
--- a/.config/ags/services/booru.js
+++ b/.config/ags/services/booru.js
@@ -14,7 +14,7 @@ const APISERVICES = {
 
 const getWorkingImageSauce = (url) => {
     if (url.includes('pximg.net')) {
-        return `https://www.pixiv.net/en/artworks/${url.substring(url.lastIndexOf('/')).replace(/_p\d+\.png$/, '')}`;
+        return `https://www.pixiv.net/en/artworks/${url.substring(url.lastIndexOf('/') + 1).replace(/_p\d+\.(png|jpg|jpeg|gif)$/, '')}`;
     }
     return url;
 }


### PR DESCRIPTION
The +1 is needed so the link doesn't end up with a double slash. Added extensions for JPEG and GIF sources to the regex.