### PR TITLE
Fix for keyboard layout indicator not showing up on all monitors

### DIFF
--- a/.config/ags/modules/.commonwidgets/statusicons.js
+++ b/.config/ags/modules/.commonwidgets/statusicons.js
@@ -277,15 +277,24 @@ const OptionalKeyboardLayout = async () => {
         return null;
     }
 };
-const optionalKeyboardLayoutInstance = await OptionalKeyboardLayout();
+const createKeyboardLayoutInstances = async () => {
+    const Hyprland = (await import('resource:///com/github/Aylur/ags/service/hyprland.js')).default;
+    const monitorsCount = Hyprland.monitors.length
+    const instances = await Promise.all(
+        Array.from({ length: monitorsCount }, () => OptionalKeyboardLayout())
+    );
 
-export const StatusIcons = (props = {}) => Widget.Box({
+    return instances;
+};
+const optionalKeyboardLayoutInstances = await createKeyboardLayoutInstances()
+
+export const StatusIcons = (props = {}, monitor = 0) => Widget.Box({
     ...props,
     child: Widget.Box({
         className: 'spacing-h-15',
         children: [
             MicMuteIndicator(),
-            optionalKeyboardLayoutInstance,
+            optionalKeyboardLayoutInstances[monitor],
             NotificationIndicator(),
             NetworkIndicator(),
             Widget.Box({

--- a/.config/ags/modules/bar/main.js
+++ b/.config/ags/modules/bar/main.js
@@ -58,7 +58,7 @@ export const Bar = async (monitor = 0) => {
                 SideModule([System()]),
             ]
         }),
-        endWidget: Indicators(),
+        endWidget: Indicators(monitor),
     });
     const focusedBarContent = Widget.CenterBox({
         className: 'bar-bg-focus',

--- a/.config/ags/modules/bar/normal/spaceright.js
+++ b/.config/ags/modules/bar/normal/spaceright.js
@@ -29,7 +29,7 @@ const SeparatorDot = () => Widget.Revealer({
     ,
 });
 
-export default () => {
+export default (monitor = 0) => {
     const barTray = Tray();
     const barStatusIcons = StatusIcons({
         className: 'bar-statusicons',
@@ -38,7 +38,7 @@ export default () => {
                 self.toggleClassName('bar-statusicons-active', visible);
             }
         }),
-    });
+    }, monitor);
     const SpaceRightDefaultClicks = (child) => Widget.EventBox({
         onHover: () => { barStatusIcons.toggleClassName('bar-statusicons-hover', true) },
         onHoverLost: () => { barStatusIcons.toggleClassName('bar-statusicons-hover', false) },


### PR DESCRIPTION
The keyboard layout indicator was only visible on one monitor because there was just one instance of it. I’m not totally sure my fix is the best way to do it, especially since I don't know JavaScript, but it's now visible on all monitors.