### PR TITLE
tray: filter out empty tray items

### DIFF
--- a/.config/ags/modules/bar/normal/tray.js
+++ b/.config/ags/modules/bar/normal/tray.js
@@ -3,15 +3,15 @@ import SystemTray from 'resource:///com/github/Aylur/ags/service/systemtray.js';
 const { Box, Icon, Button, Revealer } = Widget;
 const { Gravity } = imports.gi.Gdk;
 
-const SysTrayItem = (item) => Button({
+const SysTrayItem = (item) => item.id !== null ? Button({
     className: 'bar-systray-item',
-    child: Icon({hpack: 'center'}).bind('icon', item, 'icon'),
+    child: Icon({ hpack: 'center' }).bind('icon', item, 'icon'),
     setup: (self) => self
         .hook(item, (self) => self.tooltipMarkup = item['tooltip-markup'])
     ,
     onPrimaryClick: (_, event) => item.activate(event),
     onSecondaryClick: (btn, event) => item.menu.popup_at_widget(btn, Gravity.SOUTH, Gravity.NORTH, null),
-});
+}) : null;
 
 export const Tray = (props = {}) => {
     const trayContent = Box({


### PR DESCRIPTION
For unknown reason, an unknown program (even invisible in D-Spy) occasionally populates an empty tray item of the following properties:
```js
TrayItem {
    "category": null,
    "id": null,
    "title": null,
    "status": null,
    "window-id": null,
    "is-menu": null,
    "tooltip-markup": "",
    "icon": "image-missing"
}
```

Add a null check for the item id to workaround the issue.