### PR TITLE
ags: remove timeout source after notification dismissed

### DIFF
--- a/.config/ags/modules/.commonwidgets/notification.js
+++ b/.config/ags/modules/.commonwidgets/notification.js
@@ -250,8 +250,12 @@ export default ({
         className: 'txt-smaller txt-semibold',
         label: initTimeString,
         setup: initTimeString == 'Now' ? (self) => {
-            Utils.timeout(60000, () => self.label = getFriendlyNotifTimeString(notifObject.time))
-        } : () => {},
+            let id = Utils.timeout(60000, () => {
+                self.label = getFriendlyNotifTimeString(notifObject.time);
+                id = null;
+            });
+            self.connect('destroy', () => { if (id) GLib.source_remove(id) });
+        } : () => { },
     });
     const notifText = Box({
         valign: Gtk.Align.CENTER,


### PR DESCRIPTION
This fixes the following log spam:
```
(com.github.Aylur.ags:2273075): Gjs-CRITICAL **: 11:15:29.279: Object .Ags_Label (0x5f2be6736120), has been already disposed — impossible to get any property from it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs. == Stack trace for context 0x5f2be48b33d0 ==
#0   7ffcd01459e0 b   resource:///com/github/Aylur/ags/widgets/label.js:39 (1dcdaf08bb00 @ 10)
#1   5f2be497b5e0 i   file:///home/foobar/.config/ags/modules/.commonwidgets/notification.js:253 (1dcdaf0b72e0 @ 10)
#2   5f2be497b560 i   resource:///com/github/Aylur/ags/utils/timeout.js:14 (1f5daab1150 @ 6)
#3   5f2be497b498 i   resource:///org/gnome/gjs/modules/core/overrides/GLib.js:266 (1f5daa7d560 @ 139)

(com.github.Aylur.ags:2273075): Gjs-CRITICAL **: 11:15:29.279: Object .Ags_Label (0x5f2be6736120), has been already disposed — impossible to set any property on it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs. == Stack trace for context 0x5f2be48b33d0 ==
#0   7ffcd01459e0 b   resource:///com/github/Aylur/ags/widgets/label.js:51 (1dcdaf08bb00 @ 190)
#1   5f2be497b5e0 i   file:///home/foobar/.config/ags/modules/.commonwidgets/notification.js:253 (1dcdaf0b72e0 @ 10)
#2   5f2be497b560 i   resource:///com/github/Aylur/ags/utils/timeout.js:14 (1f5daab1150 @ 6)
#3   5f2be497b498 i   resource:///org/gnome/gjs/modules/core/overrides/GLib.js:266 (1f5daa7d560 @ 139)
```