### PR TITLE
[Feature] Change shell mode per monitor

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -222,9 +222,10 @@ let configOptions = {
         }
     },
     'bar': {
-        // Array of bar styles for each monitor.
+        // Array of bar modes for each monitor. Hit Ctrl+Alt+Slash to cycle.
+        // Modes: "normal", "focus" (workspace indicator only), "nothing"
         // Example for four monitors: ["normal", "focus", "normal", "nothing"]
-        'monitors': ["normal"]
+        'modes': ["normal"]
     },
 }
 

--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -221,6 +221,11 @@ let configOptions = {
             'cycleTab': "Ctrl+Tab",
         }
     },
+    'bar': {
+        // Array of bar styles for each monitor.
+        // Example for four monitors: ["normal", "focus", "normal", "nothing"]
+        'monitors': ["normal"]
+    },
 }
 
 // Override defaults with user's options

--- a/.config/ags/modules/bar/main.js
+++ b/.config/ags/modules/bar/main.js
@@ -101,8 +101,7 @@ export const Bar = async (monitor = 0) => {
                 'nothing': nothingContent,
             },
             setup: (self) => self.hook(currentShellMode, (self) => {
-                self.shown = currentShellMode.value;
-
+                self.shown = currentShellMode.value[monitor];
             })
         }),
     });

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -1,8 +1,8 @@
-
 const { Gdk, Gtk } = imports.gi;
 import App from 'resource:///com/github/Aylur/ags/app.js'
-import Variable from 'resource:///com/github/Aylur/ags/variable.js';
+import Hyprland from 'resource:///com/github/Aylur/ags/service/hyprland.js';
 import Mpris from 'resource:///com/github/Aylur/ags/service/mpris.js';
+import Variable from 'resource:///com/github/Aylur/ags/variable.js';
 import * as Utils from 'resource:///com/github/Aylur/ags/utils.js';
 const { exec, execAsync } = Utils;
 

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -15,11 +15,23 @@ globalThis['openMusicControls'] = showMusicControls;
 globalThis['openColorScheme'] = showColorScheme;
 globalThis['mpris'] = Mpris;
 
-// Mode switching
-const numberOfMonitors = Gdk.Display.get_default()?.get_n_monitors() || 1;
-const initialMonitorShellModes = Array.from({ length: numberOfMonitors }, () => 'normal');
-export const currentShellMode = Variable(initialMonitorShellModes, {}) // normal, focus
+// load monitor shell modes from userOptions
+const initialMonitorShellModes = () => {
+    const numberOfMonitors = Gdk.Display.get_default()?.get_n_monitors() || 1;
+    const monitorBarConfigs = [];
+    for (let i = 0; i < numberOfMonitors; i++) {
+        if (userOptions.bar.monitors[i]) {
+            monitorBarConfigs.push(userOptions.bar.monitors[i])
+        } else {
+            monitorBarConfigs.push('normal')
+        }
+    }
+    return monitorBarConfigs;
 
+}
+export const currentShellMode = Variable(initialMonitorShellModes(), {}) // normal, focus
+
+// Mode switching
 const updateMonitorShellMode = (monitorShellModes, monitor, mode) => {
     const newValue = [...monitorShellModes.value];
     newValue[monitor] = mode;

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -20,8 +20,8 @@ const initialMonitorShellModes = () => {
     const numberOfMonitors = Gdk.Display.get_default()?.get_n_monitors() || 1;
     const monitorBarConfigs = [];
     for (let i = 0; i < numberOfMonitors; i++) {
-        if (userOptions.bar.monitors[i]) {
-            monitorBarConfigs.push(userOptions.bar.monitors[i])
+        if (userOptions.bar.modes[i]) {
+            monitorBarConfigs.push(userOptions.bar.modes[i])
         } else {
             monitorBarConfigs.push('normal')
         }

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -16,17 +16,27 @@ globalThis['openColorScheme'] = showColorScheme;
 globalThis['mpris'] = Mpris;
 
 // Mode switching
-export const currentShellMode = Variable('normal', {}) // normal, focus
+const numberOfMonitors = Gdk.Display.get_default()?.get_n_monitors() || 1;
+const initialMonitorShellModes = Array.from({ length: numberOfMonitors }, () => 'normal');
+export const currentShellMode = Variable(initialMonitorShellModes, {}) // normal, focus
+
+const updateMonitorShellMode = (monitorShellModes, monitor, mode) => {
+    const newValue = [...monitorShellModes.value];
+    newValue[monitor] = mode;
+    monitorShellModes.value = newValue;
+}
 globalThis['currentMode'] = currentShellMode;
 globalThis['cycleMode'] = () => {
-    if (currentShellMode.value === 'normal') {
-        currentShellMode.value = 'focus';
-    } 
-    else if (currentShellMode.value === 'focus') {
-        currentShellMode.value = 'nothing';
+    const monitor = Hyprland.active.monitor.id || 0;
+
+    if (currentShellMode.value[monitor] === 'normal') {
+        updateMonitorShellMode(currentShellMode, monitor, 'focus')
+    }
+    else if (currentShellMode.value[monitor] === 'focus') {
+        updateMonitorShellMode(currentShellMode, monitor, 'nothing')
     }
     else {
-        currentShellMode.value = 'normal';
+        updateMonitorShellMode(currentShellMode, monitor, 'normal')
     }
 }
 


### PR DESCRIPTION
**Multi-monitor improvement.** 

- Users can now change bar shell mode ("normal", "focus", "nothing") per monitor. That way each monitor can have separate bar look. 


I use it to hide the bar on my second monitor while it stays shown on my main monitor.

I plan to improve this by adding bar monitor config to user_options.js so that selected bar look persists between sessions.