### PR TITLE
Add 'XF86AudioPrev' & 'XF86AudioPause' bindings.

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -178,11 +178,13 @@ bind = Super+Alt, Equal, exec, notify-send "Urgent notification" "Ah hell no" -u
 ##! Media
 bindl= Super+Shift, N, exec, playerctl next || playerctl position `bc <<< "100 * $(playerctl metadata mpris:length) / 1000000 / 100"` # Next track
 bindl= ,XF86AudioNext, exec, playerctl next || playerctl position `bc <<< "100 * $(playerctl metadata mpris:length) / 1000000 / 100"` # [hidden]
+bindl= ,XF86AudioPrev, exec, playerctl previous # [hidden]
 bind = Super+Shift+Alt, mouse:275, exec, playerctl previous # [hidden]
 bind = Super+Shift+Alt, mouse:276, exec, playerctl next || playerctl position `bc <<< "100 * $(playerctl metadata mpris:length) / 1000000 / 100"` # [hidden]
 bindl= Super+Shift, B, exec, playerctl previous # Previous track
 bindl= Super+Shift, P, exec, playerctl play-pause # Play/pause media
 bindl= ,XF86AudioPlay, exec, playerctl play-pause # [hidden]
+bindl= ,XF86AudioPause, exec, playerctl play-pause # [hidden]
 
 #!
 ##! Apps


### PR DESCRIPTION
Fixes problems with headset media controls, etc.