### PR TITLE
ags(volumeindicator): detect Headset

### DIFF
--- a/.config/ags/modules/indicators/indicatorvalues.js
+++ b/.config/ags/modules/indicators/indicatorvalues.js
@@ -72,12 +72,18 @@ export default (monitor = 0) => {
         nameSetup: (self) => Utils.timeout(1, () => {
             const updateAudioDevice = (self) => {
                 const usingHeadphones = (Audio.speaker?.stream?.port)?.toLowerCase().includes('headphone');
+                const usingHeadset = (Audio.speaker?.stream?.port)?.toLowerCase().includes('headset');
                 if (volumeIndicator.attribute.headphones === undefined ||
                     volumeIndicator.attribute.headphones !== usingHeadphones) {
                     volumeIndicator.attribute.headphones = usingHeadphones;
                     self.label = usingHeadphones ? 'Headphones' : 'Speakers';
-                    // Indicator.popup(1);
                 }
+                if (volumeIndicator.attribute.headphones === undefined ||
+                    volumeIndicator.attribute.headphones !== usingHeadset) {
+                    volumeIndicator.attribute.headphones = usingHeadset;
+                    self.label = usingHeadset ? 'Headset' : 'Speakers';
+                }
+                // Indicator.popup(1);
             }
             self.hook(Audio, updateAudioDevice);
             Utils.timeout(1000, updateAudioDevice);


### PR DESCRIPTION
When using a Headset the Volume Widget it will show it as Speakers this PR fixes that.
![image](https://github.com/user-attachments/assets/5dc7bac5-3d54-4661-9d3e-ff44a3471fa1)
