### PR TITLE
.local/bin(fuzzel-emoji): fix

### DIFF
--- a/.local/bin/fuzzel-emoji
+++ b/.local/bin/fuzzel-emoji
@@ -1,9 +1,9 @@
 #!/bin/bash
 if [ $? -eq 0 ]
 then
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+    sed '1,/^### DATA ###$/d' $0 | fuzzel --match-mode fzf --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
 else
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+    sed '1,/^### DATA ###$/d' $0 | fuzzel --match-mode fzf --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
 fi
 exit
 ### DATA ###


### PR DESCRIPTION
* `--no-fuzzy` has been replaced by `--match-mode` in fuzzel
see commit [a778de2e56](https://codeberg.org/dnkl/fuzzel/commit/a778de2e56a894591dc55cd103a98b019dfec5ed)