### PR TITLE
replace `--no-fuzzy` with `--match-mode fzf`

### DIFF
--- a/.config/ags/modules/onscreenkeyboard/onscreenkeyboard.js
+++ b/.config/ags/modules/onscreenkeyboard/onscreenkeyboard.js
@@ -83,7 +83,7 @@ const KeyboardControls = () => Box({
         Button({
             className: 'osk-control-button txt-norm icon-material',
             onClicked: () => { // TODO: Proper clipboard widget, since fuzzel doesn't receive mouse inputs
-                execAsync([`bash`, `-c`, "pkill fuzzel || cliphist list | fuzzel --no-fuzzy --dmenu | cliphist decode | wl-copy"]).catch(print);
+                execAsync([`bash`, `-c`, "pkill fuzzel || cliphist list | fuzzel  --match-mode fzf --dmenu | cliphist decode | wl-copy"]).catch(print);
             },
             label: 'assignment',
         }),

--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -20,7 +20,7 @@ bind = , Super, exec, true # Open app launcher
 bind = Ctrl+Super, T, exec, ~/.config/ags/scripts/color_generation/switchwall.sh # Change wallpaper
 ##! Actions
 # Screenshot, Record, OCR, Color picker, Clipboard history
-bind = Super, V, exec, pkill fuzzel || cliphist list | fuzzel --no-fuzzy --dmenu | cliphist decode | wl-copy # Clipboard history >> clipboard
+bind = Super, V, exec, pkill fuzzel || cliphist list | fuzzel  --match-mode fzf --dmenu | cliphist decode | wl-copy # Clipboard history >> clipboard
 bind = Super, Period, exec, pkill fuzzel || ~/.local/bin/fuzzel-emoji # Pick emoji >> clipboard
 bind = Ctrl+Shift+Alt, Delete, exec, pkill wlogout || wlogout -p layer-shell # [hidden]
 bind = Super+Shift, S, exec, ~/.config/ags/scripts/grimblast.sh --freeze copy area # Screen snip

--- a/.local/bin/fuzzel-emoji
+++ b/.local/bin/fuzzel-emoji
@@ -1,9 +1,9 @@
 #!/bin/bash
 if [ $? -eq 0 ]
 then
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+    sed '1,/^### DATA ###$/d' $0 | fuzzel --match-mode fzf --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
 else
-    sed '1,/^### DATA ###$/d' $0 | fuzzel --no-fuzzy --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+    sed '1,/^### DATA ###$/d' $0 | fuzzel --match-mode fzf --dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
 fi
 exit
 ### DATA ###


### PR DESCRIPTION
* `--no-fuzzy` has been replaced by `--match-mode` in fuzzel
see commit [a778de2e56](https://codeberg.org/dnkl/fuzzel/commit/a778de2e56a894591dc55cd103a98b019dfec5ed)