### PR TITLE
ags & hypr: make session manager toggleable & add power button keybind

### DIFF
--- a/.config/ags/modules/sideright/quicktoggles.js
+++ b/.config/ags/modules/sideright/quicktoggles.js
@@ -257,11 +257,19 @@ export const ModulePowerIcon = (props = {}) => Widget.Button({
     className: 'txt-small sidebar-iconbutton',
     tooltipText: 'Session',
     onClicked: () => {
-        closeEverything();
-        Utils.timeout(1, () => openWindowOnAllMonitors('session'));
+        showSessionWindow.value = !showSessionWindow.value;
+        if (showSessionWindow.value) {
+            closeEverything();
+            Utils.timeout(1, () => openWindowOnAllMonitors('session'));
+        } else {
+            closeWindowOnAllMonitors('session');
+        }
     },
     child: MaterialIcon('power_settings_new', 'norm'),
     setup: button => {
         setupCursorHover(button);
+        button.hook(showSessionWindow, (btn) => {
+            btn.toggleClassName('sidebar-button-active', showSessionWindow.value);
+        });
     }
 })

--- a/.config/ags/variables.js
+++ b/.config/ags/variables.js
@@ -70,6 +70,9 @@ globalThis['openWindowOnAllMonitors'] = (name) => {
     });
 }
 
+export const showSessionWindow = Variable(false, {});
+globalThis['showSessionWindow'] = showSessionWindow;
+
 globalThis['closeEverything'] = () => {
     const numMonitors = Gdk.Display.get_default()?.get_n_monitors() || 1;
     for (let i = 0; i < numMonitors; i++) {

--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -1,6 +1,6 @@
 # Lines ending with `# [hidden]` won't be shown on cheatsheet
 # Lines starting with #! are section headings
-
+bindle =, XF86PowerOff , exec, ags run-js 'showSessionWindow.value = !showSessionWindow.value; if (showSessionWindow.value) { closeEverything(); Utils.timeout(1, () => openWindowOnAllMonitors("session"));} else { closeWindowOnAllMonitors("session");}'
 bindl = Alt ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle # [hidden]
 bindl = Super ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_SOURCE@ toggle # [hidden]
 bindl = ,XF86AudioMute, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 0% # [hidden]


### PR DESCRIPTION
* pressing the power button on your laptop keyboard will bring up the session manager
* make the session manager toggleable.

**things to point up:**
* the shortcut `XF86PowerOff` will only work if you have the following in `/etc/systemd/logind.conf`
```
PowerKeyIgnoreInhibited=yes
HandlePowerKey=ignore
HandlePowerKeyLongPress=ignore
```
else the system will shutdown immediately clicking it.