### PR TITLE
Move dwindle config "no gaps when only" to workspace rules

### DIFF
--- a/.config/hypr/hyprland/general.conf
+++ b/.config/hypr/hyprland/general.conf
@@ -60,7 +60,6 @@ general {
 
 dwindle {
 	preserve_split = true
-        # no_gaps_when_only = 1
 	smart_split = false
 	smart_resizing = false
 }

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -84,3 +84,12 @@ layerrule = ignorealpha 0.6, indicator*
 layerrule = blur, osk
 layerrule = ignorealpha 0.6, osk
 
+# ######## Workspace rules ########
+
+# Ref https://wiki.hyprland.org/Configuring/Workspace-Rules/
+# "Smart gaps" / "No gaps when only" 
+# (replaces dwindle config setting "no_gaps_when_only = 1")
+# uncomment all three if you wish to use that.
+# workspace = w[t1], gapsout:0, gapsin:0, border: 0, rounding:0
+# workspace = w[tg1], gapsout:0, gapsin:0, border: 0, rounding:0
+# workspace = f[1], gapsout:0, gapsin:0, border: 0, rounding:0

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -89,7 +89,10 @@ layerrule = ignorealpha 0.6, osk
 # Ref https://wiki.hyprland.org/Configuring/Workspace-Rules/
 # "Smart gaps" / "No gaps when only" 
 # (replaces dwindle config setting "no_gaps_when_only = 1")
-# uncomment all three if you wish to use that.
-# workspace = w[t1], gapsout:0, gapsin:0, border: 0, rounding:0
-# workspace = w[tg1], gapsout:0, gapsin:0, border: 0, rounding:0
-# workspace = f[1], gapsout:0, gapsin:0, border: 0, rounding:0
+# uncomment all six of these if you wish to use that.
+# workspace = w[tv1], gapsout:0, gapsin:0
+# workspace = f[1], gapsout:0, gapsin:0
+# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
+# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
+# windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
+# windowrulev2 = rounding 0, floating:0, onworkspace:f[1]


### PR DESCRIPTION
Updated hyprland today and noticed that I was getting an error/red error message at the top of the screen as I had `no_gaps_when_only = 1` uncommented in the dwindle config section of `general.conf`

Turns out that setting has been removed, and the new method to achieve this setting is using workspace rules.

The rules I added were taken from a recent update to the Hyprland default/example config (https://github.com/hyprwm/Hyprland/commit/8e51a36c7fd500e865e34f08ab4dc4331dca59cf). Since there don't seem to be any existing workspace rules, I added a section for them to the rules file, and then added the example code verbatim (with one extra comment line explaining that it replaces the old dwindle config setting).

As the `no_gaps_when_only = 1` is commented out in the current dots-hyprland general.conf file, I have kept the "smart gaps" lines commented in their new position, so this shouldn't change any default functionality. My commit just removes a commented config setting that no longer exists and adds a commented replacement for it.