### PR TITLE
ags/workspaces_hyprland: add unicode icon support

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -140,6 +140,9 @@ let configOptions = {
     },
     'workspaces': {
         'shown': 10,
+        'labels': {
+            1: '🎵'
+        }
     },
     'dock': {
         'enabled': false,


### PR DESCRIPTION
This add highly experimental unicode icon support for the workspaces module. I am in no way good at this and simply wanted this for myself, but thought sharing this couldn't do any harm. 

This doesn't work with the workaround of having the scrolling workspaces for more than 10 (or num shown) workspaces but I don't use that. Anyone wanting to integrate that is welcome to obviously. Thanks for the work @end-4  <3