### PR TITLE
move gnome-bluetooth-3.0 and gammastep to ags dependencies

### DIFF
--- a/arch-packages/illogical-impulse-ags/PKGBUILD
+++ b/arch-packages/illogical-impulse-ags/PKGBUILD
@@ -2,15 +2,14 @@
 pkgname=illogical-impulse-ags
 _pkgname=ags
 pkgver=r525.05e0f23
-pkgrel=1
+pkgrel=2
 pkgdesc="Aylurs's Gtk Shell (AGS), version fixed for illogical-impulse dotfiles."
 arch=('x86_64')
 url="https://github.com/Aylur/ags"
 license=('GPL3')
 makedepends=('git' 'gobject-introspection' 'meson' 'npm' 'typescript')
-depends=('gjs' 'glib2' 'glib2-devel' 'glibc' 'gtk3' 'gtk-layer-shell' 'libpulse' 'pam')
-optdepends=('gnome-bluetooth-3.0: required for bluetooth service'
-            'greetd: required for greetd service'
+depends=('gjs' 'glib2' 'glib2-devel' 'glibc' 'gtk3' 'gtk-layer-shell' 'libpulse' 'pam' 'gnome-bluetooth-3.0' 'gammastep')
+optdepends=('greetd: required for greetd service'
             'libdbusmenu-gtk3: required for systemtray service'
             'libsoup3: required for the Utils.fetch feature'
             'libnotify: required for sending notifications'

--- a/arch-packages/illogical-impulse-gnome/PKGBUILD
+++ b/arch-packages/illogical-impulse-gnome/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=illogical-impulse-gnome
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Illogical Impulse GNOME Dependencies'
 arch=(any)
 license=(None)
@@ -9,7 +9,4 @@ depends=(
 	gnome-keyring
 	gnome-control-center
 	blueberry networkmanager
-	gammastep
-	gnome-bluetooth-3.0
 )
-

--- a/arch-packages/illogical-impulse-microtex-git/PKGBUILD
+++ b/arch-packages/illogical-impulse-microtex-git/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=illogical-impulse-microtex-git
 _pkgname=MicroTeX
-pkgver=r492.d87ebec
+pkgver=r494.0e3707f
 pkgrel=1
 pkgdesc='MicroTeX for illogical-impulse dotfiles.'
 #pkgdesc="A dynamic, cross-platform, and embeddable LaTeX rendering library"


### PR DESCRIPTION
* our ags configuration uses the bluetooth module so it can't start w/o gnome-bluetooth-3.0
* gammastep is used by ags sidebar and irrelevant to gnome