### PR TITLE
Bugs fix: move shadow options to decoration:shadow

### DIFF
--- a/.config/hypr/hyprland/general.conf
+++ b/.config/hypr/hyprland/general.conf
@@ -81,13 +81,15 @@ decoration {
         popups = true
         popups_ignorealpha = 0.6
     }
-    # Shadow
-    drop_shadow = true
-    shadow_ignore_window = true
-    shadow_range = 20
-    shadow_offset = 0 2
-    shadow_render_power = 4
-    col.shadow = rgba(0000002A)
+
+    shadow{
+        enabled = true
+        ignore_window = true
+        render_power = 4
+        range = 20
+        offset = 0 2
+        color = rgba(0000002A)
+    }
     
     # Shader
     # screen_shader = ~/.config/hypr/shaders/nothing.frag


### PR DESCRIPTION
After [commit](https://github.com/hyprwm/Hyprland/commit/d1638a09bacd84b994de3f77746b74f427b9d41e) shadow options have now moved to decoration:shadow