### PR TITLE
fix: correct desktop icon name

### DIFF
--- a/.config/ags/modules/sideleft/tools/quickscripts.js
+++ b/.config/ags/modules/sideleft/tools/quickscripts.js
@@ -12,7 +12,7 @@ import { distroID, isArchDistro, isDebianDistro, hasFlatpak } from '../../.miscu
 
 const scripts = [
     {
-        icon: 'desktop-symbolic',
+        icon: 'desktop_symbolic',
         name: getString('Change screen resolution'),
         command: `bash ${App.configDir}/modules/sideleft/tools/changeres.sh`,
         enabled: true,


### PR DESCRIPTION
Correct icon `desktop_symbolic` for change screen resolution script