### PR TITLE
[Bugfix] AGS Config - overrideConfigRecursive doesn't add new objects

### DIFF
--- a/.config/ags/modules/.configuration/user_options.js
+++ b/.config/ags/modules/.configuration/user_options.js
@@ -242,7 +242,7 @@ let configOptions = {
 // Override defaults with user's options
 function overrideConfigRecursive(userOverrides, configOptions = {}) {
     for (const [key, value] of Object.entries(userOverrides)) {
-        if (typeof value === 'object' && !(value instanceof Array)) {
+        if (typeof value === 'object' && !(value instanceof Array) && configOptions[key] !== undefined) {
             overrideConfigRecursive(value, configOptions[key]);
         }
         else {


### PR DESCRIPTION
override recursive doesn't add new keys into objects. This is bad because that means the extraGptModels option cannot, have extra (new) gpt models. This bugfix fixes that.