### PR TITLE
Fix Control+Shift+C not working in the latest foot terminal

### DIFF
--- a/.config/foot/foot.ini
+++ b/.config/foot/foot.ini
@@ -131,3 +131,6 @@ find-next=F3 Control+G
 # select-word=BTN_LEFT-2
 # select-word-whitespace=Control+BTN_LEFT-2
 # select-row=BTN_LEFT-3
+
+[text-bindings]
+\x03=Control+Shift+c


### PR DESCRIPTION
```
$ man foot.ini
```

```
SECTION: text-bindings
       This section lets you remap key combinations to custom escape sequences.

       The  format is text=combo1...comboN. That is, the string to emit may have one or
       more key  combinations,  space  separated.  Each  combination  is  in  the  form
       mod1+mod2+key.  The  names  of  the  modifiers and the key must be valid XKB key
       names.

       The text string specifies the characters, or bytes, to emit when the  associated
       key combination(s) are pressed. There are two ways to specify a character:

       •   Normal, printable characters are written as-is: abcdef.
       •   Bytes  (e.g.  ESC)  are  written as two-digit hexadecimal numbers, with a \x
           prefix: \x1b.

       Example: you would like to remap Super+k to the Up key.

       The escape sequence for the Up key is ESC [ A (without  the  spaces).  Thus,  we
       need to specify this in foot.ini (Mod4 is the XKB name for the Super/logo key):

       \x1b[A = Mod4+k

       Another example: to remap Super+c to Control+c:

       \x03 = Mod4+c
```