### PR TITLE
Fix: Adjust volume only for supported players

### DIFF
--- a/.config/ags/scripts/music/adjust-volume.sh
+++ b/.config/ags/scripts/music/adjust-volume.sh
@@ -2,14 +2,23 @@
 
 change=$1
 
-current_volume=$(playerctl volume)
+players=$(playerctl -l)
 
-new_volume=$(echo "$current_volume + $change" | bc)
+for player in $players; do
+    if playerctl -p "$player" volume &>/dev/null; then
+        current_volume=$(playerctl -p "$player" volume)
 
-if (( $(echo "$new_volume > 1.0" | bc -l) )); then
-  new_volume=1.0
-elif (( $(echo "$new_volume < 0.0" | bc -l) )); then
-  new_volume=0.0
-fi
+        new_volume=$(echo "$current_volume + $change" | bc)
+        
+        if (( $(echo "$new_volume > 1.0" | bc -l) )); then
+            new_volume=1.0
+        elif (( $(echo "$new_volume < 0.0" | bc -l) )); then
+            new_volume=0.0
+        fi
 
-playerctl volume "$new_volume"
+        playerctl -p "$player" volume "$new_volume"
+        exit 0
+    fi
+done
+
+exit 1


### PR DESCRIPTION
#953 small fix
This improves the `adjust-volume.sh` script by making it detect and adjust the volume of the first available media player that supports `playerctl volume`. Without this fix, volume control may not work correctly if a browser or another non-controllable application is running.