### PR TITLE
Pull Request: Fix Window Rules Syntax for v2

### DIFF
--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -1,99 +1,51 @@
 # ######## Window rules ########
-windowrule = noblur,.*
-# windowrule = opacity 0.89 override 0.89 override, .* # Applies transparency to EVERY WINDOW
-windowrule = float, ^(blueberry.py)$
-windowrule = float, ^(steam)$
-windowrule = float, ^(guifetch)$ # FlafyDev/guifetch
-windowrulev2 = tile, class:(dev.warp.Warp)
+
+# General rule – disable blur for all windows.
+# (Using "class:.*" as a catch-all field since at least one field is required)
+windowrulev2 = noblur, class:.*
+
+# Uncomment to apply global transparency to all windows:
+# windowrulev2 = opacity 0.89 override 0.89 override, class:.*
+
+# Specific floating windows.
+windowrulev2 = float, class:^(blueberry\.py)$
+windowrulev2 = float, class:^(steam)$
+windowrulev2 = float, class:^(guifetch)$   # FlafyDev/guifetch
+
+# Tiling rule for a specific app.
+windowrulev2 = tile, class:^dev\.warp\.Warp$
+
+# Picture-in-Picture window (matched by title).
 windowrulev2 = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrule = center, title:^(Open File)(.*)$
-windowrule = center, title:^(Select a File)(.*)$
-windowrule = center, title:^(Choose wallpaper)(.*)$
-windowrule = center, title:^(Open Folder)(.*)$
-windowrule = center, title:^(Save As)(.*)$
-windowrule = center, title:^(Library)(.*)$
-windowrule = center, title:^(File Upload)(.*)$
 
-# Picture-in-Picture
-windowrulev2 = keepaspectratio, title:^(Picture(-| )in(-| )[Pp]icture)$
-windowrulev2 = move 73% 72%,title:^(Picture(-| )in(-| )[Pp]icture)$ 
-windowrulev2 = size 25%, title:^(Picture(-| )in(-| )[Pp]icture)$
-windowrulev2 = float, title:^(Picture(-| )in(-| )[Pp]icture)$
-windowrulev2 = pin, title:^(Picture(-| )in(-| )[Pp]icture)$
+# Dialog windows – center these windows.
+windowrulev2 = center, title:^(Open File)(.*)$
+windowrulev2 = center, title:^(Select a File)(.*)$
+windowrulev2 = center, title:^(Choose wallpaper)(.*)$
+windowrulev2 = center, title:^(Open Folder)(.*)$
+windowrulev2 = center, title:^(Save As)(.*)$
+windowrulev2 = center, title:^(Library)(.*)$
+windowrulev2 = center, title:^(File Upload)(.*)$
 
-# Dialogs
-windowrule=float,title:^(Open File)(.*)$
-windowrule=float,title:^(Select a File)(.*)$
-windowrule=float,title:^(Choose wallpaper)(.*)$
-windowrule=float,title:^(Open Folder)(.*)$
-windowrule=float,title:^(Save As)(.*)$
-windowrule=float,title:^(Library)(.*)$
-windowrule=float,title:^(File Upload)(.*)$
+# --- Picture-in-Picture enhancements ---
+windowrulev2 = keepaspectratio, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = move 73% 72%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$ 
+windowrulev2 = size 25%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 
-# Tearing
-windowrule=immediate,.*\.exe
-windowrulev2=immediate,class:(steam_app)
+# Additional dialog rules to force floating.
+windowrulev2 = float, title:^(Open File)(.*)$
+windowrulev2 = float, title:^(Select a File)(.*)$
+windowrulev2 = float, title:^(Choose wallpaper)(.*)$
+windowrulev2 = float, title:^(Open Folder)(.*)$
+windowrulev2 = float, title:^(Save As)(.*)$
+windowrulev2 = float, title:^(Library)(.*)$
+windowrulev2 = float, title:^(File Upload)(.*)$
 
-# No shadow for tiled windows
-windowrulev2 = noshadow,floating:0
+# --- Tearing ---
+windowrulev2 = immediate, title:.*\.exe
+windowrulev2 = immediate, class:^(steam_app)$
 
-# ######## Layer rules ########
-layerrule = xray 1, .*
-# layerrule = noanim, .*
-layerrule = noanim, walker
-layerrule = noanim, selection
-layerrule = noanim, overview
-layerrule = noanim, anyrun
-layerrule = noanim, indicator.*
-layerrule = noanim, osk
-layerrule = noanim, hyprpicker
-layerrule = blur, shell:*
-layerrule = ignorealpha 0.6, shell:*
-
-layerrule = noanim, noanim
-layerrule = blur, gtk-layer-shell
-layerrule = ignorezero, gtk-layer-shell
-layerrule = blur, launcher
-layerrule = ignorealpha 0.5, launcher
-layerrule = blur, notifications
-layerrule = ignorealpha 0.69, notifications
-layerrule = blur, logout_dialog # wlogout
-
-# ags
-layerrule = animation slide left, sideleft.*
-layerrule = animation slide right, sideright.*
-layerrule = blur, session[0-9]*
-
-layerrule = blur, bar[0-9]*
-layerrule = ignorealpha 0.6, bar[0-9]*
-layerrule = blur, barcorner.*
-layerrule = ignorealpha 0.6, barcorner.*
-layerrule = blur, dock[0-9]*
-layerrule = ignorealpha 0.6, dock[0-9]*
-layerrule = blur, indicator.*
-layerrule = ignorealpha 0.6, indicator.*
-layerrule = blur, overview[0-9]*
-layerrule = ignorealpha 0.6, overview[0-9]*
-layerrule = blur, cheatsheet[0-9]*
-layerrule = ignorealpha 0.6, cheatsheet[0-9]*
-layerrule = blur, sideright[0-9]*
-layerrule = ignorealpha 0.6, sideright[0-9]*
-layerrule = blur, sideleft[0-9]*
-layerrule = ignorealpha 0.6, sideleft[0-9]*
-layerrule = blur, indicator.*
-layerrule = ignorealpha 0.6, indicator.*
-layerrule = blur, osk[0-9]*
-layerrule = ignorealpha 0.6, osk[0-9]*
-
-# ######## Workspace rules ########
-
-# Ref https://wiki.hyprland.org/Configuring/Workspace-Rules/
-# "Smart gaps" / "No gaps when only" 
-# (replaces dwindle config setting "no_gaps_when_only = 1")
-# uncomment all six of these if you wish to use that.
-# workspace = w[tv1], gapsout:0, gapsin:0
-# workspace = f[1], gapsout:0, gapsin:0
-# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
-# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
-# windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
-# windowrulev2 = rounding 0, floating:0, onworkspace:f[1]
+# No shadow for tiled windows (matches windows that are not floating).
+windowrulev2 = noshadow, floating:0

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -18,7 +18,7 @@ windowrulev2 = tile, class:^dev\.warp\.Warp$
 # Picture-in-Picture window (matched by title).
 windowrulev2 = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 
-# Dialog windows – center these windows.
+# Dialog windows – float+center these windows.
 windowrulev2 = center, title:^(Open File)(.*)$
 windowrulev2 = center, title:^(Select a File)(.*)$
 windowrulev2 = center, title:^(Choose wallpaper)(.*)$
@@ -26,15 +26,6 @@ windowrulev2 = center, title:^(Open Folder)(.*)$
 windowrulev2 = center, title:^(Save As)(.*)$
 windowrulev2 = center, title:^(Library)(.*)$
 windowrulev2 = center, title:^(File Upload)(.*)$
-
-# --- Picture-in-Picture enhancements ---
-windowrulev2 = keepaspectratio, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrulev2 = move 73% 72%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$ 
-windowrulev2 = size 25%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrulev2 = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrulev2 = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-
-# Additional dialog rules to force floating.
 windowrulev2 = float, title:^(Open File)(.*)$
 windowrulev2 = float, title:^(Select a File)(.*)$
 windowrulev2 = float, title:^(Choose wallpaper)(.*)$
@@ -43,9 +34,63 @@ windowrulev2 = float, title:^(Save As)(.*)$
 windowrulev2 = float, title:^(Library)(.*)$
 windowrulev2 = float, title:^(File Upload)(.*)$
 
+# --- Picture-in-Picture enhancements ---
+windowrulev2 = keepaspectratio, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = move 73% 72%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$ 
+windowrulev2 = size 25%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrulev2 = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+
 # --- Tearing ---
 windowrulev2 = immediate, title:.*\.exe
 windowrulev2 = immediate, class:^(steam_app)$
 
 # No shadow for tiled windows (matches windows that are not floating).
 windowrulev2 = noshadow, floating:0
+
+# ######## Layer rules ########
+layerrule = xray 1, .*
+# layerrule = noanim, .*
+layerrule = noanim, walker
+layerrule = noanim, selection
+layerrule = noanim, overview
+layerrule = noanim, anyrun
+layerrule = noanim, indicator.*
+layerrule = noanim, osk
+layerrule = noanim, hyprpicker
+layerrule = blur, shell:*
+layerrule = ignorealpha 0.6, shell:*
+
+layerrule = noanim, noanim
+layerrule = blur, gtk-layer-shell
+layerrule = ignorezero, gtk-layer-shell
+layerrule = blur, launcher
+layerrule = ignorealpha 0.5, launcher
+layerrule = blur, notifications
+layerrule = ignorealpha 0.69, notifications
+layerrule = blur, logout_dialog # wlogout
+
+# ags
+layerrule = animation slide left, sideleft.*
+layerrule = animation slide right, sideright.*
+layerrule = blur, session[0-9]*
+layerrule = blur, bar[0-9]*
+layerrule = ignorealpha 0.6, bar[0-9]*
+layerrule = blur, barcorner.*
+layerrule = ignorealpha 0.6, barcorner.*
+layerrule = blur, dock[0-9]*
+layerrule = ignorealpha 0.6, dock[0-9]*
+layerrule = blur, indicator.*
+layerrule = ignorealpha 0.6, indicator.*
+layerrule = blur, overview[0-9]*
+layerrule = ignorealpha 0.6, overview[0-9]*
+layerrule = blur, cheatsheet[0-9]*
+layerrule = ignorealpha 0.6, cheatsheet[0-9]*
+layerrule = blur, sideright[0-9]*
+layerrule = ignorealpha 0.6, sideright[0-9]*
+layerrule = blur, sideleft[0-9]*
+layerrule = ignorealpha 0.6, sideleft[0-9]*
+layerrule = blur, indicator.*
+layerrule = ignorealpha 0.6, indicator.*
+layerrule = blur, osk[0-9]*
+layerrule = ignorealpha 0.6, osk[0-9]*

--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -43,7 +43,7 @@ windowrulev2 = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 
 # --- Tearing ---
 windowrulev2 = immediate, title:.*\.exe
-windowrulev2 = immediate, class:^(steam_app)$
+windowrulev2 = immediate, class:^(steam_app)
 
 # No shadow for tiled windows (matches windows that are not floating).
 windowrulev2 = noshadow, floating:0


### PR DESCRIPTION
This PR updates the configuration to use the new v2 syntax exclusively. The old v1 syntax was causing invalid rule errors. All window rules now use windowrulev2 with explicit fields (e.g. class:, title:, floating:) as per the latest Hyprland documentation.

This change fixes the syntax issue and ensures the configuration is compatible with the current Hyprland version.

(I will note, this change was partially aided with ChatGPT reasoning; But this has been tested to be working very well.)