### PR TITLE
Fix PKGBUILD: greetd.ts build error (TS18047)

### DIFF
--- a/arch-packages/illogical-impulse-agsv1/PKGBUILD
+++ b/arch-packages/illogical-impulse-agsv1/PKGBUILD
@@ -39,7 +39,135 @@ sha256sums=('962f99dcf202eef30e978d1daedc7cdf213e07a3b52413c1fb7b54abc7bd08e6'
 prepare() {
   cd "$srcdir/$_pkgname-$pkgver"
   mv -T "$srcdir"/libgnome-volume-control subprojects/gvc
+
+  # Overwrite greetd.ts with fixed version
+  cat > src/service/greetd.ts << 'EOF'
+import App from '../app.js';
+import Service from '../service.js';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+
+Gio._promisify(Gio.InputStream.prototype, 'read_bytes_async');
+const SOCK = GLib.getenv('GREETD_SOCK');
+
+type Request = {
+    create_session: {
+        username: string
+    }
+    post_auth_message_response: {
+        response?: string
+    }
+    start_session: {
+        cmd: string[]
+        env: string[]
+    }
+    cancel_session: Record<never, never>
 }
+
+type Response = {
+    type: 'success'
+} | {
+    type: 'error'
+    error_type: 'auth_error' | 'error'
+    description: string
+} | {
+    type: 'auth_message'
+    auth_message_type: 'visible' | 'secret' | 'info' | 'error'
+    auth_message: string
+}
+
+export class Greetd extends Service {
+    static { Service.register(this); }
+
+    private _decoder = new TextDecoder;
+
+    readonly login = async (
+        username: string,
+        password: string,
+        cmd: string[] | string,
+        env: string[] = [],
+    ) => {
+        const session = await this.createSession(username);
+        if (session.type !== 'auth_message') {
+            this.cancelSession();
+            throw session;
+        }
+
+        const auth = await this.postAuth(password);
+        if (auth.type !== 'success') {
+            this.cancelSession();
+            throw auth;
+        }
+
+        const start = await this.startSession(cmd, env);
+        if (start.type !== 'success') {
+            this.cancelSession();
+            throw start;
+        }
+
+        App.quit();
+    };
+
+    readonly createSession = (username: string) => {
+        return this._send('create_session', { username });
+    };
+
+    readonly postAuth = (response?: string) => {
+        return this._send('post_auth_message_response', { response });
+    };
+
+    readonly startSession = (cmd: string[] | string, env: string[] = []) => {
+        const cmdv = Array.isArray(cmd)
+            ? cmd
+            : GLib.shell_parse_argv(cmd)[1];
+
+        return this._send('start_session', { cmd: cmdv, env });
+    };
+
+    readonly cancelSession = () => {
+        return this._send('cancel_session', {});
+    };
+
+    private async _send<R extends keyof Request>(req: R, payload: Request[R]): Promise<Response> {
+    const connection = new Gio.SocketClient()
+        .connect(new Gio.UnixSocketAddress({ path: SOCK }), null);
+
+    try {
+        const json = JSON.stringify({ type: req, ...payload });
+        const ostream = new Gio.DataOutputStream({
+            close_base_stream: true,
+            base_stream: connection.get_output_stream(),
+            byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN,
+        });
+
+        const istream = connection.get_input_stream();
+
+        ostream.put_int32(json.length, null);
+        ostream.put_string(json, null);
+
+        const data = await istream.read_bytes_async(4, GLib.PRIORITY_DEFAULT, null);
+        const raw = data.get_data();
+        if (!raw) throw new Error("Failed to read length from greetd socket");
+        const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+        const length = view.getUint32(0, true); // true = little endian
+
+        const res = await istream.read_bytes_async(length, GLib.PRIORITY_DEFAULT, null);
+        const resRaw = res.get_data();
+        if (!resRaw) throw new Error("Failed to read response from greetd socket");
+
+        return JSON.parse(this._decoder.decode(resRaw)) as Response;
+    } finally {
+        connection.close(null);
+    }
+}
+
+}
+
+export const greetd = new Greetd;
+export default greetd;
+EOF
+}
+
 
 build() {
   cd "$srcdir/$_pkgname-$pkgver"

--- a/arch-packages/illogical-impulse-oneui4-icons-git/PKGBUILD
+++ b/arch-packages/illogical-impulse-oneui4-icons-git/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=illogical-impulse-oneui4-icons-git
 _pkgname=OneUI4-Icons
-pkgver=r64.9ba2190
+pkgver=r70.55eada4
 pkgrel=1
 pkgdesc="A fork of mjkim0727/OneUI4-Icons for illogical-impulse dotfiles."
 arch=('x86_64')


### PR DESCRIPTION
# PR: Fix TypeScript build error in greetd.ts

This PR addresses the TypeScript build error (TS18047) caused by possible null `raw` buffer in greetd.ts.

- Added null checks on `get_data()` results.
- Now builds successfully via `makepkg`.

Tested on: Arch Linux (Hyprland)

Note: I know I cannot update the PKGBUILD, and this should update ```./illogical-impulse-agsv1/src/ags-1.9.0/src/service/greetd.ts```, but I cannot update that because the code will be overwritten when I run ```makepkg -si```

## What's Different

<details>
<summary>Proposed Fix for greetd.ts</summary>

```typescript
import App from '../app.js';
import Service from '../service.js';
import GLib from 'gi://GLib';
import Gio from 'gi://Gio';

Gio._promisify(Gio.InputStream.prototype, 'read_bytes_async');
const SOCK = GLib.getenv('GREETD_SOCK');

type Request = {
    create_session: {
        username: string
    }
    post_auth_message_response: {
        response?: string
    }
    start_session: {
        cmd: string[]
        env: string[]
    }
    cancel_session: Record<never, never>
}

type Response = {
    type: 'success'
} | {
    type: 'error'
    error_type: 'auth_error' | 'error'
    description: string
} | {
    type: 'auth_message'
    auth_message_type: 'visible' | 'secret' | 'info' | 'error'
    auth_message: string
}

export class Greetd extends Service {
    static { Service.register(this); }

    private _decoder = new TextDecoder;

    readonly login = async (
        username: string,
        password: string,
        cmd: string[] | string,
        env: string[] = [],
    ) => {
        const session = await this.createSession(username);
        if (session.type !== 'auth_message') {
            this.cancelSession();
            throw session;
        }

        const auth = await this.postAuth(password);
        if (auth.type !== 'success') {
            this.cancelSession();
            throw auth;
        }

        const start = await this.startSession(cmd, env);
        if (start.type !== 'success') {
            this.cancelSession();
            throw start;
        }

        App.quit();
    };

    readonly createSession = (username: string) => {
        return this._send('create_session', { username });
    };

    readonly postAuth = (response?: string) => {
        return this._send('post_auth_message_response', { response });
    };

    readonly startSession = (cmd: string[] | string, env: string[] = []) => {
        const cmdv = Array.isArray(cmd)
            ? cmd
            : GLib.shell_parse_argv(cmd)[1];

        return this._send('start_session', { cmd: cmdv, env });
    };

    readonly cancelSession = () => {
        return this._send('cancel_session', {});
    };

    private async _send<R extends keyof Request>(req: R, payload: Request[R]): Promise<Response> {
    const connection = new Gio.SocketClient()
        .connect(new Gio.UnixSocketAddress({ path: SOCK }), null);

    try {
        const json = JSON.stringify({ type: req, ...payload });
        const ostream = new Gio.DataOutputStream({
            close_base_stream: true,
            base_stream: connection.get_output_stream(),
            byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN,
        });

        const istream = connection.get_input_stream();

        ostream.put_int32(json.length, null);
        ostream.put_string(json, null);

        const data = await istream.read_bytes_async(4, GLib.PRIORITY_DEFAULT, null);
        const raw = data.get_data();
        if (!raw) throw new Error("Failed to read length from greetd socket");
        const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
        const length = view.getUint32(0, true); // true = little endian

        const res = await istream.read_bytes_async(length, GLib.PRIORITY_DEFAULT, null);
        const resRaw = res.get_data();
        if (!resRaw) throw new Error("Failed to read response from greetd socket");

        return JSON.parse(this._decoder.decode(resRaw)) as Response;
    } finally {
        connection.close(null);
    }
}
}

export const greetd = new Greetd;
export default greetd;
```
</details>