### PR TITLE
Update bluetooth.js

### DIFF
--- a/.config/ags/modules/sideright/centermodules/bluetooth.js
+++ b/.config/ags/modules/sideright/centermodules/bluetooth.js
@@ -57,7 +57,7 @@ const BluetoothDevice = (device) => {
             device.setConnection(newValue);
         },
         extraSetup: (self) => self.hook(device, (self) => {
-            Utils.timeout(200, () => self.enabled.value = device.connected);
+            self.value = device.connected;
         }),
     })
     const deviceRemoveButton = Button({


### PR DESCRIPTION
When I use it, the following error will occur

``` 
(com.github.Aylur.ags:98720): Gjs-CRITICAL **: 00:06:00.589: JS ERROR: TypeError: self.enabled is undefined
BluetoothDevice/extraSetup/</<@file:///home/inoribea/.config/ags/modules/sideright/centermodules/bluetooth.js:60:38
timeout/<@resource:///com/github/Aylur/ags/utils/timeout.js:14:9
_init/GLib.MainLoop.prototype.runAsync/</<@resource:///org/gnome/gjs/modules/core/overrides/GLib.js:263:34
```

The error may be caused by the undefined enabled property, which may lead to inconsistent object states when setting the property value with a delay using Utils.timeout.

