### PR TITLE
Fixes the function getImageViewerApp

### DIFF
--- a/.config/ags/modules/sideleft/apis/waifu.js
+++ b/.config/ags/modules/sideleft/apis/waifu.js
@@ -14,7 +14,7 @@ import WaifuService from '../../../services/waifus.js';
 import { darkMode } from '../../.miscutils/system.js';
 
 async function getImageViewerApp(preferredApp) {
-    Utils.execAsync(['bash', '-c', `command -v ${preferredApp}`])
+   return Utils.execAsync(['bash', '-c', `command -v ${preferredApp}`])
         .then((output) => {
             if (output != '') return preferredApp;
             else return 'xdg-open';


### PR DESCRIPTION
The async function getImageViewerApp return void as it doesn't return anything from the function instead only returning from within the promise.
This fix allows the "Waifu" tab to open image in an external viewer.

I have tested this locally and have verified that it now functions as expected.