### PR TITLE
fix: add -A to makepkg

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ install-local-pkgbuild() {
 
 	source ./PKGBUILD
 	x yay -S $installflags --asdeps "${depends[@]}"
-	x makepkg -si --noconfirm
+	x makepkg -Asi --noconfirm
 
 	x popd
 }


### PR DESCRIPTION
i was trying to install it on archlinuxarm

this patch enables the installation via `install.sh` script on non-x86 devices

i confirmed that all packages can be built under aarch64 without modification