### PR TITLE
fix(bluetooth): sync toggle state with device connection

### DIFF
--- a/.config/ags/modules/sideright/centermodules/bluetooth.js
+++ b/.config/ags/modules/sideright/centermodules/bluetooth.js
@@ -56,9 +56,13 @@ const BluetoothDevice = (device) => {
         onChange: (self, newValue) => {
             device.setConnection(newValue);
         },
-        extraSetup: (self) => self.hook(device, (self) => {
-            Utils.timeout(200, () => self.enabled.value = device.connected);
-        }),
+        extraSetup: (self) => {
+            self.hook(device, () => {
+                const enabledState = self.attribute.enabled;
+                if (enabledState.value !== device.connected)
+                    enabledState.value = device.connected;
+            });
+        },
     })
     const deviceRemoveButton = Button({
         vpack: 'center',


### PR DESCRIPTION
Problem:
When using the Bluetooth toggle in the sidebar, the label (Connected/Paired) updated correctly when the device connection state changed, but the switch itself did not reflect the real status.

How I tested:
I manually connected and disconnected Bluetooth devices using `bluetoothctl connect <ID>`, `bluetoothctl disconnect <ID>`commands, and observed that while the label changed instantly, the toggle did not update unless manually reloading the UI or rebuilding the device list

Fix:
The fix reuses the same enabled state (stored inside self.attribute.enabled) that the label and other widget parts are already observing
