### PR TITLE
Enables the Color Picker in the left Sidebar

### DIFF
--- a/.config/ags/modules/sideleft/tools/color.js
+++ b/.config/ags/modules/sideleft/tools/color.js
@@ -1,8 +1,6 @@
 // It's weird, I know
 const { Gio, GLib } = imports.gi;
 import Service from 'resource:///com/github/Aylur/ags/service.js';
-import * as Utils from 'resource:///com/github/Aylur/ags/utils.js';
-const { exec, execAsync } = Utils;
 import { clamp } from '../../.miscutils/mathfuncs.js';
 
 export class ColorPickerSelection extends Service {

--- a/.config/ags/modules/sideleft/tools/colorpicker.js
+++ b/.config/ags/modules/sideleft/tools/colorpicker.js
@@ -142,8 +142,8 @@ export default () => {
                 overlays: [saturationAndLightnessCursor],
             }),
             attribute: {
-                clicked: false,
-                setSaturationAndLightness: (self, event) => {
+                clicked: true,
+                setSaturationAndLightness: (_self, event) => {
                     const allocation = saturationAndLightnessRange.children[0].get_allocation();
                     const [_, cursorX, cursorY] = event.get_coords();
                     const cursorXPercent = clamp(cursorX / allocation.width, 0, 1);

--- a/.config/ags/modules/sideleft/tools/colorpicker.js
+++ b/.config/ags/modules/sideleft/tools/colorpicker.js
@@ -1,11 +1,9 @@
 // TODO: Make selection update when entry changes
 const { Gtk } = imports.gi;
-import App from 'resource:///com/github/Aylur/ags/app.js';
-import Variable from 'resource:///com/github/Aylur/ags/variable.js';
 import Widget from 'resource:///com/github/Aylur/ags/widget.js';
 import * as Utils from 'resource:///com/github/Aylur/ags/utils.js';
 const { execAsync, exec } = Utils;
-const { Box, Button, Entry, EventBox, Icon, Label, Overlay, Scrollable } = Widget;
+const { Box, Button, Entry, EventBox, Label, Overlay } = Widget;
 import SidebarModule from './module.js';
 import { MaterialIcon } from '../../.commonwidgets/materialicon.js';
 import { setupCursorHover } from '../../.widgetutils/cursorhover.js';


### PR DESCRIPTION
Enables the color picker in the left sidebar by setting clicked: true
Cleans up unused imports in the colorpicker.js and color.js file