### PR TITLE
Fix title on workspace change

### DIFF
--- a/.config/ags/modules/bar/normal/spaceleft.js
+++ b/.config/ags/modules/bar/normal/spaceleft.js
@@ -29,9 +29,14 @@ const WindowTitle = async () => {
                         truncate: 'end',
                         maxWidthChars: 1, // Doesn't matter, just needs to be non negative
                         className: 'txt-smallie bar-wintitle-txt',
-                        setup: (self) => self.hook(Hyprland.active.client, label => { // Hyprland.active.client
-                            label.label = Hyprland.active.client.title.length === 0 ? `Workspace ${Hyprland.active.workspace.id}` : Hyprland.active.client.title;
-                        }),
+                        setup: (self) => {
+                            self.hook(Hyprland.active.client, label => { // Hyprland.active.client
+                                label.label = Hyprland.active.client.title.length === 0 ? `Workspace ${Hyprland.active.workspace.id}` : Hyprland.active.client.title;
+                            });
+                            self.hook(Hyprland.active.workspace, label => { // Hyprland.active.client
+                                label.label = Hyprland.active.client.title.length === 0 ? `Workspace ${Hyprland.active.workspace.id}` : Hyprland.active.client.title;
+                            });
+                        }
                     })
                 ]
             })


### PR DESCRIPTION
If there aren't any opened windows, title widget displays "workspace 2", but if you switch between opened workspaces without opening any windows, this title doesn't change

In this fix, I added a hook to update this widget also when workspace number changes

(I didn't add hook on top title, because it won't change in this case anyway)