### PR TITLE
Add option to ignore certain apps in dock

### DIFF
--- a/.config/ags/modules/.configuration/default_options.jsonc
+++ b/.config/ags/modules/.configuration/default_options.jsonc
@@ -199,6 +199,7 @@
             "firefox",
             "org.gnome.Nautilus"
         ],
+        "ignoredAppsRegex": [],
         "layer": "top",
         "monitorExclusivity": true, // Dock will move to other monitor along with focus if enabled
         "searchPinnedAppIcons": false, // Try to search for the correct icon if the app class isn't an icon name

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -119,6 +119,17 @@ const Taskbar = (monitor) => Widget.Box({
                 const client = Hyprland.clients[i];
                 if (client["pid"] == -1) return;
                 const appClass = substitute(client.class);
+                const ignoredAppsRegex = userOptions.dock.ignoredAppsRegex;
+                const isIgnored = false;
+
+                for (const regex of ignoredAppsRegex) {
+                    if (!appClass.match(regex)) continue;
+                    isIgnored = true;
+                    break;
+                }
+
+                if (isIgnored) continue;
+
                 // for (const appName of userOptions.dock.pinnedApps) {
                 //     if (appClass.includes(appName.toLowerCase()))
                 //         return null;

--- a/.config/ags/modules/dock/dock.js
+++ b/.config/ags/modules/dock/dock.js
@@ -119,13 +119,17 @@ const Taskbar = (monitor) => Widget.Box({
                 const client = Hyprland.clients[i];
                 if (client["pid"] == -1) return;
                 const appClass = substitute(client.class);
-                const ignoredAppsRegex = userOptions.dock.ignoredAppsRegex;
-                const isIgnored = false;
+                const ignoredAppsRegex = userOptions.dock.ignoredAppsRegex || [];
+                let isIgnored = false;
 
                 for (const regex of ignoredAppsRegex) {
-                    if (!appClass.match(regex)) continue;
-                    isIgnored = true;
-                    break;
+                    try {
+                        const pattern = new RegExp(regex);
+                        if (pattern.test(appClass)) {
+                            isIgnored = true;
+                            break;
+                        }
+                    } catch (e) {}
                 }
 
                 if (isIgnored) continue;


### PR DESCRIPTION
I have scratchpads and i didn't want them to appear in the dock so i added this

For example i put 
```jsonc
"ignoredAppsRegex": ["^kitty-dropterm-.$"],
```
so it will ignore all app clases that match kitty-dropterm-.