### PR TITLE
Fix ddcutil to fall back to binary serial number

### DIFF
--- a/.config/ags/services/brightness.js
+++ b/.config/ags/services/brightness.js
@@ -90,27 +90,44 @@ class BrightnessDdcService extends BrightnessServiceBase {
 async function listDdcMonitorsSnBus() {
     let ddcSnBus = {};
     try {
-        const out = await Utils.execAsync('ddcutil detect --brief');
+        // Its' better not to use --brief. This way if a serial number is not
+        // found we can still use the binary serial number as an alternative
+        const out = await Utils.execAsync('ddcutil detect');
         const displays = out.split('\n\n');
         displays.forEach(display => {
-            const reg = /^Display \d+/;
-            if (!reg.test(display))
+            const reg = /[Dd]isplay/;
+            if (!reg.test(display)) {
                 return;
+            }
             const lines = display.split('\n');
             let sn, busNum;
+            let unresponsive = false;
             for (let line of lines) {
                 line = line.trim()
-                if (line.startsWith('Monitor:')) {
-                    sn = line.split(':')[3];
+
+                // Sometimes ddcutils will report a DP monitor twice, one of the
+                // two copies of the monitor will "not support DDC/CI". Just ignore it
+                // See https://www.ddcutil.com/faq/#duplicate_displayport
+                if (line.includes('unresponsive')) {
+                    unresponsive = true;
+                }
+                if (line.startsWith('Serial')) {
+                    sn = line.split(':')[1].trim();
+                    // Sometimes sn can be empty. In this cases let's relay on binary sn
+                } else if (line.startsWith('Binary') && !sn) {
+                    // Make the serial number upper case except for the leading '0x' since Hyperland
+                    // seems to use upper case for the rest of the string and ddcutil uses
+                    // lower case for all the binary sn
+                    sn = '0x'+line.split('(')[1].slice(2,-1).toUpperCase();
                 } else if (line.startsWith('I2C bus:')) {
                     busNum = line.split('/dev/i2c-')[1];
                 }
             }
-            if (sn && busNum)
+            if (sn && busNum && !unresponsive){
                 ddcSnBus[sn] = busNum;
+            }
         });
     } catch (err) {
-        print(err);
     }
     return ddcSnBus;
 }
@@ -133,10 +150,12 @@ for (let i = 0; i < service.length; i++) {
                 service[i] = new BrightnessDdcService(ddcSnBus[monitorSn]);
                 break;
             case "auto":
-                if (monitorSn in ddcSnBus && !!exec(`bash -c 'command -v ddcutil'`))
+                if (monitorSn in ddcSnBus && !!exec(`bash -c 'command -v ddcutil'`)){
                     service[i] = new BrightnessDdcService(ddcSnBus[monitorSn]);
-                else
+                }
+                else {
                     service[i] = new BrightnessCtlService();
+                }
                 break;
             default:
                 throw new Error(`Unknown brightness controller ${preferredController}`);


### PR DESCRIPTION
# Changes:

- Fix ddcutil to fall back to binary serial number if no serial number is found for a display. 
- Ignore duplicated entries for DisplayPort monitors (or any unresponsive monitors)

## Binary serial number fallback
Hyprland reports the display's binary serial number when the normal one is not found, so I adapted the code to act similarly using ddcutil's full output instead of using `--brief`, as this last one won't report the binary serial number.
<details>
<summary>For reference, this is the output of `hyprctl monitors` in my system</summary>
![image_2025-05-21_15-47-26](https://github.com/user-attachments/assets/2d3cd360-ad7c-455f-85a5-3c7bcd9b2b8f)

As you can see the serial number is reported as `0x947020B8`.
</details>
<details>
<summary>And this is the output of `ddcutil detect` in my system</summary>
![image_2025-05-21_15-47-58](https://github.com/user-attachments/assets/612e4b8e-0a64-4d6e-b603-7f2c73e72fd2)

Here the "Serial number" field is empty, while the "Binary serial number" field does report a value: `2490376376 (0x947020b8)` (of course, we would want to grab the last one in the brackets).
</details>
When using the binary serial number as a fallback we can allow the user to change the brightness of the screen even if their monitor/s don't report a proper serial number. 

The only difference between hyprctl's and ddcutil's binary serial number is that the former one makes the whole number uppercase after the leading `0x`, while ddcutil keeps it all lowercase. This is something we can easily account for, though.

## Duplicated DisplayPort monitors
If a monitor is connected via DisplayPort, there is a chance ddcutil will detect this monitor twice but only one of the two will work with DDC.
`ddcutil detect` will report the display as invalid and the last line for that monitor will say "`This monitor does not support DDC/CI. (I2C slave address x37 is unresponsive.)`".

<details>
<summary>This is how it appears in my system</summary>
![image_2025-05-21_15-49-41](https://github.com/user-attachments/assets/92172afd-72c8-4801-9815-51980982cb4f)

This is the duplicated entry for the same monitor as before.
</details>

To be fair, though, I must say that this last fix is only needed because I changed the regular expresion for finding displays to accept displays marked as invalid. I did this because when testing sometimes my monitors would turn up as invalid even when I could change the brigntess manually by command (ddcutil), but it is also true that in my last tests for some reason they weren't being reported as invalid anymore and everything looked normal again. 

I think the regexp can be reverted to it's original state with no issue, but I kinda just left it like that just in case.

(Source: https://www.ddcutil.com/faq/#duplicate_displayport)