### PR TITLE
Allow fuzzel.ini to be customized

### DIFF
--- a/.config/ags/scripts/color_generation/applycolor.sh
+++ b/.config/ags/scripts/color_generation/applycolor.sh
@@ -49,19 +49,17 @@ get_light_dark() {
 
 apply_fuzzel() {
   # Check if template exists
-  if [ ! -f "scripts/templates/fuzzel/fuzzel.ini" ]; then
+  if [ ! -f "scripts/templates/fuzzel/fuzzel.theme" ]; then
     echo "Template file not found for Fuzzel. Skipping that."
     return
   fi
   # Copy template
   mkdir -p "$CACHE_DIR"/user/generated/fuzzel
-  cp "scripts/templates/fuzzel/fuzzel.ini" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.ini
+  cp "scripts/templates/fuzzel/fuzzel.theme" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.theme
   # Apply colors
   for i in "${!colorlist[@]}"; do
-    sed -i "s/{{ ${colorlist[$i]} }}/${colorvalues[$i]#\#}/g" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.ini
+    sed -i "s/{{ ${colorlist[$i]} }}/${colorvalues[$i]#\#}/g" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.theme
   done
-
-  cp "$CACHE_DIR"/user/generated/fuzzel/fuzzel.ini "$XDG_CONFIG_HOME"/fuzzel/fuzzel.ini
 }
 
 apply_term() {

--- a/.config/ags/scripts/color_generation/applycolor.sh
+++ b/.config/ags/scripts/color_generation/applycolor.sh
@@ -54,11 +54,10 @@ apply_fuzzel() {
     return
   fi
   # Copy template
-  mkdir -p "$CACHE_DIR"/user/generated/fuzzel
-  cp "scripts/templates/fuzzel/fuzzel.theme" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.theme
+  cp "scripts/templates/fuzzel/fuzzel.theme" "$XDG_CONFIG_HOME"/fuzzel/fuzzel.theme
   # Apply colors
   for i in "${!colorlist[@]}"; do
-    sed -i "s/{{ ${colorlist[$i]} }}/${colorvalues[$i]#\#}/g" "$CACHE_DIR"/user/generated/fuzzel/fuzzel.theme
+    sed -i "s/{{ ${colorlist[$i]} }}/${colorvalues[$i]#\#}/g" "$XDG_CONFIG_HOME"/fuzzel/fuzzel.theme
   done
 }
 

--- a/.config/ags/scripts/templates/fuzzel/fuzzel.theme
+++ b/.config/ags/scripts/templates/fuzzel/fuzzel.theme
@@ -1,8 +1,3 @@
-font=Gabarito
-terminal=foot -e
-prompt=">>  "
-layer=overlay
-
 [colors]
 background={{ $background }}ff
 text={{ $onBackground }}ff
@@ -11,11 +6,3 @@ selection-text={{ $onSurfaceVariant }}ff
 border={{ $surfaceVariant }}dd
 match={{ $primary }}ff
 selection-match={{ $primary }}ff
-
-
-[border]
-radius=17
-width=1
-
-[dmenu]
-exit-immediately-if-empty=yes

--- a/.config/fuzzel/fuzzel.ini
+++ b/.config/fuzzel/fuzzel.ini
@@ -1,17 +1,8 @@
+include="~/.cache/ags/user/generated/fuzzel/fuzzel.theme"
 font=Gabarito
 terminal=foot -e
 prompt=">>  "
 layer=overlay
-
-[colors]
-background=1D1011ff
-text=F7DCDEff
-selection=574144ff
-selection-text=DEBFC2ff
-border=574144dd
-match=FFB2BCff
-selection-match=FFB2BCff
-
 
 [border]
 radius=17

--- a/.config/fuzzel/fuzzel.ini
+++ b/.config/fuzzel/fuzzel.ini
@@ -1,4 +1,4 @@
-include="~/.cache/ags/user/generated/fuzzel/fuzzel.theme"
+include="~/.config/fuzzel/fuzzel.theme"
 font=Gabarito
 terminal=foot -e
 prompt=">>  "


### PR DESCRIPTION
Instead of overwriting the entire fuzzel.ini on each theme change. Theme changes are made to `fuzzel.theme` which is then imported by `fuzzel.ini`

Rationale:
I like to use vim binds for fuzzel and there wasn't a good way to modify `fuzzel.ini` without making the end-4 update process complicated.

If you're okay with this, I'll make another PR for ii-qs