### PR TITLE
chore: add fish shell compatible setup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
    - **Prerequisite**: Your system works. That's it. You don't have to reinstall your system!
    - **Automatic**, but guided and transparent, installation for Arch(-based) Linux:
    ```bash
-   bash <(curl -s "https://end-4.github.io/dots-hyprland-wiki/setup.sh")
+   bash -c "$(curl -s https://end-4.github.io/dots-hyprland-wiki/setup.sh)"
    ```
    - **Manual** installation, other distros and more:
      - See the [Wiki](https://end-4.github.io/dots-hyprland-wiki/en/i-i/01setup/)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@
    - **Prerequisite**: Your system works. That's it. You don't have to reinstall your system!
    - **Automatic**, but guided and transparent, installation for Arch(-based) Linux:
    ```bash
+   bash <(curl -s "https://end-4.github.io/dots-hyprland-wiki/setup.sh")
+   ```
+
+   If you are using fish shell (non-posix-compliant shell) then:
+   ```bash
    bash -c "$(curl -s https://end-4.github.io/dots-hyprland-wiki/setup.sh)"
    ```
+
    - **Manual** installation, other distros and more:
      - See the [Wiki](https://end-4.github.io/dots-hyprland-wiki/en/i-i/01setup/)
      - (_Available in: English, Vietnamese, and Simplified Chinese. Translations are welcome._)


### PR DESCRIPTION
as fish is a non-posix-compliant shell, it doesn't support bash syntax like bash <(), so i have changed the url to one that fish shell supports.

btw, sorry i haven't tested this yet. please test the script before merging it should work fine, but just in case.