### PR TITLE
QS Feature: better dock

### DIFF
--- a/.config/quickshell/modules/dock/Dock.qml
+++ b/.config/quickshell/modules/dock/Dock.qml
@@ -119,24 +119,25 @@ Scope { // Scope
                                     }
                                 }
                             }
-                            DockSeparator {}
-                            // Pinned apps
-                            Repeater {
-                                model: ConfigOptions?.dock.pinnedApps ?? []
+                            
+                            // DockSeparator {}
+                            // // Pinned apps
+                            // Repeater {
+                            //     model: ConfigOptions?.dock.pinnedApps ?? []
                                 
-                                DockButton {
-                                    id: pinnedAppButton
-                                    required property string modelData
-                                    property DesktopEntry entry: DesktopEntries.byId(modelData)
-                                    onClicked: {
-                                        pinnedAppButton?.entry.execute();
-                                    }
-                                    contentItem: IconImage {
-                                        anchors.centerIn: parent
-                                        source: Quickshell.iconPath(AppSearch.guessIcon(modelData), "image-missing")
-                                    }
-                                }
-                            }
+                            //     DockButton {
+                            //         id: pinnedAppButton
+                            //         required property string modelData
+                            //         property DesktopEntry entry: DesktopEntries.byId(modelData)
+                            //         onClicked: {
+                            //             pinnedAppButton?.entry.execute();
+                            //         }
+                            //         contentItem: IconImage {
+                            //             anchors.centerIn: parent
+                            //             source: Quickshell.iconPath(AppSearch.guessIcon(modelData), "image-missing")
+                            //         }
+                            //     }
+                            // }
                             
                             DockSeparator { visible: (ConfigOptions?.dock.pinnedApps ?? []).length > 0 }
                             

--- a/.config/quickshell/modules/dock/DockAppButton.qml
+++ b/.config/quickshell/modules/dock/DockAppButton.qml
@@ -21,13 +21,14 @@ DockButton {
     property real iconSize: 35
     property real countDotWidth: 10
     property real countDotHeight: 4
-    property bool appIsActive: appToplevel.toplevels.find(t => (t.activated == true)) !== undefined
+    property bool appIsActive: !appToplevel.toplevels ? false : appToplevel.toplevels.find(t => (t.activated == true)) !== undefined
+    property DesktopEntry entry: DesktopEntries.byId(modelData.appId)
 
     MouseArea {
         id: mouseArea
         anchors.fill: parent
         hoverEnabled: true
-        acceptedButtons: Qt.NoButton
+        acceptedButtons: Qt.LeftButton | Qt.MiddleButton
         onEntered: {
             appListRoot.lastHoveredButton = appButton
             appListRoot.buttonHovered = true

--- a/.config/quickshell/modules/dock/DockAppButton.qml
+++ b/.config/quickshell/modules/dock/DockAppButton.qml
@@ -38,10 +38,18 @@ DockButton {
                 appListRoot.buttonHovered = false
             }
         }
-    }
-    onClicked: {
-        lastFocused = (lastFocused + 1) % appToplevel.toplevels.length
-        appToplevel.toplevels[lastFocused].activate()
+        onClicked: {
+            if (mouse.button === Qt.MiddleButton ) {
+                appButton.entry.execute();
+                return;
+            }
+            if (modelData.isPinnedApp && !modelData.isRunning) {
+                appButton.entry.execute();
+                return;
+            }
+            lastFocused = (lastFocused + 1) % appToplevel.toplevels.length
+            appToplevel.toplevels[lastFocused].activate()
+        }
     }
     contentItem: Item {
         anchors.centerIn: parent
@@ -65,11 +73,15 @@ DockButton {
                 horizontalCenter: parent.horizontalCenter
             }
             Repeater {
-                model: Math.min(appToplevel.toplevels.length, 3)
+                model: ScriptModel {
+                    values: {
+                        return appToplevel.toplevels ?? []
+                    }
+                }
                 delegate: Rectangle {
                     required property int index
                     radius: Appearance.rounding.full
-                    implicitWidth: (appToplevel.toplevels.length <= 3) ? 
+                    implicitWidth: !appToplevel.toplevels ? 0 : (appToplevel.toplevels.length <= 3) ? 
                         appButton.countDotWidth : appButton.countDotHeight // Circles when too many
                     implicitHeight: appButton.countDotHeight
                     color: appIsActive ? Appearance.m3colors.m3primary : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)


### PR DESCRIPTION
The pinned apps are along with running apps. `DockAppButton` and `DockSeparator` are inside a `RowLayout` container (Every `DockAppButton` has a `DockSeparator` with it and we only need the one next to the first-unpinned-running app. I have no better idea how to deal with this as my QML knowledge is really poor)

Closes #1375 if this works fine