### PR TITLE
fix(font): Kitty now follows font size from kitty.conf

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -198,9 +198,9 @@ bindl= ,XF86AudioPause, exec, playerctl play-pause # [hidden]
 
 ##! Apps
 bind = Super, T, exec, # [hidden]
-bind = Super, Return, exec, kitty -1 # Kitty (terminal)
-bind = Super, T, exec, kitty -1 # [hidden] Kitty (terminal) (alt)
-bind = Ctrl+Alt, T, exec, kitty -1 # [hidden] Kitty (for Ubuntu people)
+bind = Super, Return, exec, kitty --config ~/.config/kitty/kitty.conf # Kitty (terminal)
+bind = Super, T, exec, kitty --config ~/.config/kitty/kitty.conf # [hidden] Kitty (terminal) (alt)
+bind = Ctrl+Alt, T, exec, kitty --config ~/.config/kitty/kitty.conf # [hidden] Kitty (for Ubuntu people)
 bind = Super, E, exec, dolphin --new-window # Dolphin (file manager)
 bind = Ctrl+Super, W, exec, firefox # Firefox (browser)
 bind = Super, C, exec, code # VSCode (code editor)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cef09bf8-faff-4203-a337-a066e64a6a21)
