### PR TITLE
Add terminalApp global for kde Apps

### DIFF
--- a/.config/kdeglobals
+++ b/.config/kdeglobals
@@ -137,6 +137,7 @@ ColorScheme=MaterialYouDark
 ColorSchemeHash=3c0cecefbea43cdb8fe3da156e4a106f7384a526
 LastUsedCustomAccentColor=184,117,220
 XftHintStyle=hintslight
+TerminalApplication=kitty -1
 XftSubPixel=none
 fixed=JetBrainsMono Nerd Font,11,-1,5,400,0,0,0,0,0,0,0,0,0,0,1
 font=Rubik,11,-1,5,400,0,0,0,0,0,0,0,0,0,0,1


### PR DESCRIPTION
This helps with "Open with neovim" in dolphin.

Although it doesn't apply the quickshell theme since it opens kitty and neovim without going through a shell.

I'm not sure what would be the proper solution