### PR TITLE
Added ability to hide/show the top bar on keypress

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -32,6 +32,7 @@ bindd = Super, M, Toggle media controls, global, quickshell:mediaControlsToggle 
 bindd = Ctrl+Alt, Delete, Toggle session menu, global, quickshell:sessionToggle # Toggle session menu
 bind = Ctrl+Alt, Delete, exec, qs ipc call TEST_ALIVE || pkill wlogout || wlogout -p layer-shell # [hidden] Session menu (fallback)
 bind = Shift+Super+Alt, Slash, exec, qs -p ~/.config/quickshell/welcome.qml # [hidden] Launch welcome app
+bindd = Super+Ctrl, B, Toggle top bar, global, quickshell:topbarToggle # Toggle top bar
 
 bindle=, XF86MonBrightnessUp, exec, qs ipc call brightness increment || agsv1 run-js 'brightness.screen_value += 0.05; indicator.popup(1);' # [hidden]
 bindle=, XF86MonBrightnessDown, exec, qs ipc call brightness decrement || agsv1 run-js 'brightness.screen_value -= 0.05; indicator.popup(1);' # [hidden]

--- a/.config/quickshell/GlobalStates.qml
+++ b/.config/quickshell/GlobalStates.qml
@@ -13,6 +13,7 @@ Singleton {
     property bool overviewOpen: false
     property bool workspaceShowNumbers: false
     property bool superReleaseMightTrigger: true
+    property bool barVisible: ConfigOptions.bar.startsVisible
 
     // When user is not reluctant while pressing super, they probably don't need to see workspace numbers
     onSuperReleaseMightTriggerChanged: { 

--- a/.config/quickshell/modules/bar/Bar.qml
+++ b/.config/quickshell/modules/bar/Bar.qml
@@ -19,6 +19,8 @@ Scope {
     readonly property int osdHideMouseMoveThreshold: 20
     property bool showBarBackground: ConfigOptions.bar.showBackground
 
+    visible: GlobalStates.barVisible
+
     component VerticalBarSeparator: Rectangle {
         Layout.topMargin: barHeight / 3
         Layout.bottomMargin: barHeight / 3
@@ -465,5 +467,12 @@ Scope {
         }
 
     }
+    GlobalShortcut {
+        name: "topbarToggle"
+        description: qrTs("Toggles top bar on press")
 
+        onPressed:{
+            GlobalStates.barVisible = !GlobalStates.barVisible
+        }
+    }
 }

--- a/.config/quickshell/modules/bar/Bar.qml
+++ b/.config/quickshell/modules/bar/Bar.qml
@@ -19,8 +19,6 @@ Scope {
     readonly property int osdHideMouseMoveThreshold: 20
     property bool showBarBackground: ConfigOptions.bar.showBackground
 
-    visible: GlobalStates.barVisible
-
     component VerticalBarSeparator: Rectangle {
         Layout.topMargin: barHeight / 3
         Layout.bottomMargin: barHeight / 3
@@ -58,6 +56,7 @@ Scope {
                 item: barContent
             }
             color: "transparent"
+            visible: GlobalStates.barVisible
 
             anchors {
                 top: !ConfigOptions.bar.bottom

--- a/.config/quickshell/modules/common/ConfigOptions.qml
+++ b/.config/quickshell/modules/common/ConfigOptions.qml
@@ -48,6 +48,7 @@ Singleton {
         property string topLeftIcon: "spark" // Options: distro, spark
         property bool showBackground: true
         property bool verbose: true
+        property bool startsVisible: true // false to have the bar start as hidden on login
         property QtObject resources: QtObject {
             property bool alwaysShowSwap: true
             property bool alwaysShowCpu: false


### PR DESCRIPTION
It's sometimes useful to hide the top bar, such as with the recent game The Alters which crashes when fullscreen so you need to play windowed and have the bar hidden, or with an OLED monitor you don't always want static assets always on the screen.

Tested on a clean install and upgrading existing installs to ensure the default behavior is to show the bar.