### PR TITLE
Fixed Terminal Color generation bug for quickshell

### DIFF
--- a/.config/zshrc.d/dots-hyprland.zsh
+++ b/.config/zshrc.d/dots-hyprland.zsh
@@ -1,5 +1,5 @@
 # Use the generated color scheme
 
-if test -f ~/.cache/ags/user/generated/terminal/sequences.txt; then
-    cat ~/.cache/ags/user/generated/terminal/sequences.txt
+if test -f ~/.local/state/quickshell/user/generated/terminal/sequences.txt; then
+    cat ~/.local/state/quickshell/user/generated/terminal/sequences.txt
 fi


### PR DESCRIPTION
Recently upgraded from ags to quickshell and the terminal colors werent syncing with wallpaper i put

the source file from ~/.config/zshrc.d/dots-hyprland.zsh wasnt working since it was using the outdated ags generated cache.

Removed the ags one and added the quickshell color gen

Now it works perfectly