### PR TITLE
Update MediaControls.qml to filter "YouTube Music" included players

### DIFF
--- a/.config/quickshell/modules/mediaControls/MediaControls.qml
+++ b/.config/quickshell/modules/mediaControls/MediaControls.qml
@@ -45,6 +45,9 @@ Scope {
         let filtered = [];
         let used = new Set();
 
+        // Skip unwanted players
+        if (p1.trackTitle.includes("YouTube Music")) continue;
+
         for (let i = 0; i < players.length; ++i) {
             if (used.has(i)) continue;
             let p1 = players[i];


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

It filters tracks including "YouTube Music" in the player.trackTitle 

It is a crude fix, but it works. Further implementations should look for more efficient ways of doing this.

## Is it ready? Questions/feedback needed?


