### PR TITLE
Bar.qml: Fix round decorators transparency and visibility consistency with bar

### DIFF
--- a/.config/quickshell/modules/bar/Bar.qml
+++ b/.config/quickshell/modules/bar/Bar.qml
@@ -456,6 +456,7 @@ Scope {
                     bottom: ConfigOptions.bar.bottom ? barContent.top : undefined
                 }
                 height: Appearance.rounding.screenRounding
+                visible: showBarBackground
 
                 RoundCorner {
                     anchors.top: parent.top
@@ -463,6 +464,7 @@ Scope {
                     size: Appearance.rounding.screenRounding
                     corner: ConfigOptions.bar.bottom ? cornerEnum.bottomLeft : cornerEnum.topLeft
                     color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                    opacity: 1.0 - Appearance.transparency
                 }
                 RoundCorner {
                     anchors.top: parent.top
@@ -470,6 +472,7 @@ Scope {
                     size: Appearance.rounding.screenRounding
                     corner: ConfigOptions.bar.bottom ? cornerEnum.bottomRight : cornerEnum.topRight
                     color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                    opacity: 1.0 - Appearance.transparency  
                 }
             }
 


### PR DESCRIPTION

## Describe your changes
1. Fixed visibility consistency: Corner round decorators now properly hide when `showBackground` is false
2. Fixed transparency consistency: Corner round decorators now use the same transparency value with the main bar

- Before: 
![swappy-20250619-202904](https://github.com/user-attachments/assets/b6849dbe-9eb1-405d-a51d-04d0a0b0afd3)
![swappy-20250619-202442](https://github.com/user-attachments/assets/cab750be-64dc-46d0-8855-73aea957d280)

- After:
![swappy-20250619-204217](https://github.com/user-attachments/assets/d938574f-9d84-4aec-9fb4-a1a2350d8a38)
![swappy-20250619-204644](https://github.com/user-attachments/assets/c40df5a3-da18-4e95-a82b-e7541287b9a2)

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Ready, at least it looks good on the surface.

