### PR TITLE
todo popup script for keybinds

### DIFF
--- a/.config/hypr/hyprland/scripts/add_todo_fuzzel.sh
+++ b/.config/hypr/hyprland/scripts/add_todo_fuzzel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TODO_FILE="$HOME/.local/state/quickshell/user/todo.json"
+TMP_FILE="${TODO_FILE}.tmp"
+
+# Prompt for new todo with a small fuzzel window
+NEW_TODO="$(fuzzel --dmenu --prompt="Add todo:" --width=20 --lines=0 --font='monospace:size=8')" || exit 1
+
+# Exit if input is empty
+[ -z "$NEW_TODO" ] && exit 0
+
+# If the file does not exist or is empty, initialize with []
+if [ ! -s "$TODO_FILE" ]; then
+  echo "[]" > "$TODO_FILE"
+fi
+
+# Append the new todo using jq
+jq --arg content "$NEW_TODO" '. += [{"content":$content,"done":false}]' "$TODO_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$TODO_FILE"

--- a/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
@@ -16,6 +16,29 @@ Item {
     property int fabSize: 48
     property int fabMargins: 14
 
+    property bool isRefreshing: false
+
+    Timer {
+        id: refreshTimer
+        interval: 3000 // milliseconds = 3 seconds
+        running: root.isRefreshing
+        repeat: true
+        triggeredOnStart: false
+        onTriggered: {
+            Todo.refresh()
+        }
+    }
+
+    // Watch for visibility change
+    onVisibleChanged: {
+        if (visible) {
+            root.isRefreshing = true
+        } else {
+            root.isRefreshing = false
+        }
+    }
+    
+    
     Keys.onPressed: (event) => {
         if ((event.key === Qt.Key_PageDown || event.key === Qt.Key_PageUp) && event.modifiers === Qt.NoModifier) {
             if (event.key === Qt.Key_PageDown) {


### PR DESCRIPTION
fuzzel popup saves to todo's json

i made todowidget refresh every 3 seconds when visible so that new items are actually show

hyprland keybind can be 


bind = ,(your fav key), exec, ~/.config/quickshell/hypr/hyprland/scripts/add_todo_fuzzel.sh