### PR TITLE
Update color.txt path in switchwall.sh

### DIFF
--- a/.config/quickshell/scripts/colors/switchwall.sh
+++ b/.config/quickshell/scripts/colors/switchwall.sh
@@ -237,7 +237,7 @@ switch() {
     [[ -n "$mode_flag" ]] && matugen_args+=(--mode "$mode_flag") && generate_colors_material_args+=(--mode "$mode_flag")
     [[ -n "$type_flag" ]] && matugen_args+=(--type "$type_flag") && generate_colors_material_args+=(--scheme "$type_flag")
     generate_colors_material_args+=(--termscheme "$terminalscheme" --blend_bg_fg)
-    generate_colors_material_args+=(--cache "$STATE_DIR/user/color.txt")
+    generate_colors_material_args+=(--cache "$STATE_DIR/user/generated/color.txt")
 
     pre_process "$mode_flag"
 


### PR DESCRIPTION
Update color.txt path in switchwall.sh -

The rest of the codebase uses "$STATE_DIR/user/generated/color.txt", apart from one line in the switchwall script which still uses "$STATE_DIR/user/color.txt".

Assume this is just a typo?

## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?


