### PR TITLE
Constrains Background Widget to Stop it from Clipping Outside of Screen

### DIFF
--- a/.config/quickshell/modules/backgroundWidgets/BackgroundWidgets.qml
+++ b/.config/quickshell/modules/backgroundWidgets/BackgroundWidgets.qml
@@ -92,11 +92,20 @@ Scope {
                     color: root.colBackground
                     implicitHeight: columnLayout.implicitHeight + verticalPadding * 2
                     implicitWidth: columnLayout.implicitWidth + horizontalPadding * 2
+                    
+                    // Calculate constrained position to keep widget within screen bounds
+                    property real unconstrainedLeftMargin: (root.effectiveCenterX / monitor.scale - implicitWidth / 2)
+                    property real unconstrainedTopMargin: (root.effectiveCenterY / monitor.scale - implicitHeight / 2)
+                    
+                    // Constrain to screen boundaries
+                    property real constrainedLeftMargin: Math.max(0, Math.min(unconstrainedLeftMargin, windowRoot.width - implicitWidth))
+                    property real constrainedTopMargin: Math.max(0, Math.min(unconstrainedTopMargin, windowRoot.height - implicitHeight))
+                    
                     anchors {
                         left: parent.left
                         top: parent.top
-                        leftMargin: (root.effectiveCenterX / monitor.scale - implicitWidth / 2)
-                        topMargin: (root.effectiveCenterY / monitor.scale - implicitHeight / 2)
+                        leftMargin: constrainedLeftMargin
+                        topMargin: constrainedTopMargin
                         Behavior on leftMargin {
                             animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
                         }


### PR DESCRIPTION
I have a 3440x1440 resolution monitor. I noticed that the widget that shows the clock, clips out of my screen to varying degrees. These are my changes in a nutshell: 

- I kept the original logic to calculate the desired position of the widget (which is the `unconstrainedLeftMargin` and `unconstrainedTopMargin`)

- However, I applied a bounds check with `constrainedLeftMargin` and `constrainedTopMargin`

- The boundary constraints are `Math.max(0, ...)` (ensures widget doesn't go off the left/top edge), `Math.min(..., windowRoot.width - implicitWidth)` (ensures the widget doesn't go off the right edge and `Math.min(..., windowRoot.height - implicitHeight)` (ensure the widget doesn't go off the bottom edge.

- I updated the anchors to use my new constraints 

This fixed the background widget clipping outside of my screen on my (admittedly) edge case of a monitor resolution. I tested this on my laptop with a 1920x1080 screen and the widget seems to be working normally there, so it might work for everyone. However, testing on other resolutions and refinements to this code is always welcome.
