### PR TITLE
Implement bar.screenList into the settings app

### DIFF
--- a/.config/quickshell/modules/common/widgets/ConfigGrid.qml
+++ b/.config/quickshell/modules/common/widgets/ConfigGrid.qml
@@ -1,0 +1,12 @@
+import QtQuick
+import QtQuick.Layouts
+
+GridLayout {
+    property bool uniform: false
+
+    rowSpacing: 10
+    columnSpacing: 10
+
+    uniformCellHeights: uniform
+    uniformCellWidths: uniform
+}

--- a/.config/quickshell/modules/settings/InterfaceConfig.qml
+++ b/.config/quickshell/modules/settings/InterfaceConfig.qml
@@ -187,10 +187,11 @@ ContentPage {
 
                 function updateMonitors() {
                     loaded = true;
-                    
+
                     monitorsSelection.clear();
 
                     var empty_list = true;
+                    var monitor_count = 0;
 
                     var enabled_map = Config.options.bar.screenList.reduce((map, val) => {
                         if(!val || val === "")
@@ -204,6 +205,8 @@ ContentPage {
                             enabled: true
                         });
 
+                        ++monitor_count;
+
                         return map;
                     }, {})
 
@@ -215,8 +218,15 @@ ContentPage {
                             label: monitor.name,
                             enabled: empty_list
                         })
+
+                        ++monitor_count;
                     }
 
+                    if(monitor_count % 2 != 0)
+                        monitorsSelection.append({
+                            label: "",
+                            enabled: false
+                        })
                 }
 
                 Connections {
@@ -238,6 +248,7 @@ ContentPage {
                     ConfigSwitch {
                         text: model.label
                         checked: model.enabled
+                        opacity: model.label === "" ? 0 : 1
 
                         function removeMonitor() {
                             var screenList = Config.options.bar.screenList;

--- a/.config/quickshell/modules/settings/InterfaceConfig.qml
+++ b/.config/quickshell/modules/settings/InterfaceConfig.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QuickShell.Hyprland
+import Quickshell.Hyprland
 import "root:/services/"
 import "root:/modules/common/"
 import "root:/modules/common/widgets/"


### PR DESCRIPTION
## Describe your changes
Title is pretty self explanatory but I'll write it anyway.

- Adds a component called `ConfigGrid` which is essentially just `ConfigRow` but it uses `GridLayout` instead of `RowLayout`.
- Adds a monitor subsection to the bar section that implements `Config.options.bar.screenList` so you can toggle which monitor has a bar.

## Screenshots
With two monitors:
![image](https://github.com/user-attachments/assets/51fb78a5-ef5f-4800-bc77-5bd3fc517515)

With one monitor:
![image](https://github.com/user-attachments/assets/6da79c6d-4cc5-4d13-9a2e-8b2e666b80cd)

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready?
I believe so. I'm currently using it and it's working pretty well.

I also tested it by resetting the `screenList` in `~/.config/illogical-impulse/config.json` and it worked. 

## Questions/feedback needed?
I'm not too great with styling stuff, and this is my first time messing with QML. So let me know if I can improve on it in anway.

