### PR TITLE
feat: add option to ignore conflicting files

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -203,10 +203,11 @@ handle_file_conflict() {
   echo "4) Save repository version as ${filename}.new, keep local file"
   echo "5) Show diff and decide"
   echo "6) Skip this file"
+  echo "7) Add to ignore and skip"
   echo
 
   while true; do
-    if ! safe_read "Enter your choice (1-6): " choice "6"; then
+    if ! safe_read "Enter your choice (1-7): " choice "6"; then
       echo
       log_warning "Failed to read input. Skipping file."
       return
@@ -242,8 +243,9 @@ handle_file_conflict() {
       echo "b) Backup local and use repository version"
       echo "n) Save repository version as .new"
       echo "s) Skip this file"
+      echo "i) Add to ignore and skip"
 
-      if ! safe_read "Enter your choice (r/k/b/n/s): " subchoice "s"; then
+      if ! safe_read "Enter your choice (r/k/b/n/s/i): " subchoice "s"; then
         echo
         log_warning "Failed to read input. Skipping file."
         return
@@ -274,6 +276,12 @@ handle_file_conflict() {
         log_info "Skipping $home_file"
         break
         ;;
+      i)
+        local relative_path_to_home="${home_file#$HOME/}"
+        echo "$relative_path_to_home" >>"$HOME_UPDATE_IGNORE_FILE"
+        log_success "Added '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE and skipped."
+        break
+        ;;
       *)
         echo "Invalid choice. Please try again."
         ;;
@@ -283,8 +291,14 @@ handle_file_conflict() {
       log_info "Skipping $home_file"
       break
       ;;
+    7)
+      local relative_path_to_home="${home_file#$HOME/}"
+      echo "$relative_path_to_home" >>"$HOME_UPDATE_IGNORE_FILE"
+      log_success "Added '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE and skipped."
+      break
+      ;;
     *)
-      echo "Invalid choice. Please enter 1-6."
+      echo "Invalid choice. Please enter 1-7."
       ;;
     esac
   done


### PR DESCRIPTION
## Describe your changes

This change enhances the `update.sh` script to better handle conflicts with user-modified configuration files.


When a file conflict occurs during an update, it's often because the user has intentionally made personal modifications that they want to keep. When prompted to resolve a conflict, the user can now select "7) Add to ignore and skip". This action appends the file's path to the update ignore list, preventing it from being overwritten in all future updates.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Ready for review. Feedback is welcome
