### PR TITLE
Pr

### DIFF
--- a/.config/kde-material-you-colors/config.conf
+++ b/.config/kde-material-you-colors/config.conf
@@ -10,7 +10,7 @@ monitor = 0
 
 # File containing absolute path of an image (Takes precedence over automatic wallpaper detection)
 # Commented by default
-file = ~/.local/state/quickshell/user/wallpaper.txt
+file = ~/.local/state/quickshell/user/generated/wallpaper/path.txt
 
 # List of 7 space separated colors (hex or rgb) to be used for text in pywal/konsole/KSyntaxHighlighting instead of wallpaper ones
 # Accepted values are hex e.g #ff0000 and rgb e.g 255,0,0 colors (rgb is converted to hex)

--- a/.config/kde-material-you-colors/config.conf
+++ b/.config/kde-material-you-colors/config.conf
@@ -10,7 +10,7 @@ monitor = 0
 
 # File containing absolute path of an image (Takes precedence over automatic wallpaper detection)
 # Commented by default
-file = /home/end/.local/state/quickshell/user/wallpaper.txt
+file = ~/.local/state/quickshell/user/wallpaper.txt
 
 # List of 7 space separated colors (hex or rgb) to be used for text in pywal/konsole/KSyntaxHighlighting instead of wallpaper ones
 # Accepted values are hex e.g #ff0000 and rgb e.g 255,0,0 colors (rgb is converted to hex)

--- a/.config/qt6ct/qt6ct.conf
+++ b/.config/qt6ct/qt6ct.conf
@@ -1,5 +1,5 @@
 [Appearance]
-color_scheme_path=/home/end/.config/qt6ct/style-colors.conf
+color_scheme_path=~/.config/qt6ct/style-colors.conf
 custom_palette=true
 icon_theme=OneUI
 standard_dialogs=default


### PR DESCRIPTION
in qt6ct config and kde-material-you-colors there were two paths that had "/home/end" which ive changed to ~

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Theres something weird, I saw that kde-material-you-colors was checking for a "wallpaper.txt" which did not exist, i assume that the correct path would be " ~/.local/state/quickshell/user/generated/wallpaper/path.txt" but kde-material-you-colors says that the file does not exist for some reason

please correct me if im wrong in any way, I just thought that I would reach out
I can make a separate PR for the qt6ct path if wanted!

best regards,
mrcxlinux

