### PR TITLE
Round corner transparency of hug style bar

### DIFF
--- a/.config/quickshell/ii/modules/bar/Bar.qml
+++ b/.config/quickshell/ii/modules/bar/Bar.qml
@@ -530,7 +530,6 @@ Scope {
 
                         size: Appearance.rounding.screenRounding
                         color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
-                        opacity: 1.0 - Appearance.transparency
 
                         corner: RoundCorner.CornerEnum.TopLeft
                         states: State {
@@ -550,7 +549,6 @@ Scope {
                         }
                         size: Appearance.rounding.screenRounding
                         color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
-                        opacity: 1.0 - Appearance.transparency
 
                         corner: RoundCorner.CornerEnum.TopRight
                         states: State {


### PR DESCRIPTION
## Describe your changes
This make the round corners of hug style bar have the same transparency with bar, uhh it just a slightly different...
I remerber that it was me introduce this trick before...It seems that it was caused by bug, now the bar.qml is refactored, it is ok to remove it.
Thanks a lot!

## Is it ready? Questions/feedback needed?
I think it's ready

