### PR TITLE
Todo list add editing

### DIFF
--- a/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
@@ -1,8 +1,7 @@
 import QtQuick 2.15
 
 Item {
-    property int totalIndex // The index for both lists together (as stored in file)
-    property int listIndex // The index in its own unfinished/done list
+    property int index
     property bool done
     property string currentText
 }

--- a/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
@@ -1,7 +1,0 @@
-import QtQuick 2.15
-
-Item {
-    property int index
-    property bool done
-    property string currentText
-}

--- a/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/EditingCallbackInfo.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+
+Item {
+    property int totalIndex // The index for both lists together (as stored in file)
+    property int listIndex // The index in its own unfinished/done list
+    property bool done
+    property string currentText
+}

--- a/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
@@ -49,7 +49,6 @@ Item {
                     property bool pendingDelete: false
                     property bool enableHeightAnimation: false
                     property bool enableFading: false
-                    property EditingCallbackInfo editingCallbackInfo: EditingCallbackInfo {}
 
                     Layout.fillWidth: true
                     implicitHeight: todoItemRectangle.implicitHeight + todoListItemSpacing
@@ -93,17 +92,14 @@ Item {
                         interval: Appearance.animation.elementMoveFast.duration
                         repeat: false
                         onTriggered: {
-                            todoRepeater.fadingInIndexes = [] // Clears the list every time a button is pressed to prevent it being filled indefinitely
+                            todoRepeater.fadingInIndexes = [] // Clears the list every time a button is pressed to prevent it from being filled by canceled edits
                             if (todoItem.pendingDoneToggle) {
                                 todoItem.pendingDoneToggle = false
                                 if (!modelData.done) Todo.markDone(modelData.originalIndex)
                                 else Todo.markUnfinished(modelData.originalIndex)
                             } else if (todoItem.pendingEdit) {
                                 todoItem.pendingEdit = false
-                                todoItem.editingCallbackInfo.index = modelData.originalIndex
-                                todoItem.editingCallbackInfo.done = modelData.done
-                                todoItem.editingCallbackInfo.currentText = modelData.content
-                                root.editingCallback(todoItem.editingCallbackInfo)
+                                root.editingCallback(modelData)
                                 todoRepeater.fadingInIndexes.push(model.index) // Adds to list even when edit is canceled
                             } else if (todoItem.pendingDelete) {
                                 todoItem.pendingDelete = false

--- a/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
@@ -93,6 +93,7 @@ Item {
                         interval: Appearance.animation.elementMoveFast.duration
                         repeat: false
                         onTriggered: {
+                            todoRepeater.fadingInIndexes = [] // Clears the list every time a button is pressed to prevent it being filled indefinitely
                             if (todoItem.pendingDoneToggle) {
                                 todoItem.pendingDoneToggle = false
                                 if (!modelData.done) Todo.markDone(modelData.originalIndex)
@@ -103,7 +104,7 @@ Item {
                                 todoItem.editingCallbackInfo.done = modelData.done
                                 todoItem.editingCallbackInfo.currentText = modelData.content
                                 root.editingCallback(todoItem.editingCallbackInfo)
-                                todoRepeater.fadingInIndexes.push(model.index)
+                                todoRepeater.fadingInIndexes.push(model.index) // Adds to list even when edit is canceled
                             } else if (todoItem.pendingDelete) {
                                 todoItem.pendingDelete = false
                                 Todo.deleteItem(modelData.originalIndex)
@@ -191,8 +192,8 @@ Item {
                     for (let i = 0; i < fadingInIndexes.length; i++) {
                         if (fadingInIndexes[i] == index) {
                             fadingInIndexes.splice(i, 1)
+                            i--
                             item.fadeIn()
-                            break
                         }
                     }
                 }

--- a/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
@@ -232,8 +232,4 @@ Item {
             }
         }
     }
-
-    function fadeInTodoItem(index) {
-        todoRepeater.itemAt(index).fadeIn()
-    }
 }

--- a/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
@@ -38,6 +38,7 @@ Item {
             spacing: 0
             Repeater {
                 id: todoRepeater
+                property list<int> fadingInIndexes: []
                 model: ScriptModel {
                     values: taskList
                 }
@@ -98,11 +99,11 @@ Item {
                                 else Todo.markUnfinished(modelData.originalIndex)
                             } else if (todoItem.pendingEdit) {
                                 todoItem.pendingEdit = false
-                                todoItem.editingCallbackInfo.totalIndex = modelData.originalIndex
-                                todoItem.editingCallbackInfo.listIndex = model.index
+                                todoItem.editingCallbackInfo.index = modelData.originalIndex
                                 todoItem.editingCallbackInfo.done = modelData.done
                                 todoItem.editingCallbackInfo.currentText = modelData.content
                                 root.editingCallback(todoItem.editingCallbackInfo)
+                                todoRepeater.fadingInIndexes.push(model.index)
                             } else if (todoItem.pendingDelete) {
                                 todoItem.pendingDelete = false
                                 Todo.deleteItem(modelData.originalIndex)
@@ -186,6 +187,15 @@ Item {
                     }
                 }
 
+                onItemAdded: function(index, item) {
+                    for (let i = 0; i < fadingInIndexes.length; i++) {
+                        if (fadingInIndexes[i] == index) {
+                            fadingInIndexes.splice(i, 1)
+                            item.fadeIn()
+                            break
+                        }
+                    }
+                }
             }
             // Bottom padding
             Item {

--- a/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
@@ -13,7 +13,7 @@ Item {
     property var tabButtonList: [{"icon": "checklist", "name": qsTr("Unfinished")}, {"name": qsTr("Done"), "icon": "check_circle"}]
     property bool showAddDialog: false
     property bool showEditDialog: false
-    property var editingCallbackInfo
+    property var todoItemEditingModelData
     property int dialogMargins: 20
     property int fabSize: 48
     property int fabMargins: 14
@@ -36,7 +36,7 @@ Item {
         else if (event.key === Qt.Key_Escape && (root.showAddDialog || root.showEditDialog)) {
             root.showAddDialog = false
             root.showEditDialog = false
-            root.editingCallbackInfo = undefined
+            root.todoItemEditingModelData = undefined
             event.accepted = true;
         }
     }
@@ -236,10 +236,10 @@ Item {
 
             function editTask() {
                 if (todoInput.text.length > 0) {
-                    Todo.editTask(root.editingCallbackInfo.index, root.editingCallbackInfo.done, todoInput.text)
+                    Todo.editTask(root.todoItemEditingModelData.originalIndex, root.todoItemEditingModelData.done, todoInput.text)
                     todoInput.text = ""
                     root.showEditDialog = false
-                    root.editingCallbackInfo = undefined
+                    root.todoItemEditingModelData = undefined
                 }
             }
 
@@ -301,12 +301,12 @@ Item {
                         onClicked: {
                             root.showAddDialog = false
                             root.showEditDialog = false
-                            root.editingCallbackInfo = undefined
+                            root.todoItemEditingModelData = undefined
                         }
                     }
                     DialogButton {
                         buttonText: root.showAddDialog ? qsTr("Add") : qsTr("Edit")
-                        enabled: todoInput.text.length > 0 && (root.showAddDialog || todoInput.text != root.editingCallbackInfo?.currentText)
+                        enabled: todoInput.text.length > 0 && (root.showAddDialog || todoInput.text != root.todoItemEditingModelData?.content)
                         onClicked: root.showAddDialog ? dialog.addTask() : dialog.editTask()
                     }
                 }
@@ -314,9 +314,9 @@ Item {
         }
     }
 
-    function editingCallback(editingCallbackInfo) {
-        root.editingCallbackInfo = editingCallbackInfo
-        todoInput.text = editingCallbackInfo.currentText
+    function editingCallback(todoItemEditingModelData) {
+        root.todoItemEditingModelData = todoItemEditingModelData
+        todoInput.text = todoItemEditingModelData.content
         root.showEditDialog = true
     }
 }

--- a/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TodoWidget.qml
@@ -236,16 +236,9 @@ Item {
 
             function editTask() {
                 if (todoInput.text.length > 0) {
-                    Todo.editTask(root.editingCallbackInfo.totalIndex, root.editingCallbackInfo.done, todoInput.text)
+                    Todo.editTask(root.editingCallbackInfo.index, root.editingCallbackInfo.done, todoInput.text)
                     todoInput.text = ""
                     root.showEditDialog = false
-                    
-                    if (root.editingCallbackInfo.done) {
-                        doneTaskList.fadeInTodoItem(root.editingCallbackInfo.listIndex)
-                    } else {
-                        unfinishedTaskList.fadeInTodoItem(root.editingCallbackInfo.listIndex)
-                    }
-
                     root.editingCallbackInfo = undefined
                 }
             }

--- a/.config/quickshell/services/Todo.qml
+++ b/.config/quickshell/services/Todo.qml
@@ -31,6 +31,17 @@ Singleton {
         addItem(item)
     }
 
+    function editTask(index, done, new_desc) {
+        const item = {
+            "content": new_desc,
+            "done": done,
+        }
+        root.list[index] = item
+        // Reassign to trigger onListChanged
+        root.list = list.slice(0)
+        todoFileView.setText(JSON.stringify(root.list))
+    }
+
     function markDone(index) {
         if (index >= 0 && index < list.length) {
             list[index].done = true
@@ -85,4 +96,3 @@ Singleton {
         }
     }
 }
-


### PR DESCRIPTION
## Describe your changes
Adds a button to the todo list items, so they can be edited. Works for done items as well.
Shows a fade-in animation when edited, so it's clear which item was edited.
Has the same dialog as 'Add Task', but is called 'Edit Task'. The 'Edit' button is only enabled when the text is edited.

<img width="345" height="140" alt="editable_task" src="https://github.com/user-attachments/assets/e66a0d73-9642-44f4-9a08-84e973c63c70" /><br/>
<img width="330" height="340" alt="edit_dialog" src="https://github.com/user-attachments/assets/12c12fc1-fc80-403b-a1fe-6180b03114b7" /><br/>
<img width="330" height="340" alt="edit_dialog_button_enabled" src="https://github.com/user-attachments/assets/bf00f96b-de9a-4006-8996-9a81226fc240" />

## Is it ready? Questions/feedback needed?
1. Perhaps the 'Add Task' action could have the same fade-in animation to create a more consistent appearance for all actions.
2. I'll add another PR soon which allows for todo list ordering. They'll have overlapping code. Might be easier to merge them at the same time.