### PR TITLE
Todo list task ordering

### DIFF
--- a/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
+++ b/.config/quickshell/modules/sidebarRight/todo/TaskList.qml
@@ -41,6 +41,10 @@ Item {
                 }
                 delegate: Item {
                     id: todoItem
+                    property bool pendingTopToggle: false
+                    property bool pendingUpToggle: false
+                    property bool pendingDownToggle: false
+                    property bool pendingBottomToggle: false
                     property bool pendingDoneToggle: false
                     property bool pendingDelete: false
                     property bool enableHeightAnimation: false
@@ -59,9 +63,12 @@ Item {
                         }
                     }
 
-                    function startAction() {
-                        enableHeightAnimation = true
-                        todoItem.implicitHeight = 0
+                    function startAction(showCloseAnimation) {
+                        if (showCloseAnimation) {
+                            enableHeightAnimation = true
+                            todoItem.implicitHeight = 0
+                        }
+                        
                         actionTimer.start()
                     }
 
@@ -70,11 +77,25 @@ Item {
                         interval: Appearance.animation.elementMoveFast.duration
                         repeat: false
                         onTriggered: {
-                            if (todoItem.pendingDelete) {
-                                Todo.deleteItem(modelData.originalIndex)
+                            if (todoItem.pendingTopToggle) {
+                                todoItem.pendingTopToggle = false
+                                Todo.moveTop(modelData.originalIndex)
+                            } else if (todoItem.pendingUpToggle) {
+                                todoItem.pendingUpToggle = false
+                                Todo.moveUp(modelData.originalIndex)
+                            } else if (todoItem.pendingDownToggle) {
+                                todoItem.pendingDownToggle = false
+                                Todo.moveDown(modelData.originalIndex)
+                            } else if (todoItem.pendingBottomToggle) {
+                                todoItem.pendingBottomToggle = false
+                                Todo.moveBottom(modelData.originalIndex)
                             } else if (todoItem.pendingDoneToggle) {
+                                todoItem.pendingDoneToggle = false
                                 if (!modelData.done) Todo.markDone(modelData.originalIndex)
                                 else Todo.markUnfinished(modelData.originalIndex)
+                            } else if (todoItem.pendingDelete) {
+                                todoItem.pendingDelete = false
+                                Todo.deleteItem(modelData.originalIndex)
                             }
                         }
                     }
@@ -105,6 +126,66 @@ Item {
                                 Layout.leftMargin: 10
                                 Layout.rightMargin: 10
                                 Layout.bottomMargin: todoListItemPadding
+                                TodoItemActionButton {
+                                    visible: root.taskList.length > 1
+                                    Layout.fillWidth: false
+                                    onClicked: {
+                                        todoItem.pendingTopToggle = true
+                                        todoItem.startAction(false)
+                                    }
+                                    contentItem: MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        text: "keyboard_double_arrow_up"
+                                        iconSize: Appearance.font.pixelSize.larger
+                                        color: Appearance.colors.colOnLayer1
+                                    }
+                                }
+                                TodoItemActionButton {
+                                    visible: root.taskList.length > 1
+                                    Layout.fillWidth: false
+                                    onClicked: {
+                                        todoItem.pendingUpToggle = true
+                                        todoItem.startAction(false)
+                                    }
+                                    contentItem: MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        text: "keyboard_arrow_up"
+                                        iconSize: Appearance.font.pixelSize.larger
+                                        color: Appearance.colors.colOnLayer1
+                                    }
+                                }
+                                TodoItemActionButton {
+                                    visible: root.taskList.length > 1
+                                    Layout.fillWidth: false
+                                    onClicked: {
+                                        todoItem.pendingDownToggle = true
+                                        todoItem.startAction(false)
+                                    }
+                                    contentItem: MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        text: "keyboard_arrow_down"
+                                        iconSize: Appearance.font.pixelSize.larger
+                                        color: Appearance.colors.colOnLayer1
+                                    }
+                                }
+                                TodoItemActionButton {
+                                    visible: root.taskList.length > 1
+                                    Layout.fillWidth: false
+                                    onClicked: {
+                                        todoItem.pendingBottomToggle = true
+                                        todoItem.startAction(false)
+                                    }
+                                    contentItem: MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        text: "keyboard_double_arrow_down"
+                                        iconSize: Appearance.font.pixelSize.larger
+                                        color: Appearance.colors.colOnLayer1
+                                    }
+                                }
                                 Item {
                                     Layout.fillWidth: true
                                 }
@@ -112,7 +193,7 @@ Item {
                                     Layout.fillWidth: false
                                     onClicked: {
                                         todoItem.pendingDoneToggle = true
-                                        todoItem.startAction()
+                                        todoItem.startAction(true)
                                     }
                                     contentItem: MaterialSymbol {
                                         anchors.centerIn: parent
@@ -126,7 +207,7 @@ Item {
                                     Layout.fillWidth: false
                                     onClicked: {
                                         todoItem.pendingDelete = true
-                                        todoItem.startAction()
+                                        todoItem.startAction(true)
                                     }
                                     contentItem: MaterialSymbol {
                                         anchors.centerIn: parent

--- a/.config/quickshell/services/Todo.qml
+++ b/.config/quickshell/services/Todo.qml
@@ -31,6 +31,64 @@ Singleton {
         addItem(item)
     }
 
+    function moveTop(current_index) {
+        var item = list[current_index]
+        list.splice(current_index, 1)
+        list.unshift(item)
+
+        // Reassign to trigger onListChanged
+        root.list = list.slice(0)
+        todoFileView.setText(JSON.stringify(root.list))
+    }
+
+    function moveUp(current_index) {
+        var item = list[current_index]
+
+        for (var i = current_index - 1; i >= 0; i--) {
+            var next_item = list[i]
+            list[i] = item
+            list[current_index] = next_item
+
+            current_index = i
+            if (next_item.done == item.done) {
+                break
+            }
+        }
+
+        // Reassign to trigger onListChanged
+        root.list = list.slice(0)
+        todoFileView.setText(JSON.stringify(root.list))
+    }
+
+    function moveDown(current_index) {
+        var item = list[current_index]
+
+        for (var i = current_index + 1; i < list.length; i++) {
+            var next_item = list[i]
+            list[i] = item
+            list[current_index] = next_item
+
+            current_index = i
+            if (next_item.done == item.done) {
+                break
+            }
+        }
+
+        // Reassign to trigger onListChanged
+        root.list = list.slice(0)
+        todoFileView.setText(JSON.stringify(root.list))
+    }
+
+    function moveBottom(current_index) {
+        var item = list[current_index]
+        list.splice(current_index, 1)
+        list.push(item)
+
+        // Reassign to trigger onListChanged
+        root.list = list.slice(0)
+        todoFileView.setText(JSON.stringify(root.list))
+    }
+
     function markDone(index) {
         if (index >= 0 && index < list.length) {
             list[index].done = true

--- a/.config/quickshell/services/Todo.qml
+++ b/.config/quickshell/services/Todo.qml
@@ -31,9 +31,9 @@ Singleton {
         addItem(item)
     }
 
-    function moveTop(current_index) {
-        var item = list[current_index]
-        list.splice(current_index, 1)
+    function moveTop(index) {
+        let item = list[index]
+        list.splice(index, 1)
         list.unshift(item)
 
         // Reassign to trigger onListChanged
@@ -41,16 +41,16 @@ Singleton {
         todoFileView.setText(JSON.stringify(root.list))
     }
 
-    function moveUp(current_index) {
-        var item = list[current_index]
+    function moveUp(index) {
+        let item = list[index]
 
-        for (var i = current_index - 1; i >= 0; i--) {
-            var next_item = list[i]
+        for (let i = index - 1; i >= 0; i--) {
+            let nextItem = list[i]
             list[i] = item
-            list[current_index] = next_item
+            list[index] = nextItem
 
-            current_index = i
-            if (next_item.done == item.done) {
+            index = i
+            if (nextItem.done == item.done) {
                 break
             }
         }
@@ -60,16 +60,16 @@ Singleton {
         todoFileView.setText(JSON.stringify(root.list))
     }
 
-    function moveDown(current_index) {
-        var item = list[current_index]
+    function moveDown(index) {
+        let item = list[index]
 
-        for (var i = current_index + 1; i < list.length; i++) {
-            var next_item = list[i]
+        for (let i = index + 1; i < list.length; i++) {
+            let nextItem = list[i]
             list[i] = item
-            list[current_index] = next_item
+            list[index] = nextItem
 
-            current_index = i
-            if (next_item.done == item.done) {
+            index = i
+            if (nextItem.done == item.done) {
                 break
             }
         }
@@ -79,9 +79,9 @@ Singleton {
         todoFileView.setText(JSON.stringify(root.list))
     }
 
-    function moveBottom(current_index) {
-        var item = list[current_index]
-        list.splice(current_index, 1)
+    function moveBottom(index) {
+        let item = list[index]
+        list.splice(index, 1)
         list.push(item)
 
         // Reassign to trigger onListChanged


### PR DESCRIPTION
## Describe your changes
Adds 4 buttons to the todo list items, so they can be ordered. Move to top, move up, move down, move to bottom.
The buttons only show when at least 2 items are in the combined list. Which is the list that keeps both the unfinished and done items.
Moving an item to the top, moves it to the top of the combined list. Same for moving to the bottom.
Moving an item up, moves it up until it moves above the first item in its separated list. Same for moving down.
After an item has moved within its separated list, it will show a fade-in animation. This animation will not be shown when the item moves within the combined list, without moving within its separated list.

<img width="340" height="140" alt="non_orderable_item" src="https://github.com/user-attachments/assets/8a82e0b3-8745-4f53-9716-189ce99ff12d" /><br/>
<img width="340" height="200" alt="orderable_item" src="https://github.com/user-attachments/assets/ec8ecff6-7fec-4c40-ade0-1c73d24e64b0" />

## Is it ready? Questions/feedback needed?
1. The only little bug that I've noticed occurs when an item is moved in the combined list without being moved in its separated list. When the button to move the item is pressed, a button press animation is shown which is cut off a little too early.
2. See #1620 which has overlapping code.