### PR TITLE
Right sidebar: restore last viewed bottom widget

### DIFF
--- a/.config/quickshell/modules/common/Config.qml
+++ b/.config/quickshell/modules/common/Config.qml
@@ -206,6 +206,9 @@ Singleton {
                         property string username: "[unset]"
                     }
                 }
+                property JsonObject bottomWidgetRight: JsonObject {
+                    property int lastTab: 0
+                }
             }
 
             property JsonObject time: JsonObject {

--- a/.config/quickshell/modules/common/Config.qml
+++ b/.config/quickshell/modules/common/Config.qml
@@ -206,9 +206,6 @@ Singleton {
                         property string username: "[unset]"
                     }
                 }
-                property JsonObject bottomWidgetRight: JsonObject {
-                    property int lastTab: 0
-                }
             }
 
             property JsonObject time: JsonObject {

--- a/.config/quickshell/modules/common/Persistent.qml
+++ b/.config/quickshell/modules/common/Persistent.qml
@@ -36,6 +36,7 @@ Singleton {
             property JsonObject sidebar: JsonObject {
                 property JsonObject bottomGroup: JsonObject {
                     property bool collapsed: false
+                    property int tab: 0
                 }
             }
 

--- a/.config/quickshell/modules/common/PersistentStates.qml
+++ b/.config/quickshell/modules/common/PersistentStates.qml
@@ -12,6 +12,7 @@ Singleton {
     property QtObject sidebar: QtObject {
         property QtObject bottomGroup: QtObject {
             property bool collapsed: false
+            property int tab: 0
         }
     }
 

--- a/.config/quickshell/modules/sidebarRight/BottomWidgetGroup.qml
+++ b/.config/quickshell/modules/sidebarRight/BottomWidgetGroup.qml
@@ -14,7 +14,7 @@ Rectangle {
     color: Appearance.colors.colLayer1
     clip: true
     implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : bottomWidgetGroupRow.implicitHeight
-    property int selectedTab: 0
+    property int selectedTab: Config.options.sidebar.bottomWidgetRight.lastTab
     property bool collapsed: Persistent.states.sidebar.bottomGroup.collapsed
     property var tabs: [
         {"type": "calendar", "name": "Calendar", "icon": "calendar_month", "widget": calendarWidget}, 
@@ -146,6 +146,7 @@ Rectangle {
                         buttonIcon: modelData.icon
                         onClicked: {
                             root.selectedTab = index
+                            Config.options.sidebar.bottomWidgetRight.lastTab = index
                         }
                     }
                 }
@@ -171,9 +172,10 @@ Rectangle {
         StackLayout {
             id: tabStack
             Layout.fillWidth: true
-            height: tabStack.children[0]?.tabLoader?.implicitHeight // TODO: make this less stupid
+            // Take the highest one, because the TODO list has no implicit height. This way the heigth of the calendar is used when it's initially loaded with the TODO list
+            height: Math.max(...tabStack.children.map(child => child.tabLoader?.implicitHeight || 0)) // TODO: make this less stupid
             Layout.alignment: Qt.AlignVCenter
-            property int realIndex: 0
+            property int realIndex: root.selectedTab
             property int animationDuration: Appearance.animation.elementMoveFast.duration * 1.5
 
             // Switch the tab on halfway of the anim duration
@@ -214,6 +216,10 @@ Rectangle {
                         focus: root.selectedTab === tabItem.tabIndex
                     }
                 }
+            }
+
+            Component.onCompleted: {
+                tabStack.currentIndex = root.selectedTab
             }
         }
     }

--- a/.config/quickshell/modules/sidebarRight/BottomWidgetGroup.qml
+++ b/.config/quickshell/modules/sidebarRight/BottomWidgetGroup.qml
@@ -14,7 +14,7 @@ Rectangle {
     color: Appearance.colors.colLayer1
     clip: true
     implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : bottomWidgetGroupRow.implicitHeight
-    property int selectedTab: Config.options.sidebar.bottomWidgetRight.lastTab
+    property int selectedTab: Persistent.states.sidebar.bottomGroup.tab
     property bool collapsed: Persistent.states.sidebar.bottomGroup.collapsed
     property var tabs: [
         {"type": "calendar", "name": "Calendar", "icon": "calendar_month", "widget": calendarWidget}, 
@@ -146,7 +146,7 @@ Rectangle {
                         buttonIcon: modelData.icon
                         onClicked: {
                             root.selectedTab = index
-                            Config.options.sidebar.bottomWidgetRight.lastTab = index
+                            Persistent.states.sidebar.bottomGroup.tab = index
                         }
                     }
                 }


### PR DESCRIPTION
## Describe your changes
Reopens the last used tab of the right sidebar bottom widget. A.k.a. doesn't close the todo list when right sidebar is collapsed. Fade animations aren't impacted by this PR.

## Is it ready? Questions/feedback needed?
Completely ready.