### PR TITLE
Bar: Dynamic width of utility widget

### DIFF
--- a/.config/quickshell/ii/modules/bar/Bar.qml
+++ b/.config/quickshell/ii/modules/bar/Bar.qml
@@ -227,7 +227,10 @@ Scope {
 
                     RowLayout { // Middle section
                         id: middleSection
-                        anchors.centerIn: parent
+                        anchors {
+                            centerIn: parent
+                            horizontalCenterOffset: (rightCenterGroup.implicitWidth + (Config.options.bar.weather.enable ? weatherGroup.implicitWidth + spacing : 0) - barRoot.centerSideModuleWidth) / 2
+                        }
                         spacing: Config.options?.bar.borderless ? 4 : 8
 
                         BarGroup {
@@ -281,7 +284,6 @@ Scope {
                             id: rightCenterGroup
                             implicitWidth: rightCenterGroupContent.implicitWidth
                             implicitHeight: rightCenterGroupContent.implicitHeight
-                            Layout.preferredWidth: barRoot.centerSideModuleWidth
                             Layout.fillHeight: true
 
                             onPressed: {
@@ -295,7 +297,8 @@ Scope {
                                 ClockWidget {
                                     showDate: (Config.options.bar.verbose && barRoot.useShortenedForm < 2)
                                     Layout.alignment: Qt.AlignVCenter
-                                    Layout.fillWidth: true
+                                    Layout.leftMargin: 8
+                                    Layout.rightMargin: 8
                                 }
 
                                 UtilButtons {
@@ -312,6 +315,20 @@ Scope {
 
                         VerticalBarSeparator {
                             visible: Config.options.bar.borderless && Config.options.bar.weather.enable
+                        }
+
+                        // Weather
+                        BarGroup {
+                            id: weatherGroup
+                            visible: Config.options.bar.weather.enable
+                            implicitHeight: Appearance.sizes.baseBarHeight
+
+                            Loader {
+                                id: weatherLoader
+                                Layout.fillHeight: true
+                                active: Config.options.bar.weather.enable
+                                sourceComponent: WeatherBar {}
+                            }
                         }
                     }
 
@@ -484,17 +501,6 @@ Scope {
                                 Item {
                                     Layout.fillWidth: true
                                     Layout.fillHeight: true
-                                }
-
-                                // Weather
-                                Loader {
-                                    Layout.leftMargin: 8
-                                    Layout.fillHeight: true
-                                    active: Config.options.bar.weather.enable
-                                    sourceComponent: BarGroup {
-                                        implicitHeight: Appearance.sizes.baseBarHeight
-                                        WeatherBar {}
-                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Describe your changes
This change makes the utility widget have a dynamic width that adjusts according to the number of enabled utility buttons. As the width of the utility widget changes, the widget expands to the right, pushing the weather widget aside.

## Is it ready? Questions/feedback needed?
There may be a potential issue related to hard-coded values. To keep the workspaces widget centered, the layout calculation currently relies on the presence and size of other widgets like the weather widget.
Besides that, it looks ok.
