### PR TITLE
hyprland: add window rules for xdg-portal file dialogs

### DIFF
--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -58,6 +58,8 @@ windowrulev2 = center, title:^(Open Folder)(.*)$
 windowrulev2 = center, title:^(Save As)(.*)$
 windowrulev2 = center, title:^(Library)(.*)$
 windowrulev2 = center, title:^(File Upload)(.*)$
+windowrulev2 = center, title:^(.*)(wants to save)$
+windowrulev2 = center, title:^(.*)(wants to open)$
 windowrulev2 = float, title:^(Open File)(.*)$
 windowrulev2 = float, title:^(Select a File)(.*)$
 windowrulev2 = float, title:^(Choose wallpaper)(.*)$
@@ -65,6 +67,8 @@ windowrulev2 = float, title:^(Open Folder)(.*)$
 windowrulev2 = float, title:^(Save As)(.*)$
 windowrulev2 = float, title:^(Library)(.*)$
 windowrulev2 = float, title:^(File Upload)(.*)$
+windowrulev2 = float, title:^(.*)(wants to save)$
+windowrulev2 = float, title:^(.*)(wants to open)$
 
 
 # --- Tearing ---


### PR DESCRIPTION
## Describe your changes
Added new windowrulev2 entries to float and center file picker dialogs with titles like "wants to save" and "wants to open".

eg; drive.google.com wants to save
       drive.google.com wants to open

## Is it ready? Questions/feedback needed?
Yes, it's ready.
