### PR TITLE
feat: power-profile switcher in topbar

### DIFF
--- a/.config/quickshell/ii/modules/bar/UtilButtons.qml
+++ b/.config/quickshell/ii/modules/bar/UtilButtons.qml
@@ -104,5 +104,38 @@ Item {
                 }
             }
         }
+
+        Loader {
+            active: Config.options.bar.utilButtons.showPerfProfileToggle
+            visible: Config.options.bar.utilButtons.showPerfProfileToggle
+            sourceComponent: CircleUtilButton {
+                Layout.alignment: Qt.AlignVCenter
+                onClicked: event => {
+                    if (PowerProfiles.hasPerformanceProfile) {
+                        switch(PowerProfiles.profile) {
+                            case PowerProfile.PowerSaver: PowerProfiles.profile = PowerProfile.Balanced
+                            break;
+                            case PowerProfile.Balanced: PowerProfiles.profile = PowerProfile.Performance
+                            break;
+                            case PowerProfile.Performance: PowerProfiles.profile = PowerProfile.PowerSaver
+                            break;
+                        }
+                    } else {
+                        PowerProfiles.profile = PowerProfiles.profile == PowerProfile.Balanced ? PowerProfile.PowerSaver : PowerProfile.Balanced
+                    }
+                }
+                MaterialSymbol {
+                    horizontalAlignment: Qt.AlignHCenter
+                    fill: 0
+                    text: switch(PowerProfiles.profile) {
+                        case PowerProfile.PowerSaver: return "battery_saver"
+                        case PowerProfile.Balanced: return "balance"
+                        case PowerProfile.Performance: return "speed"
+                    }
+                    iconSize: Appearance.font.pixelSize.large
+                    color: Appearance.colors.colOnLayer2
+                }
+            }
+        }
     }
 }

--- a/.config/quickshell/ii/modules/bar/UtilButtons.qml
+++ b/.config/quickshell/ii/modules/bar/UtilButtons.qml
@@ -1,5 +1,5 @@
-import "root:/modules/common"
-import "root:/modules/common/widgets"
+import qs.modules.common
+import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
@@ -107,8 +107,8 @@ Item {
         }
 
         Loader {
-            active: Config.options.bar.utilButtons.showPerfProfileToggle
-            visible: Config.options.bar.utilButtons.showPerfProfileToggle
+            active: Config.options.bar.utilButtons.showPerformanceProfileToggle
+            visible: Config.options.bar.utilButtons.showPerformanceProfileToggle
             sourceComponent: CircleUtilButton {
                 Layout.alignment: Qt.AlignVCenter
                 onClicked: event => {

--- a/.config/quickshell/ii/modules/bar/UtilButtons.qml
+++ b/.config/quickshell/ii/modules/bar/UtilButtons.qml
@@ -130,7 +130,7 @@ Item {
                     fill: 0
                     text: switch(PowerProfiles.profile) {
                         case PowerProfile.PowerSaver: return "battery_saver"
-                        case PowerProfile.Balanced: return "balance"
+                        case PowerProfile.Balanced: return "dynamic_form"
                         case PowerProfile.Performance: return "speed"
                     }
                     iconSize: Appearance.font.pixelSize.large

--- a/.config/quickshell/ii/modules/bar/UtilButtons.qml
+++ b/.config/quickshell/ii/modules/bar/UtilButtons.qml
@@ -6,6 +6,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Hyprland
 import Quickshell.Services.Pipewire
+import Quickshell.Services.UPower
 
 Item {
     id: root

--- a/.config/quickshell/ii/modules/common/Config.qml
+++ b/.config/quickshell/ii/modules/common/Config.qml
@@ -123,6 +123,7 @@ Singleton {
                     property bool showMicToggle: false
                     property bool showKeyboardToggle: true
                     property bool showDarkModeToggle: true
+                    property bool showPerfProfileToggle: false
                 }
                 property JsonObject tray: JsonObject {
                     property bool monochromeIcons: true

--- a/.config/quickshell/ii/modules/common/Config.qml
+++ b/.config/quickshell/ii/modules/common/Config.qml
@@ -124,7 +124,7 @@ Singleton {
                     property bool showMicToggle: false
                     property bool showKeyboardToggle: true
                     property bool showDarkModeToggle: true
-                    property bool showPerfProfileToggle: false
+                    property bool showPerformanceProfileToggle: false
                 }
                 property JsonObject tray: JsonObject {
                     property bool monochromeIcons: true

--- a/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -164,8 +164,11 @@ ContentPage {
                     }
                 }
                 ConfigSwitch {
-                    opacity: 0
-                    enabled: false
+                    text: "Performance Profile toggle"
+                    checked: Config.options.bar.utilButtons.showPerfProfileToggle
+                    onCheckedChanged: {
+                        Config.options.bar.utilButtons.showPerfProfileToggle = checked;
+                    }
                 }
             }
         }

--- a/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -165,9 +165,9 @@ ContentPage {
                 }
                 ConfigSwitch {
                     text: "Performance Profile toggle"
-                    checked: Config.options.bar.utilButtons.showPerfProfileToggle
+                    checked: Config.options.bar.utilButtons.showPerformanceProfileToggle
                     onCheckedChanged: {
-                        Config.options.bar.utilButtons.showPerfProfileToggle = checked;
+                        Config.options.bar.utilButtons.showPerformanceProfileToggle = checked;
                     }
                 }
             }


### PR DESCRIPTION
## Describe your changes

Adds a power profile toggle to the topbar, using PowerProfiles from quickshell and power-profiles-daemon
Disabled by default

## Is it ready? Questions/feedback needed?

I didn't encounter any bug while testing and it's a pretty simple feature.
I don't really like the js `switch`es in the click event, but as it's a 3-options toggle I didn't really see a better way to implement it, please lmk if I should change that.
