### PR TITLE
Fix monitor offset w/ left-of-center monitors in overview

### DIFF
--- a/.config/quickshell/ii/modules/overview/OverviewWidget.qml
+++ b/.config/quickshell/ii/modules/overview/OverviewWidget.qml
@@ -175,10 +175,8 @@ Item {
 
                     property int workspaceColIndex: (windowData?.workspace.id - 1) % Config.options.overview.columns
                     property int workspaceRowIndex: Math.floor((windowData?.workspace.id - 1) % root.workspacesShown / Config.options.overview.columns)
-                    xOffset: {
-                        return (root.workspaceImplicitWidth + workspaceSpacing) * workspaceColIndex - (monitor?.x * root.scale)
-                    }
-                    yOffset: (root.workspaceImplicitHeight + workspaceSpacing) * workspaceRowIndex - (monitor?.y * root.scale)
+                    xOffset: (root.workspaceImplicitWidth + workspaceSpacing) * workspaceColIndex
+                    yOffset: (root.workspaceImplicitHeight + workspaceSpacing) * workspaceRowIndex
 
                     Timer {
                         id: updateWindowPosition
@@ -186,8 +184,8 @@ Item {
                         repeat: false
                         running: false
                         onTriggered: {
-                            window.x = Math.round(Math.max((windowData?.at[0] - monitorData?.reserved[0]) * root.scale, 0) + xOffset)
-                            window.y = Math.round(Math.max((windowData?.at[1] - monitorData?.reserved[1]) * root.scale, 0) + yOffset)
+                            window.x = Math.round(Math.max((windowData?.at[0] - (monitor?.x ?? 0) - monitorData?.reserved[0]) * root.scale, 0) + xOffset)
+                            window.y = Math.round(Math.max((windowData?.at[1] - (monitor?.y ?? 0) - monitorData?.reserved[1]) * root.scale, 0) + yOffset)
                         }
                     }
 

--- a/.config/quickshell/ii/modules/overview/OverviewWindow.qml
+++ b/.config/quickshell/ii/modules/overview/OverviewWindow.qml
@@ -22,8 +22,8 @@ Item { // Window
     property var availableWorkspaceWidth
     property var availableWorkspaceHeight
     property bool restrictToWorkspace: true
-    property real initX: Math.max((windowData?.at[0] - monitorData?.reserved[0]) * root.scale, 0) + xOffset
-    property real initY: Math.max((windowData?.at[1] - monitorData?.reserved[1]) * root.scale, 0) + yOffset
+    property real initX: Math.max((windowData?.at[0] - (monitorData?.x ?? 0) - monitorData?.reserved[0]) * root.scale, 0) + xOffset
+    property real initY: Math.max((windowData?.at[1] - (monitorData?.y ?? 0) - monitorData?.reserved[1]) * root.scale, 0) + yOffset
     property real xOffset: 0
     property real yOffset: 0
     


### PR DESCRIPTION
## Describe your changes
Fixes the overview window having incorrect monitor offsets when a monitor is left-of-center. This manifests as the window positions not being aligned with the correct workspace on that monitor.

## Is it ready? Questions/feedback needed?
Tested on a triple monitor setup and with dual/single monitors.