### PR TITLE
Properly fix open with menu in KDE

### DIFF
--- a/.config/hypr/hyprland/env.conf
+++ b/.config/hypr/hyprland/env.conf
@@ -12,6 +12,7 @@ env = ELECTRON_OZONE_PLATFORM_HINT,auto
 # ############ Themes #############
 env = QT_QPA_PLATFORM, wayland
 env = QT_QPA_PLATFORMTHEME, kde
+env = XDG_MENU_PREFIX, plasma-
 
 # ######## Wayland #########
 # Tearing

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ source ./scriptdata/installers
 source ./scriptdata/options
 
 #####################################################################################
-if ! command -v pacman >/dev/null 2>&1; then 
+if ! command -v pacman >/dev/null 2>&1; then
   printf "\e[31m[$0]: pacman not found, it seems that the system is not ArchLinux or Arch-based distros. Aborting...\e[0m\n"
   exit 1
 fi
@@ -23,7 +23,7 @@ startask () {
   printf 'This script 1. only works for ArchLinux and Arch-based distros.\n'
   printf '            2. does not handle system-level/hardware stuff like Nvidia drivers\n'
   printf "\e[31m"
-  
+
   printf "Would you like to create a backup for \"$XDG_CONFIG_HOME\" and \"$HOME/.local/\" folders?\n[y/N]: "
   read -p " " backup_confirm
   case $backup_confirm in
@@ -34,7 +34,7 @@ startask () {
       echo "Skipping backup..."
       ;;
   esac
-  
+
 
   printf '\n'
   printf 'Do you want to confirm every time before a command executes?\n'
@@ -144,7 +144,6 @@ esac
 
 v sudo usermod -aG video,i2c,input "$(whoami)"
 v bash -c "echo i2c-dev | sudo tee /etc/modules-load.d/i2c-dev.conf"
-v sudo pacman -S archlinux-xdg-menu && XDG_MENU_PREFIX=arch- kbuildsycoca6; sudo ln -sf /etc/xdg/menus/plasma-applications.menu /etc/xdg/menus/applications.menu
 v systemctl --user enable ydotool --now
 v sudo systemctl enable bluetooth --now
 v gsettings set org.gnome.desktop.interface font-name 'Rubik 11'

--- a/scriptdata/previous_dependencies.conf
+++ b/scriptdata/previous_dependencies.conf
@@ -1,6 +1,7 @@
 ### This file contains a list of dependencies which were previously explicitly installed that are now installed using meta packages
 ### Must be one package per line as it needs to be compared against the explicitly installed list from pacman
 illogical-impulse-ags
+archlinux-xdg-menu
 axel
 bc
 coreutils


### PR DESCRIPTION
## Describe your changes
* Use XDG menu scheme from KDE, which is already implicitly introduced by illogical-impulse-kde.
* Set XDG_MENU_PREFIX globally, so kbuildsycoca6 is automatically invoked by /usr/bin/xdg-mime via the pacman hook. Consequently, the manual call can (and should) be removed.


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?


ready