### PR TITLE
fix(ai): add the full received message to rawContent (OpenAi format)

### DIFF
--- a/.config/quickshell/ii/services/Ai.qml
+++ b/.config/quickshell/ii/services/Ai.qml
@@ -689,6 +689,7 @@ Singleton {
             }
 
             requester.message.content += newContent;
+            requester.message.rawContent += newContent;
 
             if (dataJson.done) {
                 requester.markDone();


### PR DESCRIPTION
The messages were not preserved and passed to further calls outside of the reasoning part.

## Describe your changes

Append the newContent string to rawContent, just like it is appened to the regular content.

## Is it ready? Questions/feedback needed?

Pretty much I think.
