### PR TITLE
Fix empty notifications

### DIFF
--- a/.config/quickshell/ii/services/Notifications.qml
+++ b/.config/quickshell/ii/services/Notifications.qml
@@ -34,11 +34,9 @@ Singleton {
         property string urgency: notification?.urgency.toString() ?? "normal"
         property Timer timer
 
-        readonly property Connections conn: Connections {
-            target: wrapper?.notification?.Component ?? root // stupid warning aaaaaaa
-
-            function onDestruction(): void {
-                wrapper.destroy();
+        onNotificationChanged: {
+            if (notification === null) {
+                root.discardNotification(notificationId);
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

This fixes #1465 where notifications become empty if the source application (Betterbird, Vesktop and Ferdium in my case) closes the notification before interacting with it in the shell.

I used **onNotificationChanged** handler to detect when the notification property becomes null (which happens when the underlying object is destroyed). When this occurs, it triggers root.discardNotification(), so the empty notification does not appear.

## Is it ready? Questions/feedback needed?
I think it is ready for review, as I haven't received empty notifications anymore (at least from the problematic apps I mentioned before).
