### PR TITLE
Overrideable default terminal app

### DIFF
--- a/.config/hypr/hyprland/env.conf
+++ b/.config/hypr/hyprland/env.conf
@@ -24,4 +24,4 @@ env = XDG_MENU_PREFIX, plasma-
 env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, ~/.local/state/quickshell/.venv
 
 # ######## Terminal application #########
-env = TERMINAL, "kitty -1"
+env = TERMINAL,kitty -1

--- a/.config/hypr/hyprland/env.conf
+++ b/.config/hypr/hyprland/env.conf
@@ -22,3 +22,6 @@ env = XDG_MENU_PREFIX, plasma-
 
 # ######## Virtual envrionment #########
 env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, ~/.local/state/quickshell/.venv
+
+# ######## Terminal application #########
+env = TERMINAL, "kitty -1"

--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -201,10 +201,10 @@ bindl= ,XF86AudioPlay, exec, playerctl play-pause # [hidden]
 bindl= ,XF86AudioPause, exec, playerctl play-pause # [hidden]
 
 ##! Apps
-bind = Super, Return, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Terminal
-bind = Super, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # [hidden] Kitty (terminal) (alt)
-bind = Ctrl+Alt, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # [hidden] Kitty (for Ubuntu people)
-bind = Super, E, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "dolphin" "nautilus" "nemo" "thunar" "kitty -1 fish -c yazi" # File manager
+bind = Super, Return, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "$TERMINAL" "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # Terminal
+bind = Super, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh  "$TERMINAL" "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # [hidden] (terminal) (alt)
+bind = Ctrl+Alt, T, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "$TERMINAL" "kitty -1" "foot" "alacritty" "wezterm" "konsole" "kgx" "uxterm" "xterm" # [hidden] (terminal) (for Ubuntu people)
+bind = Super, E, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "dolphin" "nautilus" "nemo" "thunar" "$TERMINAL" "kitty -1 fish -c yazi" # File manager
 bind = Super, W, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "google-chrome-stable" "zen-browser" "firefox" "brave" "chromium" "microsoft-edge-stable" "opera" "librewolf" # Browser
 bind = Super, C, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "code" "codium" "cursor" "zed" "zedit" "zeditor" "kate" "gnome-text-editor" "emacs" "command -v nvim && kitty -1 nvim" # Code editor
 bind = Super+Shift, W, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "wps" "onlyoffice-desktopeditors" # Office software

--- a/.config/hypr/hyprland/scripts/launch_first_available.sh
+++ b/.config/hypr/hyprland/scripts/launch_first_available.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 for cmd in "$@"; do
+    [[ -z "$cmd" ]] && continue
     eval "command -v ${cmd%% *}" >/dev/null 2>&1 || continue
     eval "$cmd" &
     exit
 done
-exit 1


### PR DESCRIPTION
## Describe your changes

Allow us to override the terminal app. Some of us really don't like kitty.

To use, set the env var `TERMINAL` to terminal of your choice, either in hyprland `env.conf` or via whatever script runs before your desktop is initialized.

## Is it ready? Questions/feedback needed?

Yes