### PR TITLE
quickshell: fix qml null safety and monitor property errors

### DIFF
--- a/.config/quickshell/ii/modules/background/Background.qml
+++ b/.config/quickshell/ii/modules/background/Background.qml
@@ -28,12 +28,12 @@ Scope {
 
             // Hide when fullscreen
             readonly property Toplevel activeWindow: ToplevelManager.activeToplevel
-            property bool focusingThisMonitor: HyprlandData.activeWorkspace.monitor == monitor.name
+            property bool focusingThisMonitor: HyprlandData.activeWorkspace?.monitor == monitor?.name
             visible: !(activeWindow?.fullscreen && activeWindow?.activated && focusingThisMonitor)
 
             // Workspaces
             property HyprlandMonitor monitor: Hyprland.monitorFor(modelData)
-            property list<var> relevantWindows: HyprlandData.windowList.filter(win => win.monitor == monitor.id && win.workspace.id >= 0).sort((a, b) => a.workspace.id - b.workspace.id)
+            property list<var> relevantWindows: HyprlandData.windowList.filter(win => win.monitor == monitor?.id && win.workspace.id >= 0).sort((a, b) => a.workspace.id - b.workspace.id)
             property int firstWorkspaceId: relevantWindows[0]?.workspace.id || 1
             property int lastWorkspaceId: relevantWindows[relevantWindows.length - 1]?.workspace.id || 10
             // Wallpaper
@@ -157,7 +157,7 @@ Scope {
                     const lower = Math.floor(bgRoot.firstWorkspaceId / chunkSize) * chunkSize;
                     const upper = Math.ceil(bgRoot.lastWorkspaceId / chunkSize) * chunkSize;
                     const range = upper - lower;
-                    return (Config.options.background.parallax.enableWorkspace ? ((bgRoot.monitor.activeWorkspace.id - lower) / range) : 0.5)
+                    return (Config.options.background.parallax.enableWorkspace ? ((bgRoot.monitor?.activeWorkspace?.id ?? 1 - lower) / range) : 0.5)
                         + (0.15 * GlobalStates.sidebarRightOpen * Config.options.background.parallax.enableSidebar)
                         - (0.15 * GlobalStates.sidebarLeftOpen * Config.options.background.parallax.enableSidebar)
                 }
@@ -199,7 +199,7 @@ Scope {
 
                 ColumnLayout {
                     id: clockColumn
-                    anchors.centerIn: wallpaper
+                    anchors.centerIn: parent
                     spacing: 0
 
                     StyledText {

--- a/.config/quickshell/ii/modules/bar/ActiveWindow.qml
+++ b/.config/quickshell/ii/modules/bar/ActiveWindow.qml
@@ -14,8 +14,8 @@ Item {
     readonly property Toplevel activeWindow: ToplevelManager.activeToplevel
 
     property string activeWindowAddress: `0x${activeWindow?.HyprlandToplevel?.address}`
-    property bool focusingThisMonitor: HyprlandData.activeWorkspace.monitor == monitor.name
-    property var biggestWindow: HyprlandData.biggestWindowForWorkspace(HyprlandData.monitors[root.monitor.id]?.activeWorkspace.id)
+    property bool focusingThisMonitor: HyprlandData.activeWorkspace?.monitor == monitor?.name
+    property var biggestWindow: HyprlandData.biggestWindowForWorkspace(HyprlandData.monitors[root.monitor?.id]?.activeWorkspace.id)
 
     implicitWidth: colLayout.implicitWidth
 
@@ -45,7 +45,7 @@ Item {
             elide: Text.ElideRight
             text: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
                 root.activeWindow?.title :
-                (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor.activeWorkspace?.id}`
+                (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor?.activeWorkspace?.id ?? 1}`
         }
 
     }

--- a/.config/quickshell/ii/modules/bar/weather/WeatherBar.qml
+++ b/.config/quickshell/ii/modules/bar/weather/WeatherBar.qml
@@ -21,7 +21,7 @@ MouseArea {
         
         MaterialSymbol {
             fill: 0
-            text: WeatherIcons.codeToName[Weather.data.wCode]
+            text: WeatherIcons.codeToName[Weather.data?.wCode] ?? "question_mark"
             iconSize: Appearance.font.pixelSize.large
             color: Appearance.colors.colOnLayer1
             Layout.alignment: Qt.AlignVCenter
@@ -31,7 +31,7 @@ MouseArea {
             visible: true
             font.pixelSize: Appearance.font.pixelSize.small
             color: Appearance.colors.colOnLayer1
-            text: Weather.data.temp
+            text: Weather.data?.temp ?? "--°"
             Layout.alignment: Qt.AlignVCenter
         }
     }

--- a/.config/quickshell/ii/modules/overview/Overview.qml
+++ b/.config/quickshell/ii/modules/overview/Overview.qml
@@ -21,7 +21,7 @@ Scope {
             required property var modelData
             property string searchingText: ""
             readonly property HyprlandMonitor monitor: Hyprland.monitorFor(root.screen)
-            property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor.id)
+            property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor?.id)
             screen: modelData
             visible: GlobalStates.overviewOpen
 

--- a/.config/quickshell/ii/modules/overview/OverviewWidget.qml
+++ b/.config/quickshell/ii/modules/overview/OverviewWidget.qml
@@ -20,7 +20,7 @@ Item {
     property var windows: HyprlandData.windowList
     property var windowByAddress: HyprlandData.windowByAddress
     property var windowAddresses: HyprlandData.addresses
-    property var monitorData: HyprlandData.monitors.find(m => m.id === root.monitor.id)
+    property var monitorData: HyprlandData.monitors.find(m => m.id === root.monitor?.id)
     property real scale: Config.options.overview.scale
     property color activeBorderColor: Appearance.colors.colSecondary
 
@@ -149,7 +149,7 @@ Item {
                             const address = `0x${toplevel.HyprlandToplevel.address}`
                             var win = windowByAddress[address]
                             const inWorkspaceGroup = (root.workspaceGroup * root.workspacesShown < win?.workspace?.id && win?.workspace?.id <= (root.workspaceGroup + 1) * root.workspacesShown)
-                            const inMonitor = root.monitor.id === win.monitor
+                            const inMonitor = root.monitor?.id === win.monitor
                             return inWorkspaceGroup && inMonitor;
                         })
                     }

--- a/.local/state/quickshell/user/ai/chats/chat.json
+++ b/.local/state/quickshell/user/ai/chats/chat.json
@@ -1,0 +1,7 @@
+{
+  "messages": [],
+  "created": "2024-01-01T00:00:00Z",
+  "updated": "2024-01-01T00:00:00Z",
+  "title": "Default Chat",
+  "id": "default"
+}


### PR DESCRIPTION
## Describe your changes

I have fixed some type errors and null checks I saw when restarting quickshell, like;
  @modules/bar/ActiveWindow.qml[17:-1]: TypeError: Cannot read property 'monitor' of null
  @modules/bar/ActiveWindow.qml[17:-1]: TypeError: Cannot read property 'monitor' of null
  @modules/background/Background.qml[31:-1]: TypeError: Cannot read property 'monitor' of null

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

It is ready, no question/feedback needed.


