### PR TITLE
Easy configuration of monitors using nwg-displays

### DIFF
--- a/.config/quickshell/ii/modules/sidebarRight/SidebarRight.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/SidebarRight.qml
@@ -142,6 +142,17 @@ Scope {
                                 }
                                 QuickToggleButton {
                                     toggled: false
+                                    buttonIcon: "monitor"
+                                    onClicked: {
+                                        GlobalStates.sidebarRightOpen = false
+                                        Quickshell.execDetached(["nwg-displays"])
+                                    }
+                                    StyledToolTip {
+                                        content: Translation.tr("Display Settings")
+                                    }
+                                }
+                                QuickToggleButton {
+                                    toggled: false
                                     buttonIcon: "power_settings_new"
                                     onClicked: {
                                         GlobalStates.sessionOpen = true

--- a/.config/quickshell/translations/en_US.json
+++ b/.config/quickshell/translations/en_US.json
@@ -311,4 +311,5 @@
   "Pressure": "Pressure",
   "Visibility": "Visibility",
   "Precipitation": "Precipitation"
+  "Display Settings": "Display Settings"
 }

--- a/arch-packages/illogical-impulse-hyprland/PKGBUILD
+++ b/arch-packages/illogical-impulse-hyprland/PKGBUILD
@@ -18,4 +18,5 @@ depends=(
   hyprwayland-scanner
   xdg-desktop-portal-hyprland
   wl-clipboard
+  nwg-displays
 )


### PR DESCRIPTION
## Describe your changes

Added a quick toggle button on the right sidebar for monitor display settings
Added nwd-displays as a dependency under illogical-impulse-hyprland

## Is it ready? Questions/feedback needed?
It's pretty much ready, I did it the easy way though. There's the alternative of making a custom display configuration tool using the built-in settings gui

