### PR TITLE
fix(touchpad): improve scroll speed handling for touchpad in StyledListView & StyledFlickable

### DIFF
--- a/.config/quickshell/ii/modules/common/widgets/StyledFlickable.qml
+++ b/.config/quickshell/ii/modules/common/widgets/StyledFlickable.qml
@@ -1,6 +1,24 @@
 import QtQuick
 
 Flickable {
+    id: root
     maximumFlickVelocity: 3500
     boundsBehavior: Flickable.DragOverBounds
+
+    property real touchpadScrollFactor: 100
+    property real mouseScrollFactor: 50 
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        onWheel: function(wheelEvent) {
+            var delta = wheelEvent.angleDelta.y / 120;
+            // The angleDelta.y of a touchpad is usually small and continuous, 
+            // while that of a mouse wheel is typically in multiples of ±120.
+            var scrollFactor = Math.abs(wheelEvent.angleDelta.y) >= 120 ? root.mouseScrollFactor : root.touchpadScrollFactor;
+            var targetY = root.contentY - delta * scrollFactor;
+            targetY = Math.max(0, Math.min(targetY, root.contentHeight - root.height));
+            root.contentY = targetY;
+        }
+    }
 }

--- a/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
+++ b/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
@@ -15,6 +15,9 @@ ListView {
     property real dragDistance: 0
     property bool popin: true
 
+    property real touchpadScrollFactor: 100
+    property real mouseScrollFactor: 50
+
     function resetDrag() {
         root.dragIndex = -1
         root.dragDistance = 0
@@ -22,6 +25,20 @@ ListView {
 
     maximumFlickVelocity: 3500
     boundsBehavior: Flickable.DragOverBounds
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        onWheel: function(wheelEvent) {
+            var delta = wheelEvent.angleDelta.y / 120;
+            // The angleDelta.y of a touchpad is usually small and continuous, 
+            // while that of a mouse wheel is typically in multiples of ±120.
+            var scrollFactor = Math.abs(wheelEvent.angleDelta.y) >= 120 ? root.mouseScrollFactor : root.touchpadScrollFactor;
+            var targetY = root.contentY - delta * scrollFactor;
+            targetY = Math.max(0, Math.min(targetY, root.contentHeight - root.height));
+            root.contentY = targetY;
+        }
+    }
 
     add: Transition {
         animations: [

--- a/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
+++ b/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
@@ -282,6 +282,9 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 spacing: 10
                 popin: false
 
+                touchpadScrollFactor: 600
+                mouseScrollFactor: 200
+
                 property int lastResponseLength: 0
 
                 clip: true

--- a/.config/quickshell/ii/modules/sidebarLeft/Anime.qml
+++ b/.config/quickshell/ii/modules/sidebarLeft/Anime.qml
@@ -137,6 +137,9 @@ Item {
                 anchors.fill: parent
                 spacing: 10
                 
+                touchpadScrollFactor: 600
+                mouseScrollFactor: 200
+
                 property int lastResponseLength: 0
 
                 clip: true


### PR DESCRIPTION
## Describe your changes

### Background

Previously, in all places where `StyledListView` or `StyledFlickable` were used — such as `AiChat`, `Anime`, `NotificationGroup`, `TaskList`, `SearchWidget`, and even `ContentPage` used in settings (and many others) — scrolling with a touchpad was **EXTREMELY** slow, while mouse wheel scrolling was completely normal.

I tried many approaches to address this issue (e.g., tweaking `maximumFlickVelocity`, etc.), but none of them worked. I suspect this might be a bug in Quickshell itself.

In the end, I decided to implement a (somewhat inelegant?) workaround by adding logic to `StyledListView` and `StyledFlickable` to differentiate between mouse and touchpad inputs and adjust scrolling accordingly.

### Current Changes

I’ve added two new properties to both `StyledListView` and `StyledFlickable`:
`touchpadScrollFactor` and `mouseScrollFactor`.

These help differentiate the scroll speed based on input device, and allow for fine-tuned adjustments per component. All existing animations and behaviors are preserved.

Default values:

```qml
property real touchpadScrollFactor: 100
property real mouseScrollFactor: 50
```

These values feel most comfortable based on testing with my ASUS laptop.
However, there are two exceptions: `Anime` and `AiChat`, which have a lot of content and are vertically long. For these, I used:

```qml
touchpadScrollFactor: 600
mouseScrollFactor: 200
```

So far, other components perform well using the default values.

### Demo

This is tested on my laptop (Model: ASUS TX Air 2025) using its built-in touchpad.
I tried to keep my finger movement speed as consistent as possible.

**Before**

https://github.com/user-attachments/assets/d4e925b6-a4c2-47bd-b4c5-897173dea722

**After**

https://github.com/user-attachments/assets/283ed448-0eb4-4d78-ba7a-dd9a4b3ce939



### Additional Notes

If you're developing new components based on `StyledListView` or `StyledFlickable`, remember to add `touchpadScrollFactor` and `mouseScrollFactor` where necessary — though the default values should already work well in most cases.

As for the natural inertia after lifting fingers from the touchpad (which should result in continued scrolling), there's unfortunately nothing I can do — as it was never implemented in the first place.
However, I’ve kept the long-press + drag scrolling behavior, which still provides smooth and elegant deceleration.

If Qt or Quickshell fixes this in the future, feel free to remove this custom logic entirely.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Tested thoroughly on my ASUS laptop.
Feedback is very welcome — especially from those using other laptops or touchpads.


