### PR TITLE
scriptsdata: Add `#!/bin/bash`

### DIFF
--- a/scriptdata/environment-variables
+++ b/scriptdata/environment-variables
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This is NOT a script for execution, but for loading functions, so NOT need execution permission or shebang.
 XDG_BIN_HOME=${XDG_BIN_HOME:-$HOME/.local/bin}
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}

--- a/scriptdata/functions
+++ b/scriptdata/functions
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This is NOT a script for execution, but for loading functions, so NOT need execution permission or shebang.
 # NOTE that you NOT need to `cd ..' because the `$0' is NOT this file, but the script file which will source this file.
 

--- a/scriptdata/installers
+++ b/scriptdata/installers
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is provided for non-Arch(based) distros.
 # As for Arch Linux, we use local PKGBUILDs or AUR packages, which is the "right" way compared to copying files directly into /usr/local/* .
 # P.S. install-yay() should be kept for Arch(based) distros.

--- a/scriptdata/options
+++ b/scriptdata/options
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This is NOT a script for execution, but for loading functions, so NOT need execution permission or shebang.
 # NOTE that you NOT need to `cd ..' because the `$0' is NOT this file, but the script file which will source this file.
 


### PR DESCRIPTION
Add `#!/bin/bash` to scripts without .sh or .bash extension (bash syntax highlighting does not work without it).

Ready for merge

