### PR TITLE
add vpn toggle to sidebarRight and vpn status icon to bar

### DIFF
--- a/.config/quickshell/ii/modules/bar/BarContent.qml
+++ b/.config/quickshell/ii/modules/bar/BarContent.qml
@@ -414,6 +414,13 @@ Item { // Bar content region
                             color: rightSidebarButton.colText
                         }
                         MaterialSymbol {
+                            Layout.rightMargin: indicatorsRowLayout.realSpacing
+                            text: VPN.materialSymbol
+                            iconSize: Appearance.font.pixelSize.larger
+                            color: rightSidebarButton.colText
+                            visible: VPN.available
+                        }
+                        MaterialSymbol {
                             text: Bluetooth.bluetoothConnected ? "bluetooth_connected" : Bluetooth.bluetoothEnabled ? "bluetooth" : "bluetooth_disabled"
                             iconSize: Appearance.font.pixelSize.larger
                             color: rightSidebarButton.colText

--- a/.config/quickshell/ii/modules/sidebarRight/SidebarRight.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/SidebarRight.qml
@@ -166,6 +166,7 @@ Scope {
                             IdleInhibitor {}
                             EasyEffectsToggle {}
                             CloudflareWarp {}
+                            VPNToggle {}
                         }
 
                         // Center widget group

--- a/.config/quickshell/ii/modules/sidebarRight/quickToggles/VPNToggle.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/quickToggles/VPNToggle.qml
@@ -1,0 +1,32 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import "../"
+import qs
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Quickshell.Hyprland
+
+QuickToggleButton {
+    toggled: VPN.connected
+    buttonIcon: VPN.materialSymbol
+    visible: VPN.available
+    onClicked: {
+    	if (VPN.connected) {
+        	disconnectVPN.running = true
+        }
+    }
+    altAction: () => {
+        Quickshell.execDetached(["bash", "-c", `${Config.options.apps.network}`])
+        GlobalStates.sidebarRightOpen = false
+    }
+    Process {
+        id: disconnectVPN
+        command: ["bash", "-c", "nmcli connection down $(nmcli -g UUID,TYPE connection show --active | awk -F: '/vpn|wireguard/{print $1}')"]
+    }
+    StyledToolTip {
+        content: Translation.tr("%1 | Right-click to configure").arg(VPN.vpnName)
+    }
+}

--- a/.config/quickshell/ii/services/VPN.qml
+++ b/.config/quickshell/ii/services/VPN.qml
@@ -1,0 +1,85 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+/**
+ * VPN service
+ */
+Singleton {
+    id: root
+
+    property bool connected: false
+    property bool available: false
+    property int updateInterval: 1000
+    property string vpnName: ""
+    property string materialSymbol: VPN.connected ? "vpn_key" : "vpn_key_off"
+    function update() {
+        updateVPNActive.startCheck();
+        updateVPNName.running = true;
+        updateVPNAvailable.running = true;
+    }
+
+    Timer {
+        interval: 10
+        running: true
+        repeat: true
+        onTriggered: {
+            root.update();
+            interval = root.updateInterval;
+        }
+    }
+
+    Process {
+        id: updateVPNActive
+        property string buffer
+        command: ["sh", "-c", "nmcli -t -f TYPE c show --active"]
+        running: true
+        function startCheck() {
+            buffer = "";
+            updateVPNActive.running = true;
+        }
+        stdout: SplitParser {
+            onRead: data => {
+                updateVPNActive.buffer += data + "\n";
+            }
+        }
+        onExited: (exitCode, exitStatus) => {
+            const lines = updateVPNActive.buffer.trim().split('\n');
+            let isConnected = false
+            lines.forEach(line => {
+                if (line.includes("vpn"))
+                    isConnected = true;
+                else if (line.includes("wireguard"))
+                    isConnected = true;
+            });
+            root.connected = isConnected;
+        }
+    }
+
+    Process {
+        id: updateVPNName
+        command: ["sh", "-c", "nmcli -t -f NAME,TYPE c show --active | awk -F: 'BEGIN {found=0} $2 == \"vpn\" || $2 == \"wireguard\" {print $1; found=1} END {if (found == 0) print \"\"}'"]
+        running: true
+        stdout: SplitParser {
+            onRead: data => {
+            	if (data.trim() == "") {
+            		root.vpnName = "Disconnected"
+            	} else {
+                	root.vpnName = data.trim();
+                }
+            }
+        }
+    }
+
+    Process {
+    	id: updateVPNAvailable
+    	command: ["sh", "-c", "command -v protonvpn-app"]
+    	running: true
+    	onExited: (exitCode, exitStatus) => {
+    	   root.available = exitCode === 0
+    	}
+    }
+}


### PR DESCRIPTION
## Describe your changes

adds a VPN toggle to sidebarRight and a VPN status icon to the bar
only visible if Proton VPN is installed (by checking if the protonvpn-app command exists)
only disconnecting from the VPN is supported as disconnecting (from a VPN interface created by the Proton VPN app) makes the VPN interface disappear completely and since there can be multiple VPN interfaces

<img width="450" height="183" alt="image" src="https://github.com/user-attachments/assets/c7b63eb1-2b2f-40a3-a42d-d7a783fc9170" />
<img width="445" height="176" alt="image" src="https://github.com/user-attachments/assets/70cf5cd7-f499-4d46-8f57-ee5698570fb7" />

## Is it ready?

seems to be


