### PR TITLE
Update workspace_action.sh

### DIFF
--- a/.config/hypr/hyprland/scripts/workspace_action.sh
+++ b/.config/hypr/hyprland/scripts/workspace_action.sh
@@ -1,2 +1,29 @@
-#!/usr/bin/env bash
-hyprctl dispatch "$1" $(((($(hyprctl activeworkspace -j | jq -r .id) - 1)  / 10) * 10 + $2))
+#!/bin/bash
+##This script is kinda an improvement for the workspace_action script of end4. This script allows for relative workspace keybind. The next and prev workspaces allow for relative-
+##Workspace support, using the second arg. while the first arg is "ch" or "mv"
+
+##Example Usage: bash workspace_action ch next
+
+curr_workspace="$(hyprctl monitors -j | jq -r '.[] | select(.focused) | .activeWorkspace.name')"
+next_workspace="$(echo $curr_workspace +1 | bc)" 
+prev_workspace="$(echo $curr_workspace -1 | bc)"
+
+if [ "$1" == "ch" ]; then
+  if [ "$2" == "next" ]; then
+    hyprctl dispatch workspace $next_workspace
+  elif [ "$2" == "prev" ]; then
+    hyprctl dispatch workspace $prev_workspace
+  else 
+    hyprctl dispatch workspace $2
+  fi 
+elif [ "$1" == "mv" ]; then
+   if [ "$2" == "next" ]; then
+    hyprctl dispatch movetoworkspace $next_workspace
+   elif [ "$2" == "prev" ]; then
+    hyprctl dispatch movetoworkspace $prev_workspace
+   else 
+    hyprctl dispatch movetoworkspace $2
+   fi 
+else
+  echo "Valid Options are: mv and ch"
+fi


### PR DESCRIPTION
This script is kinda an improvement for the workspace_action script of end4. This script allows for relative workspace keybind. The next and prev workspaces allow for relative Workspace support, using the second arg. while the first arg is "ch" or "mv"

i made this script as i found it annoying that when using the traditional keybind, bind = ... , workspace, r+1/r-1, hyprland changed 4 workspaces instead of 1. And upon investigation, it seems that using hyprctl is better. but the original workspace_action didnt work for relative workspace. and was frankly quite obfuscated. So this is a better script in my opinion.

## Describe your changes

Well, i just used simple if/else/elif statements for better maintainablity. Added support for relative workspaces, i guess?

## Is it ready? Questions/feedback needed?
I wouldnt be too sure. this is my first contribution to other's work on github. It might need some feedback/reviewing?

