### PR TITLE
feat(bar): add network speed display to bar

### DIFF
--- a/.config/quickshell/ii/modules/bar/BarContent.qml
+++ b/.config/quickshell/ii/modules/bar/BarContent.qml
@@ -98,7 +98,7 @@ Item { // Bar content region
                 }
             }
         }
-        
+
         // Visual content
         ScrollHint {
             reveal: barLeftSideMouseArea.hovered
@@ -420,6 +420,17 @@ Item { // Bar content region
                 sourceComponent: BarGroup {
                     implicitHeight: Appearance.sizes.baseBarHeight
                     WeatherBar {}
+                }
+            }
+
+            // Network Speed
+            Loader {
+                Layout.leftMargin: 8
+                Layout.fillHeight: true
+                active: Config.options.bar.networkSpeed.enable
+                sourceComponent: BarGroup {
+                    implicitHeight: Appearance.sizes.baseBarHeight
+                    NetworkSpeed {}
                 }
             }
         }

--- a/.config/quickshell/ii/modules/bar/NetworkSpeed.qml
+++ b/.config/quickshell/ii/modules/bar/NetworkSpeed.qml
@@ -1,0 +1,174 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import qs
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+    implicitWidth: networkLayout.implicitWidth + 16
+    implicitHeight: Appearance.sizes.barHeight
+
+    // Display modes: 0=total, 1=download, 2=upload, 3=both
+    property int displayMode: 0
+
+    // Helper function to format network speed
+    function formatSpeed(bytesPerSecond) {
+        if (bytesPerSecond < 1024) {
+            return bytesPerSecond.toFixed(0) + " B/s";
+        } else if (bytesPerSecond < 1024 * 1024) {
+            return (bytesPerSecond / 1024).toFixed(1) + " KB/s";
+        } else if (bytesPerSecond < 1024 * 1024 * 1024) {
+            return (bytesPerSecond / (1024 * 1024)).toFixed(1) + " MB/s";
+        } else {
+            return (bytesPerSecond / (1024 * 1024 * 1024)).toFixed(1) + " GB/s";
+        }
+    }
+
+    function getDisplayText() {
+        var downloadSpeed = ResourceUsage.networkDownloadSpeed;
+        var uploadSpeed = ResourceUsage.networkUploadSpeed;
+        var totalSpeed = downloadSpeed + uploadSpeed;
+
+        switch (displayMode) {
+        case 0 // Total speed
+        :
+            return formatSpeed(totalSpeed);
+        case 1 // Download only
+        :
+            return "↓ " + formatSpeed(downloadSpeed);
+        case 2 // Upload only
+        :
+            return "↑ " + formatSpeed(uploadSpeed);
+        case 3 // Both (dual row)
+        :
+            return ""; // Handled separately
+        default:
+            return formatSpeed(totalSpeed);
+        }
+    }
+
+    RowLayout {
+        id: networkLayout
+        anchors.centerIn: parent
+        spacing: 6
+
+        MaterialSymbol {
+            text: "network_check"
+            iconSize: Appearance.font.pixelSize.normal
+            color: Appearance.colors.colOnLayer1
+        }
+
+        // Single line display (modes 0, 1, 2)
+        StyledText {
+            id: singleLineText
+            visible: displayMode !== 3
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colOnLayer1
+            text: getDisplayText()
+        }
+
+        // Side by side display (mode 3)
+        RowLayout {
+            visible: displayMode === 3
+            spacing: 4
+
+            StyledText {
+                id: downloadText
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: Appearance.colors.colOnLayer1
+                text: "↓ " + formatSpeed(ResourceUsage.networkDownloadSpeed)
+            }
+
+            StyledText {
+                id: uploadText
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: Appearance.colors.colOnLayer1
+                text: "↑ " + formatSpeed(ResourceUsage.networkUploadSpeed)
+            }
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton
+        onClicked: {
+            displayMode = (displayMode + 1) % 4;
+        }
+    }
+
+    StyledPopup {
+        hoverTarget: mouseArea
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 4
+
+            // Header
+            RowLayout {
+                spacing: 5
+
+                MaterialSymbol {
+                    fill: 0
+                    font.weight: Font.Medium
+                    text: "network_check"
+                    iconSize: Appearance.font.pixelSize.large
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+
+                StyledText {
+                    text: Translation.tr("Network Speed")
+                    font {
+                        weight: Font.Medium
+                        pixelSize: Appearance.font.pixelSize.normal
+                    }
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+            }
+
+            // Speed info
+            RowLayout {
+                spacing: 5
+
+                MaterialSymbol {
+                    text: "download"
+                    color: Appearance.colors.colOnSurfaceVariant
+                    iconSize: Appearance.font.pixelSize.large
+                }
+                StyledText {
+                    text: Translation.tr("Download:")
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignRight
+                    color: Appearance.colors.colOnSurfaceVariant
+                    text: formatSpeed(ResourceUsage.networkDownloadSpeed)
+                }
+            }
+
+            RowLayout {
+                spacing: 5
+
+                MaterialSymbol {
+                    text: "upload"
+                    color: Appearance.colors.colOnSurfaceVariant
+                    iconSize: Appearance.font.pixelSize.large
+                }
+                StyledText {
+                    text: Translation.tr("Upload:")
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignRight
+                    color: Appearance.colors.colOnSurfaceVariant
+                    text: formatSpeed(ResourceUsage.networkUploadSpeed)
+                }
+            }
+        }
+    }
+}

--- a/.config/quickshell/ii/modules/common/Config.qml
+++ b/.config/quickshell/ii/modules/common/Config.qml
@@ -174,6 +174,9 @@ Singleton {
                     property bool useUSCS: false // Instead of metric (SI) units
                     property int fetchInterval: 10 // minutes
                 }
+                property JsonObject networkSpeed: JsonObject {
+                    property bool enable: false
+                }
             }
 
             property JsonObject battery: JsonObject {

--- a/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -269,7 +269,7 @@ ContentPage {
 
         ContentSubsection {
             title: Translation.tr("Tray")
-            
+
             ConfigSwitch {
                 text: Translation.tr('Tint icons')
                 checked: Config.options.bar.tray.monochromeIcons
@@ -286,6 +286,17 @@ ContentPage {
                 checked: Config.options.bar.weather.enable
                 onCheckedChanged: {
                     Config.options.bar.weather.enable = checked;
+                }
+            }
+        }
+
+        ContentSubsection {
+            title: Translation.tr("Network Speed")
+            ConfigSwitch {
+                text: Translation.tr("Enable")
+                checked: Config.options.bar.networkSpeed.enable
+                onCheckedChanged: {
+                    Config.options.bar.networkSpeed.enable = checked;
                 }
             }
         }
@@ -463,6 +474,6 @@ ContentPage {
             StyledToolTip {
                 content: Translation.tr("Such regions could be images or parts of the screen that have some containment.\nMight not always be accurate.\nThis is done with an image processing algorithm run locally and no AI is used.")
             }
-        }        
+        }
     }
 }


### PR DESCRIPTION
* Introduced `NetworkSpeed.qml` to display current network speed.
* Configurable display modes: total, download, upload, or both.
* Added toggle in `InterfaceConfig.qml` to enable/disable network speed display.
* Updated `Config.qml` to support network speed configuration.
* Integrated network speed component into `BarContent.qml`.