### PR TITLE
Make KDE file dialogue always spawn in reasonable size

### DIFF
--- a/.config/hypr/hyprland/rules.conf
+++ b/.config/hypr/hyprland/rules.conf
@@ -26,6 +26,7 @@ windowrulev2 = float, class:.*bluedevilwizard
 windowrulev2 = float, title:.*Welcome
 windowrulev2 = float, title:^(illogical-impulse Settings)$
 windowrulev2 = float, class:org.freedesktop.impl.portal.desktop.kde
+windowrulev2 = size 60% 65%, class:org.freedesktop.impl.portal.desktop.kde
 windowrulev2 = float, class:^(Zotero)$
 windowrulev2 = size 45%, class:^(Zotero)$
 


### PR DESCRIPTION
## Describe your changes

I always make this change to my config because the KDE file picker acts strangely under anything that isn't KDE and likes to spawn in super small window sometimes and not remember resizes etc.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

This should be fine as is I'd think


