### PR TITLE
More detailed resources usage

### DIFF
--- a/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
+++ b/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
@@ -141,7 +141,14 @@ StyledPopup {
                    ResourceItem {
                     icon: "planner_review"
                     label: Translation.tr("Freq:")
-                    value: ` ${ Math.round(ResourceUsage.cpuFreqency)}MHz` 
+                    value: ` ${ Math.round(ResourceUsage.cpuFreqency)} MHz` 
+
+                  }
+
+                  ResourceItem {
+                    icon: "thermometer"
+                    label: Translation.tr("Temp:")
+                    value: ` ${ Math.round(ResourceUsage.cpuTemperature)} °C` 
 
                 }
             }

--- a/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
+++ b/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
@@ -136,6 +136,13 @@ StyledPopup {
                     icon: "bolt"
                     label: Translation.tr("Load:")
                     value: (ResourceUsage.cpuUsage > 0.8 ? Translation.tr("High") : ResourceUsage.cpuUsage > 0.4 ? Translation.tr("Medium") : Translation.tr("Low")) + ` (${Math.round(ResourceUsage.cpuUsage * 100)}%)`
+                  }
+
+                   ResourceItem {
+                    icon: "planner_review"
+                    label: Translation.tr("Freq:")
+                    value: ` ${ Math.round(ResourceUsage.cpuFreqency)}MHz` 
+
                 }
             }
         }

--- a/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
+++ b/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
@@ -141,7 +141,7 @@ StyledPopup {
                    ResourceItem {
                     icon: "planner_review"
                     label: Translation.tr("Freq:")
-                    value: ` ${ Math.round(ResourceUsage.cpuFreqency)} MHz` 
+                    value: ` ${ Math.round(ResourceUsage.cpuFreqency * 100) / 100} GHz` 
 
                   }
 

--- a/.config/quickshell/ii/services/ResourceUsage.qml
+++ b/.config/quickshell/ii/services/ResourceUsage.qml
@@ -19,6 +19,7 @@ Singleton {
 	property double swapUsed: swapTotal - swapFree
     property double swapUsedPercentage: swapTotal > 0 ? (swapUsed / swapTotal) : 0
     property double cpuUsage: 0
+    property double cpuFreqency: 0
     property var previousCpuStats
 
 	Timer {
@@ -29,6 +30,7 @@ Singleton {
             // Reload files
             fileMeminfo.reload()
             fileStat.reload()
+            fileCpuinfo.reload()
 
             // Parse memory and swap usage
             const textMeminfo = fileMeminfo.text()
@@ -53,10 +55,21 @@ Singleton {
 
                 previousCpuStats = { total, idle }
             }
+
+            // Parse CPU frequency
+            const cpuInfo = fileCpuinfo.text()
+            const cpuCoreFrequencies = cpuInfo.match(/cpu MHz\s+:\s+(\d+\.\d+)\n/g).map(x => Number(x.match(/\d+\.\d+/)))
+            const cpuCoreFreqencyAvg = cpuCoreFrequencies.reduce((a, b) => a + b, 0) / cpuCoreFrequencies.length
+            cpuFreqency = cpuCoreFreqencyAvg
+
+
+
             interval = Config.options?.resources?.updateInterval ?? 3000
         }
 	}
 
 	FileView { id: fileMeminfo; path: "/proc/meminfo" }
-    FileView { id: fileStat; path: "/proc/stat" }
+  FileView { id: fileStat; path: "/proc/stat" }
+  FileView { id: fileCpuinfo; path: "/proc/cpuinfo" }
+
 }

--- a/.config/quickshell/ii/services/ResourceUsage.qml
+++ b/.config/quickshell/ii/services/ResourceUsage.qml
@@ -61,7 +61,7 @@ Singleton {
             const cpuInfo = fileCpuinfo.text()
             const cpuCoreFrequencies = cpuInfo.match(/cpu MHz\s+:\s+(\d+\.\d+)\n/g).map(x => Number(x.match(/\d+\.\d+/)))
             const cpuCoreFreqencyAvg = cpuCoreFrequencies.reduce((a, b) => a + b, 0) / cpuCoreFrequencies.length
-            cpuFreqency = cpuCoreFreqencyAvg
+            cpuFreqency = cpuCoreFreqencyAvg / 1000
             
 
             //Process process temp

--- a/.config/quickshell/ii/services/ResourceUsage.qml
+++ b/.config/quickshell/ii/services/ResourceUsage.qml
@@ -5,7 +5,6 @@ import qs.modules.common
 import QtQuick
 import Quickshell
 import Quickshell.Io
-import QtSensors
 /**
  * Simple polled resource usage service with RAM, Swap, and CPU usage.
  */


### PR DESCRIPTION
## Describe your changes
As requested in [issue #1847](https://github.com/end-4/dots-hyprland/issues/1847), this pull request adds additional CPU information to the `ResourcesPopup.qml` module. This includes the CPU frequency and the CPU temperature. 

A prieview:

<img width="2559" height="176" alt="image" src="https://github.com/user-attachments/assets/1d12bde8-a9ed-4842-a49d-fbdf37ccf019" />


## Is it ready? Questions/feedback needed?

The CPU info has been fully tested on both my desktop and laptop and works as expected.

We might consider adding GPU-related metrics for a more complete system overview.