### PR TITLE
bar: add workspace number mapping

### DIFF
--- a/.config/quickshell/ii/modules/bar/Workspaces.qml
+++ b/.config/quickshell/ii/modules/bar/Workspaces.qml
@@ -216,7 +216,10 @@ Item {
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
-                        font.pixelSize: Appearance.font.pixelSize.small - ((text.length - 1) * (text !== "10") * 2)
+                        font {
+                            pixelSize: Appearance.font.pixelSize.small - ((text.length - 1) * (text !== "10") * 2)
+                            family: Config.options?.bar.workspaces.useNerdFont ? Appearance.font.family.iconNerd : Appearance.font.family.main
+                        }
                         text: Config.options?.bar.workspaces.numberMap[button.workspaceValue - 1] || button.workspaceValue
                         elide: Text.ElideRight
                         color: (monitor?.activeWorkspace?.id == button.workspaceValue) ? 

--- a/.config/quickshell/ii/modules/common/Config.qml
+++ b/.config/quickshell/ii/modules/common/Config.qml
@@ -175,6 +175,7 @@ Singleton {
                     property bool alwaysShowNumbers: false
                     property int showNumberDelay: 300 // milliseconds
                     property list<string> numberMap: ["1", "2"] // Characters to show instead of numbers on workspace indicator
+                    property bool useNerdFont: false
                 }
                 property JsonObject weather: JsonObject {
                     property bool enable: false


### PR DESCRIPTION
## Describe your changes
Thanks for this awesome dotfile !!!
This PR adds a mapping to workspace numbers so users can assign custom characters to represent a workspace.
In my case, I use it to represent my worspace as kanji like shown
<img width="1919" height="55" alt="image" src="https://github.com/user-attachments/assets/dbc3e217-4fb5-43bd-b541-bec8104c49e7" />

## Is it ready? Questions/feedback needed?

Yes, it's ready. It's just a small change and it's my first contribution to this project
