### PR TITLE
lock: use default pam config and start without password

### DIFF
--- a/.config/quickshell/ii/modules/lock/LockContext.qml
+++ b/.config/quickshell/ii/modules/lock/LockContext.qml
@@ -33,20 +33,12 @@ Scope {
     }
 
     function tryUnlock() {
-        if (currentText === "") return;
-
         root.unlockInProgress = true;
         pam.start();
     }
 
     PamContext {
         id: pam
-
-        // Its best to have a custom pam config for quickshell, as the system one
-        // might not be what your interface expects, and break in some way.
-        // This particular example only supports passwords.
-        configDirectory: "pam"
-        config: "password.conf"
 
         // pam_unix will ask for a response for the password prompt
         onPamMessage: {

--- a/.config/quickshell/ii/modules/lock/LockSurface.qml
+++ b/.config/quickshell/ii/modules/lock/LockSurface.qml
@@ -133,7 +133,7 @@ MouseArea {
             id: confirmButton
             implicitWidth: height
             toggled: true
-            enabled: !root.context.unlockInProgress && root.context.currentText.length > 0
+            enabled: !root.context.unlockInProgress
             colBackgroundToggled: Appearance.colors.colPrimary
 
             onClicked: root.context.tryUnlock()

--- a/.config/quickshell/ii/modules/lock/pam/password.conf
+++ b/.config/quickshell/ii/modules/lock/pam/password.conf
@@ -1,1 +1,0 @@
-auth required pam_unix.so


### PR DESCRIPTION
Fixes #1800

## Describe your changes

use default pam config and start without password

## Is it ready? Questions/feedback needed?

ready
