### PR TITLE
Fix non-existent property error in SysTray.qml

### DIFF
--- a/.config/quickshell/ii/modules/bar/SysTray.qml
+++ b/.config/quickshell/ii/modules/bar/SysTray.qml
@@ -1,5 +1,6 @@
 import qs.modules.common
 import qs.modules.common.widgets
+import qs.modules.bar
 import QtQuick
 import QtQuick.Layouts
 import Quickshell


### PR DESCRIPTION
## Describe your changes
This PR fixes an error, mentioned in #1940, by adding an additional import to SysTray.qml

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Should be enough to fix an error