### PR TITLE
Make window snap respect window gaps

### DIFF
--- a/.config/hypr/hyprland/general.conf
+++ b/.config/hypr/hyprland/general.conf
@@ -34,6 +34,7 @@ general {
     
     snap {
     	enabled = true
+        respect_gaps = true
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Without this option the windows snap to the borders of the monitor which is ugly with round corners.

https://github.com/user-attachments/assets/661c801e-1bf5-45c5-bc27-5b366b555926


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
might want to increase the snapping trigger zone [docs](https://wiki.hypr.land/Configuring/Variables/#snap) (default is 10 px) but i'll leave that up to you

