### PR TITLE
fix(ai): Resolve infinite loop in function calling

### DIFF
--- a/.config/quickshell/ii/services/Ai.qml
+++ b/.config/quickshell/ii/services/Ai.qml
@@ -800,13 +800,9 @@ Singleton {
         if (!message.functionPending) return;
         message.functionPending = false; // User decided, no more "thinking"
 
-        const responseMessage = createFunctionOutputMessage(message.functionName, "", false);
-        const id = idForMessage(responseMessage);
-        root.messageIDs = [...root.messageIDs, id];
-        root.messageByID[id] = responseMessage;
-
-        commandExecutionProc.message = responseMessage;
-        commandExecutionProc.baseMessageContent = responseMessage.content;
+        // Instead of creating a new message, append output to the existing AI message
+        commandExecutionProc.message = message;
+        commandExecutionProc.baseMessageContent = message.content;
         commandExecutionProc.shellCommand = message.functionCall.args.command;
         commandExecutionProc.running = true; // Start the command execution
     }
@@ -827,6 +823,10 @@ Singleton {
         }
         onExited: (exitCode, exitStatus) => {
             commandExecutionProc.message.functionResponse += `[[ Command exited with code ${exitCode} (${exitStatus}) ]]\n`;
+            
+            // Mark the message as completed and continue
+            commandExecutionProc.message.thinking = false;
+            commandExecutionProc.message.done = true;
             requester.makeRequest(); // Continue
         }
     }


### PR DESCRIPTION
## Summary

Fixes a critical bug where AI function calling would create an infinite loop, causing the AI to repeatedly 
execute the same command.

>[!WARNING]
>I am not a very good programmer. 
>This fix was almost exclusively generated using Claude Code. 
>However, I have been thorough in both testing and root cause analysis. I've been using this fix for about a week without issues. 

## Problem
- AI calls `run_shell_command` function
- User approves command execution  
- Command executes successfully
- AI immediately calls the same function again in an endless cycle

## Root Cause
`addFunctionOutputMessage()` was creating duplicate "user" role messages containing function output. These 
messages were sent to AI models in API requests, which interpreted them as new user instructions rather than 
function results.

## Solution
- **Remove duplicate message creation**: Use the existing AI assistant message instead of creating new function 
output messages
- **Proper state management**: Mark messages as completed using `thinking` and `done` properties
- **Clean API requests**: Eliminates confusing duplicate messages from conversation history

## Changes
- `services/Ai.qml`: Modified `approveCommand()\` function (lines ~803-807)
- `services/Ai.qml`: Updated `onExited()` handler (lines ~825-830)

## Testing
✅ Function calls execute once without loops  
✅ Command output displays in real-time  
✅ AI provides appropriate follow-up responses  
✅ No duplicate messages appear in chat  
✅ All function types work: `run_shell_command`, `get_shell_config`, etc.  

## Backwards Compatibility
- No breaking changes to existing API or message structure
- All existing function types continue to work  
- No changes required to AI model configurations

Fixes function calling for all users with tool-capable AI models using OpenAI-compatible APIs (including local 
Ollama models)."
