### PR TITLE
fix(brightness): use the monitor's max brightness instead of '100'

### DIFF
--- a/.config/quickshell/ii/services/Brightness.qml
+++ b/.config/quickshell/ii/services/Brightness.qml
@@ -76,7 +76,7 @@ Singleton {
         required property ShellScreen screen
         readonly property bool isDdc: root.ddcMonitors.some(m => m.model === screen.model)
         readonly property string busNum: root.ddcMonitors.find(m => m.model === screen.model)?.busNum ?? ""
-        property int maxBrightness: 100
+        property int rawMaxBrightness: 100
         property real brightness
         property bool ready: false
 
@@ -96,8 +96,8 @@ Singleton {
             stdout: SplitParser {
                 onRead: data => {
                     const [, , , current, max] = data.split(" ");
-                    monitor.maxBrightness = parseInt(max);
-                    monitor.brightness = parseInt(current) / monitor.maxBrightness;
+                    monitor.rawMaxBrightness = parseInt(max);
+                    monitor.brightness = parseInt(current) / monitor.rawMaxBrightness;
                     monitor.ready = true;
                 }
             }
@@ -105,8 +105,8 @@ Singleton {
 
         function setBrightness(value: real): void {
             value = Math.max(0.01, Math.min(1, value));
-            const rounded = Math.round(value * monitor.maxBrightness);
-            if (Math.round(brightness * monitor.maxBrightness) === rounded)
+            const rounded = Math.round(value * monitor.rawMaxBrightness);
+            if (Math.round(brightness * monitor.rawMaxBrightness) === rounded)
                 return;
             brightness = value;
             setProc.command = isDdc ? ["ddcutil", "-b", busNum, "setvcp", "10", rounded] : ["brightnessctl", "s", rounded, "--quiet"];


### PR DESCRIPTION
## Summary
Use the actual max Monitor brightness instead of hard coded `100`.

## Problem
Some monitors report a max brightness other than `100` from ddcutil (in my case 50).
Thus the brightness only changes from e.g. 1-50 and stays the same from 50+.

## Solution
In the ddc monitor initialization remember the max brightness and use it instead of `100` when updating the brightness.
If not using ddc the max brightness defaults to 100.

## Changes
`.config/quickshell/ii/services/Brightness.qml`

## Test Scenarios
- [x] On local machine