### PR TITLE
feat(ai): Add auto-scroll functionality to AI chat

### DIFF
--- a/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
+++ b/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
@@ -211,7 +211,6 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         }
         
         // Always scroll to bottom when user sends a message
-        messageListView.shouldAutoScroll = true
         messageListView.positionViewAtEnd()
     }
 
@@ -320,26 +319,13 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
 
                 property int lastResponseLength: 0
 
-                // Simple auto-scroll state tracking (proven chat pattern)
                 property bool shouldAutoScroll: true
-                
-                // Track when user scrolls - simple and reliable
-                onContentYChanged: {
-                    shouldAutoScroll = atYEnd
-                }
-                
-                // Auto-scroll when content height changes (during streaming)
+                onContentYChanged: shouldAutoScroll = atYEnd
                 onContentHeightChanged: {
-                    if (shouldAutoScroll) {
-                        positionViewAtEnd()
-                    }
+                    if (shouldAutoScroll) positionViewAtEnd();
                 }
-                
-                // Auto-scroll when new messages are added
-                onCountChanged: {
-                    if (shouldAutoScroll) {
-                        positionViewAtEnd()
-                    }
+                onCountChanged: { // Auto-scroll when new messages are added
+                    if (shouldAutoScroll) positionViewAtEnd();
                 }
 
                 clip: true

--- a/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
+++ b/.config/quickshell/ii/modules/sidebarLeft/AiChat.qml
@@ -209,6 +209,10 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         else {
             Ai.sendUserMessage(inputText);
         }
+        
+        // Always scroll to bottom when user sends a message
+        messageListView.shouldAutoScroll = true
+        messageListView.positionViewAtEnd()
     }
 
     Process {
@@ -315,6 +319,28 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 mouseScrollFactor: Config.options.interactions.scrolling.mouseScrollFactor * 1.4
 
                 property int lastResponseLength: 0
+
+                // Simple auto-scroll state tracking (proven chat pattern)
+                property bool shouldAutoScroll: true
+                
+                // Track when user scrolls - simple and reliable
+                onContentYChanged: {
+                    shouldAutoScroll = atYEnd
+                }
+                
+                // Auto-scroll when content height changes (during streaming)
+                onContentHeightChanged: {
+                    if (shouldAutoScroll) {
+                        positionViewAtEnd()
+                    }
+                }
+                
+                // Auto-scroll when new messages are added
+                onCountChanged: {
+                    if (shouldAutoScroll) {
+                        positionViewAtEnd()
+                    }
+                }
 
                 clip: true
                 layer.enabled: true


### PR DESCRIPTION
## Summary

>Cleaned from PR #1960. New branch created from fresh pull of `upstream/main` before writing changes, sending PR.

>[!WARNING]
>I am not a very good programmer.
>This code was almost entirely generated by Claude Code.
>I have reviewed it to the best of my human ability.
>This specific fix has been working for me for about a week without issues.

Add intelligent auto-scroll behavior to AI chat interface that preserves user intent.

## Features
- Smart auto-scroll when user sends messages
- Stops auto-scroll when user manually scrolls up  
- Resumes auto-scroll when user scrolls back to bottom
- Follows streaming responses automatically

## Test plan
- [x] Send message and verify auto-scroll to response
- [x] Scroll up during response and verify auto-scroll stops
- [x] Scroll back to bottom and verify auto-scroll resumes
- [x] Test with rapid messages and long streaming responses

🤖 Generated with [Claude Code](https://claude.ai/code)