### PR TITLE
fix: thumbnail generation

### DIFF
--- a/.config/quickshell/ii/modules/wallpaperSelector/WallpaperDirectoryItem.qml
+++ b/.config/quickshell/ii/modules/wallpaperSelector/WallpaperDirectoryItem.qml
@@ -64,7 +64,7 @@ MouseArea {
                     active: root.useThumbnail
                     sourceComponent: ThumbnailImage {
                         id: thumbnailImage
-                        generateThumbnail: false
+                        generateThumbnail: true
                         sourcePath: fileModelData.filePath
 
                         cache: false


### PR DESCRIPTION
## Describe your changes
This PR fixes thumbnail generation issues by enabling option to generate thumbnails when not found.

## Is it ready? Questions/feedback needed?
It seems the dotfiles don't properly check for some thumbnails.
Normally, viewing the file in a file manager should generate a thumbnail in the appropriate dir.

Using the command below, I can generate a hash which when I go into the system thumbnail cache I and search for the generated thumbnail.

```bash
printf "file:///home/user/Pictures/Wallpapers/samurai.png" | md5sum | awk '{print $1}'
```
However, some wallpaper thumbnails don't show in the selector. I tried to check the implementation but I haven't learnt qs yet. This PR would make more sense to fix the issue of the selector not being able to retrieve some thumbnails generated by the system.

