### PR TITLE
feat(sideright): add Flatpak support for EasyEffects service and toggle

### DIFF
--- a/.config/quickshell/ii/modules/sidebarRight/quickToggles/EasyEffectsToggle.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/quickToggles/EasyEffectsToggle.qml
@@ -21,7 +21,7 @@ QuickToggleButton {
     }
 
     altAction: () => {
-        Quickshell.execDetached(["easyeffects"])
+        Quickshell.execDetached(["bash", "-c", "flatpak run com.github.wwmm.easyeffects || easyeffects"])
         GlobalStates.sidebarRightOpen = false
     }
 

--- a/.config/quickshell/ii/services/EasyEffects.qml
+++ b/.config/quickshell/ii/services/EasyEffects.qml
@@ -25,12 +25,12 @@ Singleton {
 
     function disable() {
         root.active = false
-        Quickshell.execDetached(["pkill", "easyeffects"])
+        Quickshell.execDetached(["bash", "-c", "pkill easyeffects || flatpak pkill com.github.wwmm.easyeffects"])
     }
 
     function enable() {
         root.active = true
-        Quickshell.execDetached(["easyeffects", "--gapplication-service"])
+        Quickshell.execDetached(["bash", "-c", "easyeffects --gapplication-service || flatpak run com.github.wwmm.easyeffects --gapplication-service"])
     }
 
     function toggle() {
@@ -44,7 +44,7 @@ Singleton {
     Process {
         id: fetchAvailabilityProc
         running: true
-        command: ["bash", "-c", "command -v easyeffects"]
+        command: ["bash", "-c", "command -v easyeffects || flatpak info com.github.wwmm.easyeffects > /dev/null 2>&1"]
         onExited: (exitCode, exitStatus) => {
             root.available = exitCode === 0
         }
@@ -53,7 +53,7 @@ Singleton {
     Process {
         id: fetchActiveStateProc
         running: true
-        command: ["pidof", "easyeffects"]
+        command: ["bash", "-c", "pidof easyeffects || flatpak ps | grep com.github.wwmm.easyeffects > /dev/null 2>&1"]
         onExited: (exitCode, exitStatus) => {
             root.active = exitCode === 0
         }


### PR DESCRIPTION
This commit introduces support for the Flatpak version of EasyEffects within QuickShell, alongside the existing native package support. This allows users to seamlessly manage EasyEffects whether it's installed via a traditional package manager or Flatpak. 

Key changes include:
- **`.config/quickshell/ii/services/EasyEffects.qml`**:
    - Modified `fetchAvailabilityProc` to check for both native `easyeffects` and Flatpak `com.github.wwmm.easyeffects`.
    - Updated `fetchActiveStateProc` to detect active processes for both native and Flatpak EasyEffects.
    - Enhanced `disable` function to gracefully terminate both native and Flatpak EasyEffects processes.
    - Improved `enable` function to launch the Flatpak version if available, falling back to the native version otherwise.
- **`.config/quickshell/ii/modules/sidebarRight/quickToggles/EasyEffectsToggle.qml`**:
    - Modified the `altAction` (right-click) to prioritize launching the Flatpak EasyEffects GUI, with a fallback to the native application.

These changes ensure a more robust and flexible integration of EasyEffects into QuickShell, accommodating different installation methods without requiring additional user configuration. The reason behind this pull request is so I don't have to download all the effects separately.

## Is it ready? Questions/feedback needed?
✅ Yes, I have tested it with both regular and flatpak version of easyeffects and it works fine