### PR TITLE
bar: fixed kb layout+variant display in top right

### DIFF
--- a/.config/quickshell/ii/modules/bar/BarContent.qml
+++ b/.config/quickshell/ii/modules/bar/BarContent.qml
@@ -293,11 +293,17 @@ Item { // Bar content region
                         active: HyprlandXkb.layoutCodes.length > 1
                         visible: active
                         Layout.rightMargin: indicatorsRowLayout.realSpacing
-                        sourceComponent: StyledText {
-                            text: HyprlandXkb.currentLayoutCode
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            color: rightSidebarButton.colText
-                            animateChange: true
+                        sourceComponent: Item {
+                            implicitWidth: layoutCodeText.implicitWidth
+                            StyledText {
+                                id: layoutCodeText
+                                anchors.centerIn: parent
+                                horizontalAlignment: Text.AlignHCenter
+                                text: HyprlandXkb.currentLayoutCode.split(":").join("\n")
+                                font.pixelSize: text.includes("\n") ? Appearance.font.pixelSize.smaller : Appearance.font.pixelSize.small
+                                color: rightSidebarButton.colText
+                                animateChange: true
+                            }
                         }
                     }
                     MaterialSymbol {

--- a/.config/quickshell/ii/modules/verticalBar/VerticalBarContent.qml
+++ b/.config/quickshell/ii/modules/verticalBar/VerticalBarContent.qml
@@ -273,11 +273,18 @@ Item { // Bar content region
                         active: HyprlandXkb.layoutCodes.length > 1
                         visible: active
                         Layout.bottomMargin: indicatorsColumnLayout.realSpacing
-                        sourceComponent: StyledText {
-                            text: HyprlandXkb.currentLayoutCode
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            color: rightSidebarButton.colText
-                            animateChange: true
+                        Layout.alignment: Qt.AlignHCenter
+                        sourceComponent: Item {
+                            implicitHeight: layoutCodeText.implicitHeight
+                            StyledText {
+                                id: layoutCodeText
+                                anchors.centerIn: parent
+                                horizontalAlignment: Text.AlignHCenter
+                                text: HyprlandXkb.currentLayoutCode.split(":").join("\n")
+                                font.pixelSize: text.includes("\n") ? Appearance.font.pixelSize.smaller : Appearance.font.pixelSize.small
+                                color: rightSidebarButton.colText
+                                animateChange: true
+                            }
                         }
                     }
                     MaterialSymbol {

--- a/.config/quickshell/ii/services/HyprlandXkb.qml
+++ b/.config/quickshell/ii/services/HyprlandXkb.qml
@@ -57,7 +57,7 @@ Singleton {
                     // Match variant: (whitespace + ) variant + whitespace + key + whitespace + description
                     const matchVariant = line.match(/^\s*(\S+)\s+(\S+)\s+(.+)$/);
                     if (matchVariant && matchVariant[3] === targetDescription) {
-                        const complexLayout = matchVariant[2] + " " + matchVariant[1];
+                        const complexLayout = matchVariant[2] + matchVariant[1];
                         root.cachedLayoutCodes[matchVariant[3]] = complexLayout;
                         root.currentLayoutCode = complexLayout;
                         return true;

--- a/.config/quickshell/ii/services/HyprlandXkb.qml
+++ b/.config/quickshell/ii/services/HyprlandXkb.qml
@@ -46,13 +46,24 @@ Singleton {
                     if (!line.trim() || line.trim().startsWith('!'))
                         return false;
 
-                    // Match: key + whitespace + description
-                    const match = line.match(/^\s*(\S+)\s+(.+)$/);
-                    if (match && match[2] === targetDescription) {
-                        root.cachedLayoutCodes[match[2]] = match[1];
-                        root.currentLayoutCode = match[1];
+                    // Match layout: (whitespace + ) key + whitespace + description
+                    const matchLayout = line.match(/^\s*(\S+)\s+(.+)$/);
+                    if (matchLayout && matchLayout[2] === targetDescription) {
+                        root.cachedLayoutCodes[matchLayout[2]] = matchLayout[1];
+                        root.currentLayoutCode = matchLayout[1];
                         return true;
                     }
+
+                    // Match variant: (whitespace + ) variant + whitespace + key + whitespace + description
+                    const matchVariant = line.match(/^\s*(\S+)\s+(\S+)\s+(.+)$/);
+                    if (matchVariant && matchVariant[3] === targetDescription) {
+                        const complexLayout = matchVariant[2] + " " + matchVariant[1];
+                        root.cachedLayoutCodes[matchVariant[3]] = complexLayout;
+                        root.currentLayourCode = complexLayout;
+                        return true;
+                    }
+                    
+                    return false;
                 });
                 // console.log("[HyprlandXkb] Found line:", foundLine);
                 // console.log("[HyprlandXkb] Layout:", root.currentLayoutName, "| Code:", root.currentLayoutCode);

--- a/.config/quickshell/ii/services/HyprlandXkb.qml
+++ b/.config/quickshell/ii/services/HyprlandXkb.qml
@@ -59,7 +59,7 @@ Singleton {
                     if (matchVariant && matchVariant[3] === targetDescription) {
                         const complexLayout = matchVariant[2] + " " + matchVariant[1];
                         root.cachedLayoutCodes[matchVariant[3]] = complexLayout;
-                        root.currentLayourCode = complexLayout;
+                        root.currentLayoutCode = complexLayout;
                         return true;
                     }
                     


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

In the top-right bar, the keyboard layout did not accurately change when also providing a variant.
Here is an example of a keyboard setup where nothing happened before:
```
kb_layout = us,ro
kb_variant = ,std
kb_options = grp:shifts_toggle
```
In this case, pressing both shift keys would cause the layout to change, allowing for the input of Romanian characters. However, in the top right, "us" will still be displayed.
The fix is supposed to handle the layout + variant case.

## Is it ready? Questions/feedback needed?

Just see if you like it :)
