### PR TITLE
Trying to improve transparency.

### DIFF
--- a/.config/quickshell/ii/modules/common/Appearance.qml
+++ b/.config/quickshell/ii/modules/common/Appearance.qml
@@ -122,10 +122,10 @@ Singleton {
         property color colLayer0Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer0, colOnLayer0, 0.9, root.contentTransparency))
         property color colLayer0Active: ColorUtils.transparentize(ColorUtils.mix(colLayer0, colOnLayer0, 0.8, root.contentTransparency))
         property color colLayer0Border: ColorUtils.mix(root.m3colors.m3outlineVariant, colLayer0, 0.4)
-        property color colLayer1: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize("white", 0.97): ColorUtils.transparentize("white", 0.8) : m3colors.m3surfaceContainerLow;
+        property color colLayer1: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize(colors.colOnLayer0, 0.98): ColorUtils.transparentize(colors.colLayer0, 0.8) : m3colors.m3surfaceContainerLow;
         property color colOnLayer1: m3colors.m3onSurfaceVariant;
         property color colOnLayer1Inactive: ColorUtils.mix(colOnLayer1, colLayer1, 0.45);
-        property color colLayer2: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize("white", 0.94): ColorUtils.transparentize("white", 0.7) : m3colors.m3surfaceContainer
+        property color colLayer2: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize(colors.colOnLayer0, 0.96): ColorUtils.transparentize(colors.colLayer0, 0.7) : m3colors.m3surfaceContainer
         property color colOnLayer2: m3colors.m3onSurface;
         property color colOnLayer2Disabled: ColorUtils.mix(colOnLayer2, m3colors.m3background, 0.4);
         property color colLayer1Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer1, colOnLayer1, 0.92), root.contentTransparency)
@@ -133,11 +133,11 @@ Singleton {
         property color colLayer2Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer2, colOnLayer2, 0.90), root.contentTransparency)
         property color colLayer2Active: ColorUtils.transparentize(ColorUtils.mix(colLayer2, colOnLayer2, 0.80), root.contentTransparency);
         property color colLayer2Disabled: ColorUtils.transparentize(ColorUtils.mix(colLayer2, m3colors.m3background, 0.8), root.contentTransparency);
-        property color colLayer3: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize("white", 0.92) : ColorUtils.transparentize("white", 0.5) : m3colors.m3surfaceContainerHigh
+        property color colLayer3: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize(colors.colOnLayer0, 0.94) : ColorUtils.transparentize(colors.colLayer0, 0.5) : m3colors.m3surfaceContainerHigh
         property color colOnLayer3: m3colors.m3onSurface;
         property color colLayer3Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer3, colOnLayer3, 0.90), root.contentTransparency)
         property color colLayer3Active: ColorUtils.transparentize(ColorUtils.mix(colLayer3, colOnLayer3, 0.80), root.contentTransparency);
-        property color colLayer4: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize("white", 0.9): ColorUtils.transparentize("white", 0.2) : m3colors.m3surfaceContainerHighest
+        property color colLayer4: root.contentTransparency ? m3colors.darkmode ? ColorUtils.transparentize(colors.colOnLayer0, 0.92): ColorUtils.transparentize(colors.colLayer0, 0.2) : m3colors.m3surfaceContainerHighest
         property color colOnLayer4: m3colors.m3onSurface;
         property color colLayer4Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer4, colOnLayer4, 0.90), root.contentTransparency)
         property color colLayer4Active: ColorUtils.transparentize(ColorUtils.mix(colLayer4, colOnLayer4, 0.80), root.contentTransparency);

--- a/.config/quickshell/ii/modules/common/widgets/NotificationGroup.qml
+++ b/.config/quickshell/ii/modules/common/widgets/NotificationGroup.qml
@@ -117,7 +117,7 @@ MouseArea { // Notification group area
         id: background
         anchors.left: parent.left
         width: parent.width
-        color: popup ? ColorUtils.applyAlpha(Appearance.colors.colLayer2, 1 - Appearance.backgroundTransparency) : Appearance.colors.colLayer2
+        color: popup ? Appearance.m3colors.darkmode ? ColorUtils.applyAlpha(Appearance.colors.colLayer0, 0.6) : ColorUtils.applyAlpha(Appearance.colors.colLayer2, 1 - Appearance.backgroundTransparency) : Appearance.colors.colLayer2
         radius: Appearance.rounding.normal
         anchors.leftMargin: root.xOffset
 


### PR DESCRIPTION
## Describe your changes
A very simple fix to improve the visual hierarchy in transparent mode.
I know it's not perfect , yet I think its better 🙃
<!--- ONE FEATURE PER PULL REQUEST ONLY -->
|Before | After[updated] |
|---|---|
|<img width="575" height="1080" alt="original_dark" src="https://github.com/user-attachments/assets/3e0168e0-830e-4efb-93f0-5c7a16dd8f17" />|<img width="575" height="1080" alt="dark_adjusted_transparency" src="https://github.com/user-attachments/assets/97c09d4e-6567-448d-afdc-e9c40404bb79" />|
|<img width="575" height="1080" alt="original_dark1" src="https://github.com/user-attachments/assets/e251dd2f-3588-48de-a20d-96b27b41b7fa" />|<img width="575" height="1080" alt="dark_adjusted_transparency1" src="https://github.com/user-attachments/assets/d5f51b29-672a-487a-a62e-021c13b7f0c1" />|
|<img width="590" height="1080" alt="original_light" src="https://github.com/user-attachments/assets/bc774f3b-f56a-4805-81b0-cb79e481d15e" />|<img width="575" height="1080" alt="light_transparency1" src="https://github.com/user-attachments/assets/19c05232-9be5-453a-8390-7f068f3ab4cd" />|
|<img width="575" height="1080" alt="original_light1" src="https://github.com/user-attachments/assets/4e4ca706-3e54-4b4d-942e-4d09b88d94ef" />|<img width="575" height="1080" alt="light_transparency" src="https://github.com/user-attachments/assets/eb76ea05-a9be-4ddc-aa36-3d28137980d7" />|


## Is it ready? Questions/feedback needed?
You can see the screenshots and I was not able find any side effects. Merge it if you like it or just reject it.