### PR TITLE
Changed the night light on/off/auto mode to continuous instead of right click to auto

### DIFF
--- a/.config/quickshell/ii/modules/sidebarRight/quickToggles/NightLight.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/quickToggles/NightLight.qml
@@ -7,22 +7,38 @@ import Quickshell.Io
 
 QuickToggleButton {
     id: nightLightButton
-    property bool enabled: Hyprsunset.active
-    toggled: enabled
-    buttonIcon: Config.options.light.night.automatic ? "night_sight_auto" : "bedtime"
+
+    property int nightLightState: 0 // Start with "off" state
+
+    toggled: nightLightState > 0
+    buttonIcon: {
+        switch (nightLightState) {
+            case 0: return "bedtime"; // Off
+            case 1: return "bedtime"; // On
+            case 2: return "night_sight_auto"; // Auto
+        }
+    }
+
     onClicked: {
-        Hyprsunset.toggle()
-    }
+        // Cycle through states: 0 (off) -> 1 (on) -> 2 (auto) -> 0 (off)
+        nightLightState = (nightLightState + 1) % 3;
 
-    altAction: () => {
-        Config.options.light.night.automatic = !Config.options.light.night.automatic
-    }
-
-    Component.onCompleted: {
-        Hyprsunset.fetchState()
-    }
-    
-    StyledToolTip {
-        text: Translation.tr("Night Light | Right-click to toggle Auto mode")
+        switch (nightLightState) {
+            case 0: // Set to Off
+                Config.options.light.night.automatic = false;
+                if (Hyprsunset.active) {
+                    Hyprsunset.toggle();
+                }
+                break;
+            case 1: // Set to On
+                Config.options.light.night.automatic = false;
+                if (!Hyprsunset.active) {
+                    Hyprsunset.toggle();
+                }
+                break;
+            case 2: // Set to Auto
+                Config.options.light.night.automatic = true;
+                break;
+        }
     }
 }


### PR DESCRIPTION
When Night Light is enabled by clicking the Quicktoggle, and then switched to Auto Mode via a right-click, the Night Light remains enabled if the current time falls within the Scheduled Time range (from the start time to the end time).

However, if the Quicktoggle is clicked again, the Night Light gets disabled, even though Auto Mode is still active and the current time is still within the Scheduled Time range.

Upon reloading the QuickShell, the Night Light is enabled again, but the Quicktoggle remains in the Disabled state, while Auto Mode is still active.

I have made the states continuous—Off, On, and Auto—so that only one state can be active at a time.