### PR TITLE
fix(HyprlandXkb): keyboard layout indicator broken on systems

### DIFF
--- a/.config/quickshell/ii/services/HyprlandXkb.qml
+++ b/.config/quickshell/ii/services/HyprlandXkb.qml
@@ -82,7 +82,7 @@ Singleton {
             id: devicesCollector
             onStreamFinished: {
                 const parsedOutput = JSON.parse(devicesCollector.text);
-                const hyprlandKeyboard = parsedOutput["keyboards"].find(kb => kb.main === true);
+                const hyprlandKeyboard = parsedOutput["keyboards"].find(kb => kb.main === true) || parsedOutput.keyboards.find(k => k.main === true);
                 root.layoutCodes = hyprlandKeyboard["layout"].split(",");
                 root.currentLayoutName = hyprlandKeyboard["active_keymap"];
                 // console.log("[HyprlandXkb] Fetched | Layouts (multiple: " + (root.layouts.length > 1) + "): "


### PR DESCRIPTION
## Describe your changes

Fixes the keyboard layout indicator in `HyprlandXkb.qml`.  
After the Arch update at the end of August, the keyboard layout display in Quickshell stopped working on both of my systems (reinstalling with `install.sh` did not help). This commit fixes the issue.

## Is it ready? Questions/feedback needed?

Yes, it is ready. This fix restores the layout indicator display on my systems.