### PR TITLE
cheatsheet: added element weight to periodic table

### DIFF
--- a/.config/quickshell/ii/modules/cheatsheet/ElementTile.qml
+++ b/.config/quickshell/ii/modules/cheatsheet/ElementTile.qml
@@ -26,9 +26,31 @@ RippleButton {
 
         StyledText {
             id: elementNumber
-            anchors.centerIn: parent
+            anchors.left: parent.left
             color: Appearance.colors.colOnLayer2
             text: root.element.number
+            font.pixelSize: Appearance.font.pixelSize.smallest
+        }
+    }
+
+    Rectangle {
+        anchors {
+            top: parent.top
+            right: parent.right
+            topMargin: 4
+            rightMargin: 4
+        }
+        color: Appearance.colors.colLayer2
+        radius: Appearance.rounding.full
+        implicitWidth: Math.max(20, elementWeight.implicitWidth)
+        implicitHeight: Math.max(20, elementWeight.implicitHeight)
+        width: height
+
+        StyledText {
+            id: elementWeight
+            anchors.right: parent.right
+            color: Appearance.colors.colOnLayer2
+            text: root.element.weight
             font.pixelSize: Appearance.font.pixelSize.smallest
         }
     }


### PR DESCRIPTION
## Describe your changes

Added the element weight to the periodic table in the cheatsheet. (I find it useful for chemistry class lol)
It was fairly easy, as the data was already stored in periodic_table.js.

## Is it ready? Questions/feedback needed?

The design/layout is pretty rough, but it seems readable enough. I'm open to any sort of changes and proposals!