### PR TITLE
fix(brightness): prevent bus number collision for identical monitor m…

### DIFF
--- a/.config/quickshell/ii/services/Brightness.qml
+++ b/.config/quickshell/ii/services/Brightness.qml
@@ -74,8 +74,14 @@ Singleton {
         id: monitor
 
         required property ShellScreen screen
-        readonly property bool isDdc: root.ddcMonitors.some(m => m.model === screen.model)
-        readonly property string busNum: root.ddcMonitors.find(m => m.model === screen.model)?.busNum ?? ""
+        readonly property bool isDdc: {
+            const match = root.ddcMonitors.find(m => m.model === screen.model && !root.monitors.slice(0, root.monitors.indexOf(this)).some(mon => mon.busNum === m.busNum));
+            return !!match;
+        }
+        readonly property string busNum: {
+            const match = root.ddcMonitors.find(m => m.model === screen.model && !root.monitors.slice(0, root.monitors.indexOf(this)).some(mon => mon.busNum === m.busNum));
+            return match?.busNum ?? "";
+        }
         property int rawMaxBrightness: 100
         property real brightness
         property bool ready: false


### PR DESCRIPTION
Bug: Brightness control affects wrong monitor when multiple displays share the same model name

Environment: 3 monitors: DP-1 (DELL S2721DGF), HDMI-A-2 (DELL G2724D), DP-2 (DELL G2724D)

Problem:
When scrolling to adjust brightness on DP-2 (middle monitor), the brightness of HDMI-A-2 (left monitor) changes instead. Both monitors share the model name "DELL G2724D".

Root cause:
The brightness monitor matching logic uses find(m => m.model === screen.model) which always returns the first ddcutil entry with a matching model name. When DP-2 tries to find its bus number, it gets assigned HDMI-A-2's bus instead of its own.

Solution:
Modified the matching logic to exclude bus numbers already claimed by previously-initialized monitors, ensuring each monitor gets its own unique I2C bus even when model names are identical.
