### PR TITLE
fix: ignore case (The latest Hyprland process name has changed)

### DIFF
--- a/.config/quickshell/ii/modules/common/functions/Session.qml
+++ b/.config/quickshell/ii/modules/common/functions/Session.qml
@@ -22,7 +22,7 @@ Singleton {
 
     function logout() {
         closeAllWindows();
-        Quickshell.execDetached(["pkill", "Hyprland"]);
+        Quickshell.execDetached(["pkill", "-i", "Hyprland"]);
     }
 
     function launchTaskManager() {


### PR DESCRIPTION
hyprland's main process name has been changed from Hyprland to hyprland (all lower-case).
