### PR TITLE
fix(settings): fixed open config button file from settings

### DIFF
--- a/.config/quickshell/ii/settings.qml
+++ b/.config/quickshell/ii/settings.qml
@@ -10,6 +10,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
+import Quickshell
 import qs
 import qs.services
 import qs.modules.common
@@ -173,7 +174,11 @@ ApplicationWindow {
                         buttonText: Translation.tr("Config file")
                         expanded: navRail.expanded
                         onClicked: {
-                            Qt.openUrlExternally(`${Directories.config}/illogical-impulse/config.json`);
+                            Quickshell.execDetached([
+                                "bash", "-c",
+                                'file="$0"; ~/.config/hypr/hyprland/scripts/launch_first_available.sh "code \"$file\"" "codium \"$file\"" "cursor \"$file\"" "zed \"$file\"" "zedit \"$file\"" "zeditor \"$file\"" "kate \"$file\"" "gnome-text-editor \"$file\"" "emacs \"$file\"" "command -v nvim && kitty -1 nvim \"$file\"" "command -v micro && kitty -1 micro \"$file\""',
+                                CF.FileUtils.trimFileProtocol(Directories.config + "/illogical-impulse/config.json")
+                            ])
                         }
 
                         StyledToolTip {


### PR DESCRIPTION
## Describe your changes
Fixed the `Config file` button not working with the tooltip "*If the button doens't work [...]*"
I reused the hyprland script `~/.config/hypr/hyprland/scripts/launch_first_available.sh`.

- `Qt.openUrlExternally` doesn't make sense to me if we open a local file in an editor
  - Imported `Quickshell` and used `Quickshell.execDetached` instead
- `${Directories.config}` : the file prefix is still here -> `file://` (or something like that)
  - Used `CF.FileUtils.trimFileProtocol` to fix that
    > CF is coming from you and the start of the file

Implementing a proper interface to select the favorite editor and "remember it" might be practical in the future (for now it just loops through a list of app until it finds something)

## Is it ready? Questions/feedback needed?
I think so, you can test it on your system beforehand tho

