### PR TITLE
Set background opacity when using live wallpaper

### DIFF
--- a/.config/quickshell/ii/modules/background/Background.qml
+++ b/.config/quickshell/ii/modules/background/Background.qml
@@ -178,6 +178,7 @@ Variants {
             StyledImage {
                 id: wallpaper
                 visible: opacity > 0 && !blurLoader.active
+                opacity: (status === Image.Ready && !bgRoot.wallpaperIsVideo) ? 1 : 0
                 cache: false
                 smooth: false
                 // Range = groups that workspaces span on


### PR DESCRIPTION

## Describe your changes
Fix what was causing thumbnail to display over mpvpaper

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Live wallpaper still looks buggy when reload unless set transparent wallpaper bg as in #2072


