### PR TITLE
Add more status in the network icon

### DIFF
--- a/.config/quickshell/ii/modules/sidebarRight/quickToggles/NetworkToggle.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/quickToggles/NetworkToggle.qml
@@ -10,7 +10,7 @@ import Quickshell.Io
 import Quickshell.Hyprland
 
 QuickToggleButton {
-    toggled: Network.wifiEnabled
+    toggled: Network.wifiStatus !== "disabled"
     buttonIcon: Network.materialSymbol
     onClicked: Network.toggleWifi()
     altAction: () => {


### PR DESCRIPTION
## Describe your changes

This adds more status icons for the network icon so you know what's going on.

To better explain what is achieved, here's all the icons it can display:
<img width="717" height="132" alt="status" src="https://github.com/user-attachments/assets/bb7b6088-94b8-40d4-92a2-79fc4e327bb8" />

1) Connected through LAN
2) Adapter is turned off
3) Adapter is turned on and is looking for a network to connect
4) Found a network is trying to connect
5) Connected and above 83% signal strength
6) Connected and above 67% signal strength (this icon is new)
7) Connected and above 50% signal strength
8) Connected and above 33% signal strength
9) Connected and above 17% signal strength
10) Connected and **_below_** 17% signal strength
11) Connected, but limited connection (can't connect to the internet/ping failed)

So basically:
- Icon 2 is now only shown when the adapter is turned off.
- Icons 3, 4 and 11 are new status.
- And the signal strength has a new icon (6) so it improves the granularity and the jump is less noticeable, as before it would go from 100% to 50% filled. Now there's this 75% filled icon.

Also, the button in the right sidebar will also reflect its background to the state of the adapter instead of the connection. That is, the button only turns off if the adapter is turned off as well. Before, if you were not where you have a saved connection, clicking the button would do nothing as it would not find a connection.

## Is it ready? Questions/feedback needed?

The PR is ready, I've been using it for a few weeks already. The connection loss icon (11) does show up even after the connection started normally, but goes bad later.

I only have a laptop with a single adapter, no idea what could happen on a system with multiple adapters. My guess, based on the code, is that it will show up the status of only one of them, with a possibility of randomly changing which adapter status is shown.