### PR TITLE
Update keybinds with keycodes for workspace navigation

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -108,6 +108,7 @@ bind = Super+Alt, F, fullscreenstate, 0 3 # Fullscreen spoof
 bind = Super, P, pin # Pin
 
 #/# bind = Super+Alt, Hash,, # Send to workspace # (1, 2, 3,...)
+# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
 bind = Super+Alt, code:10, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh movetoworkspacesilent 1 # [hidden]
 bind = Super+Alt, code:11, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh movetoworkspacesilent 2 # [hidden]
 bind = Super+Alt, code:12, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh movetoworkspacesilent 3 # [hidden]
@@ -140,6 +141,7 @@ bind = Ctrl+Super, S, togglespecialworkspace, # [hidden]
 ##! Workspace
 # Switching
 #/# bind = Super, Hash,, # Focus workspace # (1, 2, 3,...)
+# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
 bind = Super, code:10, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh workspace 1 # [hidden]
 bind = Super, code:11, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh workspace 2 # [hidden]
 bind = Super, code:12, exec, ~/.config/hypr/hyprland/scripts/workspace_action.sh workspace 3 # [hidden]


### PR DESCRIPTION
Fixes https://github.com/end-4/dots-hyprland/issues/1705

## Describe your changes
Some keyboard layouts such as Azerty and Bépo default to symbols for the digits row, contrary to Qwerty-based layouts. Pressing Shift allows typing the actual digits instead of symbols.

Unfortunately, this breaks Workspace navigation in Hyprland configurations unless using keycodes for binding the digits row (1, 2, 3...0).

This commit does exactly that. It was tested with three keyboards, each time with 2 layouts: Azerty (French) / Qwerty (US). The physical keyboards were:
- Asus Strix Scope II 96 Wireless
- Keychron Q3 HE QMK (ISO layout)
- The keyboard integrated in the Lenovo Thinkpad P16s Gen3 laptop.

## Is it ready? Questions/feedback needed?
I tested with only 3 physical keyboards, on Arch with Hyprland installed (these dots, and in the past with Prasanthrangan's HyDE).
It is hard for me to tell if there would be compatibility issues with other hardware / OS.

