### PR TITLE
feat: add DeepSeek Chat LLM integration to quickshell AI service

### DIFF
--- a/.config/quickshell/ii/services/ai/OpenAiApiStrategy.qml
+++ b/.config/quickshell/ii/services/ai/OpenAiApiStrategy.qml
@@ -21,9 +21,14 @@ ApiStrategy {
                 }),
             ],
             "stream": true,
-            "tools": tools,
             "temperature": temperature,
         };
+        
+        // Only include tools if they are not empty (DeepSeek doesn't accept empty tools array)
+        if (tools && tools.length > 0) {
+            baseData.tools = tools;
+        }
+        
         return model.extraParams ? Object.assign({}, baseData, model.extraParams) : baseData;
     }
 


### PR DESCRIPTION
## Summary
- Add DeepSeek Chat model configuration with proper API endpoint and key management
- Configure model with 128K context length support and OpenAI-compatible API format
- Add DeepSeek-specific icon and pricing information
- Fix API strategy selection to use model-specific strategies instead of currentApiStrategy
- Fix tools array handling to avoid sending empty tools array to DeepSeek API

## Test plan
- [ ] Verify DeepSeek Chat appears in model selection list
- [ ] Test API key configuration for DeepSeek model
- [ ] Verify proper API endpoint and request format
- [ ] Test that empty tools arrays are not sent to DeepSeek API
- [ ] Confirm model-specific API strategies are used correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)