### PR TITLE
Hide Bluetooth widgets for systems without Bluetooth

### DIFF
--- a/.config/quickshell/ii/modules/bar/BarContent.qml
+++ b/.config/quickshell/ii/modules/bar/BarContent.qml
@@ -301,6 +301,7 @@ Item { // Bar content region
                         color: rightSidebarButton.colText
                     }
                     MaterialSymbol {
+                        visible: BluetoothStatus.available
                         text: BluetoothStatus.connected ? "bluetooth_connected" : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
                         iconSize: Appearance.font.pixelSize.larger
                         color: rightSidebarButton.colText

--- a/.config/quickshell/ii/modules/sidebarRight/quickToggles/BluetoothToggle.qml
+++ b/.config/quickshell/ii/modules/sidebarRight/quickToggles/BluetoothToggle.qml
@@ -11,6 +11,7 @@ import Quickshell.Hyprland
 
 QuickToggleButton {
     id: root
+    visible: BluetoothStatus.available
     toggled: BluetoothStatus.enabled
     buttonIcon: BluetoothStatus.connected ? "bluetooth_connected" : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
     onClicked: {

--- a/.config/quickshell/ii/modules/verticalBar/VerticalBarContent.qml
+++ b/.config/quickshell/ii/modules/verticalBar/VerticalBarContent.qml
@@ -279,6 +279,7 @@ Item { // Bar content region
                         color: rightSidebarButton.colText
                     }
                     MaterialSymbol {
+                        visible: BluetoothStatus.available
                         text: BluetoothStatus.connected ? "bluetooth_connected" : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
                         iconSize: Appearance.font.pixelSize.larger
                         color: rightSidebarButton.colText

--- a/.config/quickshell/ii/services/BluetoothStatus.qml
+++ b/.config/quickshell/ii/services/BluetoothStatus.qml
@@ -12,6 +12,7 @@ import QtQuick
 Singleton {
     id: root
 
+    readonly property bool available: Bluetooth.adapters.values.length > 0
     readonly property bool enabled: Bluetooth.defaultAdapter?.enabled ?? false
     readonly property BluetoothDevice firstActiveDevice: Bluetooth.defaultAdapter?.devices.values.find(device => device.connected) ?? null
     readonly property int activeDeviceCount: Bluetooth.defaultAdapter?.devices.values.filter(device => device.connected).length ?? 0


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

This hides the Bluetooth widgets on systems that don't have it (technically where no adapters were found):

<img width="434" height="111" alt="image" src="https://github.com/user-attachments/assets/e6238baa-3b1d-498c-980d-e156cbbfddf0" />
<img width="239" height="40" alt="image" src="https://github.com/user-attachments/assets/0a071a67-200f-4a94-a686-37c3930778bf" />

## Is it ready? Questions/feedback needed?

Ready for review

