### PR TITLE
Include keypad numbers for keybinds with numbers

### DIFF
--- a/.config/hypr/hyprland/keybinds.conf
+++ b/.config/hypr/hyprland/keybinds.conf
@@ -223,6 +223,11 @@ binde = Super, Minus, exec, qs -c $qsConfig ipc call zoom zoomOut # Zoom out
 binde = Super, Equal, exec, qs -c $qsConfig ipc call zoom zoomIn # Zoom in
 binde = Super, Minus, exec, qs -c $qsConfig ipc call TEST_ALIVE || ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.1 # [hidden] Zoom out
 binde = Super, Equal, exec, qs -c $qsConfig ipc call TEST_ALIVE || ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.1 # [hidden] Zoom in
+# Zoom with keypad
+binde = Super, code:82, exec, qs -c $qsConfig ipc call zoom zoomOut # Zoom out
+binde = Super, code:86, exec, qs -c $qsConfig ipc call zoom zoomIn # Zoom in
+binde = Super, code:82, exec, qs -c $qsConfig ipc call TEST_ALIVE || ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.1 # [hidden] Zoom out
+binde = Super, code:86, exec, qs -c $qsConfig ipc call TEST_ALIVE || ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.1 # [hidden] Zoom in
 
 ##! Media
 bindl= Super+Shift, N, exec, playerctl next || playerctl position `bc <<< "100 * $(playerctl metadata mpris:length) / 1000000 / 100"` # Next track


### PR DESCRIPTION
## Describe your changes

Adds the keypad numbers for the `Super`+`#` and `Super`+`Alt`+`#` keybinds. Useful for those who have a full keyboard.

Also includes zooming with the keypad plus and minus.

## Is it ready? Questions/feedback needed?

Ready.