### PR TITLE
Fix bad keyboard layout if variant name has commas

### DIFF
--- a/dots/.config/quickshell/ii/services/HyprlandXkb.qml
+++ b/dots/.config/quickshell/ii/services/HyprlandXkb.qml
@@ -109,7 +109,7 @@ Singleton {
                 root.currentLayoutName = dataString.substring(dataString.indexOf(",") + 1);
 
                 // Update layout for on-screen keyboard (osk)
-                Config.options.osk.layout = root.currentLayoutName
+                Config.options.osk.layout = root.currentLayoutName.split(" (")[0];
             } else if (event.name == "configreloaded") {
                 // Mark layout code list to be updated when config is reloaded
                 root.needsLayoutRefresh = true;


### PR DESCRIPTION
## Describe your changes

This fixes two bugs with keyboard layouts:

- If the layout name has commas it just breaks the tray visualization.  
For example, I use the "English (US, intl., with dead keys)" layout, but I use a magic trick to make Ctrl+dead_key shortcuts work by changing the layout to English (US) when Ctrl is pressed down and back to international when it's released. So when I started quickshell it would show "us intl" in the tray, when I pressed Ctrl it would change to "us" (as expected), but when it went back to the intl variant it would not change to "us intl". The problem is that the code was splitting by commas and getting index 1, but because the intl name has commas it would just get "English (US".
- The second "bug" is that the German/Russian layout for the OSK keyboard would only work for the fully German and Russian layouts, but not for the local variants, like German (Austria), German (Switzerland), Russian (Belarus) and so on. So I decided to remove the parenthesis part, so all of those variants show the OSK as German or Russian as expected. Right now the OSK does not offer French AZERTY, but it will have some troubles because Canada and some others use QWERTY instead, and the code as I left would make all French keyboards AZERTY.

## Is it ready? Questions/feedback needed?

Maybe? I just did it, but I tested with English US, German Austrian, English International with dead keys and Russian Belarus