### PR TITLE
Fix dominant color from least_busy_region as BGR

### DIFF
--- a/.config/quickshell/ii/scripts/images/least_busy_region.py
+++ b/.config/quickshell/ii/scripts/images/least_busy_region.py
@@ -294,7 +294,8 @@ def get_dominant_color(image_path, x, y, w, h, screen_width=None, screen_height=
     _, labels, centers = cv2.kmeans(region, K, None, criteria, 10, cv2.KMEANS_RANDOM_CENTERS)
     counts = np.bincount(labels.flatten())
     dominant = centers[np.argmax(counts)]
-    return [int(x) for x in dominant]
+    # Reverse from BGR to RGB
+    return [int(x) for x in reversed(dominant)]
 
 def main():
     parser = argparse.ArgumentParser(description="Find least busy region in an image and output a JSON. Made for determining a suitable position for a wallpaper widget.")


### PR DESCRIPTION
## Describe your changes

The least_busy_region.py script extracts a dominant colour, but it returns as BGR instead of RGB as Quickshell expects, so this reverses the color components so it returns it as RGB.

One can easily test this by simply creating a fully red image an running the script, you'll notice it returns the dominant colour as `#0000FE`, which is blue instead of red.

## Is it ready? Questions/feedback needed?

Yes
