### PR TITLE
Fix: Preserve chronological order of clipboard history

### DIFF
--- a/.config/quickshell/ii/services/Cliphist.qml
+++ b/.config/quickshell/ii/services/Cliphist.qml
@@ -21,6 +21,9 @@ Singleton {
         entry: a
     }))
     function fuzzyQuery(search: string): var {
+        if (search.trim() === "") {
+            return entries;
+        }
         if (root.sloppySearch) {
             const results = entries.slice(0, 100).map(str => ({
                 entry: str,


### PR DESCRIPTION
The fuzzy search logic was incorrectly sorting entries alphabetically when the search query was empty.
This change modifies the `fuzzyQuery` function to bypass the search and return the original, unsorted list when the input is empty. 
