### PR TITLE
Don't scroll when deleting clipboard history items

### DIFF
--- a/.config/quickshell/ii/modules/overview/SearchWidget.qml
+++ b/.config/quickshell/ii/modules/overview/SearchWidget.qml
@@ -403,7 +403,7 @@ Item { // Wrapper
                             return entry;
                         })
                         const commandResultObject = {
-                            key: `cmd /${root.searchingText}`,
+                            key: `cmd ${root.searchingText}`,
                             name: StringUtils.cleanPrefix(root.searchingText, Config.options.search.prefix.shellCommand).replace("file://", ""),
                             clickActionName: Translation.tr("Run"),
                             type: Translation.tr("Run command"),


### PR DESCRIPTION
## Describe your changes

When you delete an item in the clipboard history it scrolls to the first item. This should prevent that behaviour and just keep you where you are.

Also, I think this makes things more efficient because ScriptModel only updates the stuff with different keys now. I guess the default behaviour would compare the object itself that would always be false.

## Is it ready? Questions/feedback needed?

It's good.

Maybe more testing, but my tests worked fine. Writing more stuff goes back to first item, backspace also works like that.  All the possible search options worked fine. And deleting stuff on the clipboard history don't go jumping around anymore.