### PR TITLE
Delete items in clipboard history with Shift+Del

### DIFF
--- a/dots/.config/quickshell/ii/modules/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/overview/SearchItem.qml
@@ -96,7 +96,13 @@ RippleButton {
         root.itemExecute()
     }
     Keys.onPressed: (event) => {
-        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+        if (event.key === Qt.Key_Delete && event.modifiers === Qt.ShiftModifier) {
+            const deleteAction = root.entry.actions.find(action => action.name == "Delete");
+
+            if (deleteAction) {
+                deleteAction.execute()
+            }
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             root.keyboardDown = true
             root.clicked()
             event.accepted = true;

--- a/dots/.config/quickshell/ii/modules/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/overview/SearchWidget.qml
@@ -179,7 +179,7 @@ Item { // Wrapper
         }
 
         // Only handle visible printable characters (ignore control chars, arrows, etc.)
-        if (event.text && event.text.length === 1 && event.key !== Qt.Key_Enter && event.key !== Qt.Key_Return && event.text.charCodeAt(0) >= 0x20) // ignore control chars like Backspace, Tab, etc.
+        if (event.text && event.text.length === 1 && event.key !== Qt.Key_Enter && event.key !== Qt.Key_Return && event.key !== Qt.Key_Delete && event.text.charCodeAt(0) >= 0x20) // ignore control chars like Backspace, Tab, etc.
         {
             if (!searchInput.activeFocus) {
                 searchInput.forceActiveFocus();


### PR DESCRIPTION
## Describe your changes

This allows deleting items in the clipboard history by pressing `Shift`+`Del`.

## Is it ready? Questions/feedback needed?

Yes. But definitely needs #2198, otherwise the jumping around is unbearable.
