### PR TITLE
Fix Booru pending query not dismissing when fetch fails

### DIFF
--- a/dots/.config/quickshell/ii/services/Booru.qml
+++ b/dots/.config/quickshell/ii/services/Booru.qml
@@ -399,6 +399,9 @@ Singleton {
             }
             else if (xhr.readyState === XMLHttpRequest.DONE) {
                 console.log("[Booru] Request failed with status: " + xhr.status)
+                newResponse.message = root.failMessage
+                root.runningRequests--;
+                root.responses = [...root.responses, newResponse]
             }
             root.responseFinished()
         }


### PR DESCRIPTION
## Describe your changes

If the Booru fetch fails with a non 200 response the pending query message stays "forever" on the UI. I've added the same code that removes the message from the other parts of the code in the `else` part.

## Is it ready? Questions/feedback needed?

Yes.