### PR TITLE
Implement support for multiple wallpapers for different monitors

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -221,6 +221,10 @@ Singleton {
                     property bool enableSidebar: true
                     property real widgetsFactor: 1.2
                 }
+                property JsonObject multiMonitor: JsonObject {
+                    property bool enable: false
+                }
+                property list<var> wallpapersByMonitor: []
             }
 
             property JsonObject bar: JsonObject {
@@ -581,7 +585,7 @@ Singleton {
             property JsonObject wallpaperSelector: JsonObject {
                 property bool useSystemFileDialog: false
             }
-            
+
             property JsonObject windows: JsonObject {
                 property bool showTitlebar: true // Client-side decoration for shell apps
                 property bool centerTitle: true

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -38,8 +38,9 @@ Variants {
         property int firstWorkspaceId: relevantWindows[0]?.workspace.id || 1
         property int lastWorkspaceId: relevantWindows[relevantWindows.length - 1]?.workspace.id || 10
         // Wallpaper
-        property bool wallpaperIsVideo: Config.options.background.wallpaperPath.endsWith(".mp4") || Config.options.background.wallpaperPath.endsWith(".webm") || Config.options.background.wallpaperPath.endsWith(".mkv") || Config.options.background.wallpaperPath.endsWith(".avi") || Config.options.background.wallpaperPath.endsWith(".mov")
-        property string wallpaperPath: wallpaperIsVideo ? Config.options.background.thumbnailPath : Config.options.background.wallpaperPath
+        property bool wallpaperIsVideo: resolvedPath.endsWith(".mp4") || resolvedPath.endsWith(".webm") || resolvedPath.endsWith(".mkv") || resolvedPath.endsWith(".avi") || resolvedPath.endsWith(".mov")
+        property string resolvedPath: WallpaperListener.effectivePerMonitor[monitor.name] || Config.options.background.wallpaperPath
+        property string wallpaperPath: wallpaperIsVideo ? Config.options.background.thumbnailPath : resolvedPath
         property bool wallpaperSafetyTriggered: {
             const enabled = Config.options.workSafety.enable.wallpaper;
             const sensitiveWallpaper = (CF.StringUtils.stringListContainsSubstring(wallpaperPath.toLowerCase(), Config.options.workSafety.triggerCondition.fileKeywords));

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -39,7 +39,10 @@ Variants {
         property int lastWorkspaceId: relevantWindows[relevantWindows.length - 1]?.workspace.id || 10
         // Wallpaper
         property bool wallpaperIsVideo: resolvedPath.endsWith(".mp4") || resolvedPath.endsWith(".webm") || resolvedPath.endsWith(".mkv") || resolvedPath.endsWith(".avi") || resolvedPath.endsWith(".mov")
-        property string resolvedPath: WallpaperListener.effectivePerMonitor[monitor.name] || Config.options.background.wallpaperPath
+        property var wallpaperData: WallpaperListener.effectivePerMonitor[monitor.name] || { path: Config.options.background.wallpaperPath, workspaceFirst: 1, workspaceLast: 10 }
+        property string resolvedPath: wallpaperData.path || Config.options.background.wallpaperPath
+        property int wallpaperFirstWorkspace: wallpaperData.workspaceFirst || 1
+        property int wallpaperLastWorkspace: wallpaperData.workspaceLast || 10
         property string wallpaperPath: wallpaperIsVideo ? Config.options.background.thumbnailPath : resolvedPath
         property bool wallpaperSafetyTriggered: {
             const enabled = Config.options.workSafety.enable.wallpaper;
@@ -134,10 +137,17 @@ Variants {
                 opacity: (status === Image.Ready && !bgRoot.wallpaperIsVideo) ? 1 : 0
                 cache: false
                 smooth: false
-                // Range = groups that workspaces span on
-                property int chunkSize: Config?.options.bar.workspaces.shown ?? 10
-                property int lower: Math.floor(bgRoot.firstWorkspaceId / chunkSize) * chunkSize
-                property int upper: Math.ceil(bgRoot.lastWorkspaceId / chunkSize) * chunkSize
+                // Use per-monitor workspace range if multiMonitor is enabled, otherwise use dynamic global range
+                property bool usePerMonitorRange: WallpaperListener.multiMonitorEnabled &&
+                    (wallpaperData.workspaceFirst !== undefined && wallpaperData.workspaceLast !== undefined)
+                property int chunkSize: usePerMonitorRange ? bgRoot.wallpaperLastWorkspace - bgRoot.wallpaperFirstWorkspace + 1 : 
+                    Config?.options.bar.workspaces.shown ?? 10
+                property int lower: usePerMonitorRange ?
+                    Math.floor(bgRoot.wallpaperFirstWorkspace / chunkSize) * chunkSize :
+                    Math.floor(bgRoot.firstWorkspaceId / chunkSize) * chunkSize
+                property int upper: usePerMonitorRange ?
+                    Math.ceil(bgRoot.wallpaperLastWorkspace / chunkSize) * chunkSize :
+                    Math.ceil(bgRoot.lastWorkspaceId / chunkSize) * chunkSize
                 property int range: upper - lower
                 property real valueX: {
                     let result = 0.5;

--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelector.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelector.qml
@@ -77,7 +77,12 @@ Scope {
         }
 
         function random(): void {
-            Wallpapers.randomFromCurrentFolder();
+            let monitorName = "";
+            if (Config.options.background?.multiMonitor?.enable) {
+                const focusedMonitor = Hyprland.focusedMonitor?.name;
+                monitorName = focusedMonitor;
+            }
+            Wallpapers.randomFromCurrentFolder(Appearance.m3colors.darkmode, monitorName);
         }
     }
 
@@ -93,7 +98,12 @@ Scope {
         name: "wallpaperSelectorRandom"
         description: "Select random wallpaper in current folder"
         onPressed: {
-            Wallpapers.randomFromCurrentFolder();
+            let monitorName = "";
+            if (Config.options.background?.multiMonitor?.enable) {
+                const focusedMonitor = Hyprland.focusedMonitor?.name;
+                monitorName = focusedMonitor;
+            }
+            Wallpapers.randomFromCurrentFolder(Appearance.m3colors.darkmode, monitorName);
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -79,7 +79,8 @@ ContentPage {
                     source: {
                         // Show appropriate wallpaper based on mode and monitor
                         if (Config.options.background.multiMonitor.enable) {
-                            return WallpaperListener.effectivePerMonitor[currentScreenName]
+                            const wallpaperData = WallpaperListener.effectivePerMonitor[currentScreenName]
+                            return wallpaperData?.path
                         } else {
                             return Config.options.background.wallpaperPath
                         }

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 import Qt5Compat.GraphicalEffects
 import Quickshell
 import Quickshell.Io
@@ -10,6 +11,7 @@ import qs.modules.common.functions
 
 ContentPage {
     forceWidth: true
+    readonly property string currentScreenName: Window.window?.openedScreenName || ""
 
     Process {
         id: randomWallProc
@@ -67,14 +69,21 @@ ContentPage {
             Item {
                 implicitWidth: 340
                 implicitHeight: 200
-                
+
                 StyledImage {
                     id: wallpaperPreview
                     anchors.fill: parent
                     sourceSize.width: parent.implicitWidth
                     sourceSize.height: parent.implicitHeight
                     fillMode: Image.PreserveAspectCrop
-                    source: Config.options.background.wallpaperPath
+                    source: {
+                        // Show appropriate wallpaper based on mode and monitor
+                        if (Config.options.background.multiMonitor.enable) {
+                            return WallpaperListener.effectivePerMonitor[currentScreenName]
+                        } else {
+                            return Config.options.background.wallpaperPath
+                        }
+                    }
                     cache: false
                     layer.enabled: true
                     layer.effect: OpacityMask {
@@ -170,6 +179,24 @@ ContentPage {
                     }
                 }
             }
+        }
+
+        // Wallpaper feature flags
+        ConfigSwitch {
+            buttonIcon: "monitor"
+            text: Translation.tr("Per-monitor wallpapers")
+            checked: Config.options.background.multiMonitor.enable
+            onCheckedChanged: {
+                const wasEnabled = Config.options.background.multiMonitor.enable
+                Config.options.background.multiMonitor.enable = checked
+
+                // When disabling per-monitor mode, apply global wallpaper to all monitors
+                if (wasEnabled && !checked) {
+                    const globalPath = Config.options.background.wallpaperPath
+                    Wallpapers.apply(globalPath, Appearance.m3colors.darkmode)
+                }
+            }
+            StyledToolTip { text: Translation.tr("Enable assigning different wallpapers to each monitor.") }
         }
 
         ConfigSelectionArray {
@@ -322,7 +349,7 @@ ContentPage {
                     ]
                 }
             }
-            
+
         }
     }
 

--- a/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
@@ -39,4 +39,17 @@ if [ "$downloadPath" == "$currentWallpaperPath" ]; then
     downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper-1.$ext"
 fi
 curl "$link" -o "$downloadPath"
-"$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+
+SHELL_CONFIG_FILE="$HOME/.config/illogical-impulse/config.json"
+multiMonitorEnabled=$(jq -r '.background.multiMonitor.enable' "$SHELL_CONFIG_FILE" 2>/dev/null)
+
+if [ "$multiMonitorEnabled" == "true" ]; then
+    focusedMonitor=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name' 2>/dev/null)
+    if [ -n "$focusedMonitor" ]; then
+        "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath" --monitor "$focusedMonitor"
+    else
+        "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+    fi
+else
+    "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+fi

--- a/dots/.config/quickshell/ii/scripts/colors/random/random_osu_wall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/random/random_osu_wall.sh
@@ -41,4 +41,17 @@ if [ "$downloadPath" == "$currentWallpaperPath" ]; then
     downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper-1.$ext"
 fi
 curl "$link" -o "$downloadPath"
-"$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+
+SHELL_CONFIG_FILE="$HOME/.config/illogical-impulse/config.json"
+multiMonitorEnabled=$(jq -r '.background.multiMonitor.enable' "$SHELL_CONFIG_FILE" 2>/dev/null)
+
+if [ "$multiMonitorEnabled" == "true" ]; then
+    focusedMonitor=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name' 2>/dev/null)
+    if [ -n "$focusedMonitor" ]; then
+        "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath" --monitor "$focusedMonitor"
+    else
+        "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+    fi
+else
+    "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"
+fi

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -144,11 +144,13 @@ EOF
 set_wallpaper_path() {
     local path="$1"
     local monitor="${2:-}"
+    local start_workspace="${3:-}"
+    local end_workspace="${4:-}"
     if [ -f "$SHELL_CONFIG_FILE" ]; then
         if [ -n "$monitor" ]; then
-            jq --arg name "$monitor" --arg path "$path" '
+            jq --arg name "$monitor" --arg path "$path" --argjson startWs "$start_workspace" --argjson endWs "$end_workspace" '
                 .background.wallpapersByMonitor = (
-                    (.background.wallpapersByMonitor // []) | map(select(.monitor != $name)) + [{"monitor": $name, "path": $path}]
+                    (.background.wallpapersByMonitor // []) | map(select(.monitor != $name)) + [{"monitor": $name, "path": $path, "workspaceFirst": $startWs, "workspaceLast": $endWs}]
                 )' "$SHELL_CONFIG_FILE" > "$SHELL_CONFIG_FILE.tmp" && mv "$SHELL_CONFIG_FILE.tmp" "$SHELL_CONFIG_FILE"
         else
             jq --arg path "$path" '.background.wallpaperPath = $path' "$SHELL_CONFIG_FILE" > "$SHELL_CONFIG_FILE.tmp" && mv "$SHELL_CONFIG_FILE.tmp" "$SHELL_CONFIG_FILE"
@@ -170,6 +172,8 @@ switch() {
     color_flag="$4"
     color="$5"
     target_monitor="$6"
+    start_workspace="${7:-}"
+    end_workspace="${8:-}"
 
     # Start Gemini auto-categorization if enabled
     aiStylingEnabled=$(jq -r '.background.clock.cookie.aiStyling' "$SHELL_CONFIG_FILE")
@@ -225,7 +229,7 @@ switch() {
             fi
 
             # Set wallpaper path
-            set_wallpaper_path "$imgpath" "$target_monitor"
+            set_wallpaper_path "$imgpath" "$target_monitor" "$start_workspace" "$end_workspace"
 
             # Set video wallpaper
             local video_path="$imgpath"
@@ -258,7 +262,7 @@ switch() {
             matugen_args=(image "$imgpath")
             generate_colors_material_args=(--path "$imgpath")
             # Update wallpaper path in config
-            set_wallpaper_path "$imgpath" "$target_monitor"
+            set_wallpaper_path "$imgpath" "$target_monitor" "$start_workspace" "$end_workspace"
             remove_restore
         fi
     fi
@@ -328,6 +332,8 @@ main() {
     color=""
     noswitch_flag=""
     target_monitor=""
+    start_workspace=""
+    end_workspace=""
 
     get_type_from_config() {
         jq -r '.appearance.palette.type' "$SHELL_CONFIG_FILE" 2>/dev/null || echo "auto"
@@ -345,6 +351,28 @@ main() {
         source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
         "$SCRIPT_DIR"/scheme_for_image.py "$img" 2>/dev/null | tr -d '\n'
         deactivate
+    }
+
+    detect_monitor_workspace_range() {
+        local monitor="$1"
+        local workspace_rules=$(hyprctl workspacerules -j 2>/dev/null)
+        if [ -z "$workspace_rules" ] || [ "$workspace_rules" = "null" ]; then
+            echo "1 10"
+            return
+        fi
+
+        local workspaces=$(echo "$workspace_rules" | jq -r --arg mon "$monitor" \
+            '[.[] | select(.monitor == $mon) | .workspaceString | tonumber] | sort | .[]')
+        if [ -z "$workspaces" ]; then
+            echo "1 10"
+            return
+        fi
+
+        local start_ws=$(echo "$workspace_rules" | jq -r --arg mon "$monitor" \
+            '([.[] | select(.monitor == $mon and .default == true) | .workspaceString | tonumber] | .[0]) //
+             ([.[] | select(.monitor == $mon) | .workspaceString | tonumber] | sort | .[0])')
+        local end_ws=$(echo "$workspaces" | tail -1)
+        echo "$start_ws $end_ws"
     }
 
     while [[ $# -gt 0 ]]; do
@@ -377,6 +405,14 @@ main() {
                 target_monitor="$2"
                 shift 2
                 ;;
+            --start-workspace)
+                start_workspace="$2"
+                shift 2
+                ;;
+            --end-workspace)
+                end_workspace="$2"
+                shift 2
+                ;;
             --noswitch)
                 noswitch_flag="1"
                 if [ -n "$target_monitor" ]; then
@@ -400,6 +436,11 @@ main() {
     if [[ "$config_color" =~ ^#?[A-Fa-f0-9]{6}$ ]]; then
         color_flag="1"
         color="$config_color"
+    fi
+
+    # Detect workspace range based on hyprctl workspacerules
+    if [[ -n "$target_monitor" && ( -z "$start_workspace" || -z "$end_workspace" ) ]]; then
+        read start_workspace end_workspace < <(detect_monitor_workspace_range "$target_monitor")
     fi
 
     # If type_flag is not set, get it from config
@@ -451,7 +492,7 @@ main() {
         fi
     fi
 
-    switch "$imgpath" "$mode_flag" "$type_flag" "$color_flag" "$color" "$target_monitor"
+    switch "$imgpath" "$mode_flag" "$type_flag" "$color_flag" "$color" "$target_monitor" "$start_workspace" "$end_workspace"
 }
 
 main "$@"

--- a/dots/.config/quickshell/ii/services/WallpaperListener.qml
+++ b/dots/.config/quickshell/ii/services/WallpaperListener.qml
@@ -33,7 +33,9 @@ Singleton {
                 const screen = screens[i]
                 const monitor = Hyprland.monitorFor(screen)
                 if (monitor && globalPath && globalPath.length > 0) {
-                    result[monitor.name] = globalPath
+                    result[monitor.name] = {
+                        path: globalPath
+                    }
                 }
             }
             root.effectivePerMonitor = result
@@ -44,7 +46,13 @@ Singleton {
         for (let i = 0; i < byMonitorList.length; ++i) {
             const entry = byMonitorList[i]
             if (entry && entry.monitor && entry.path) {
-                byMonitorMap[entry.monitor] = entry.path
+                const data = { path: entry.path }
+                if (entry.startWorkspace !== undefined && entry.endWorkspace !== undefined) {
+                    data.startWorkspace = entry.startWorkspace
+                    data.endWorkspace = entry.endWorkspace
+                }
+
+                byMonitorMap[entry.monitor] = data
             }
         }
 
@@ -52,9 +60,11 @@ Singleton {
             const screen = screens[i]
             const monitor = Hyprland.monitorFor(screen)
             if (monitor) {
-                const path = byMonitorMap[monitor.name] || globalPath
-                if (path && path.length > 0) {
-                    result[monitor.name] = path
+                const wallpaperData = byMonitorMap[monitor.name] || {
+                    path: globalPath
+                }
+                if (wallpaperData.path && wallpaperData.path.length > 0) {
+                    result[monitor.name] = wallpaperData
                 }
             }
         }

--- a/dots/.config/quickshell/ii/services/WallpaperListener.qml
+++ b/dots/.config/quickshell/ii/services/WallpaperListener.qml
@@ -1,0 +1,83 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.services
+
+Singleton {
+    id: root
+    property var effectivePerMonitor: ({})
+
+    // Bindings to watch config toggles for refresh
+    readonly property bool multiMonitorEnabled: Config.options.background?.multiMonitor?.enable || false
+    onMultiMonitorEnabledChanged: scheduleRefresh()
+    readonly property string globalWallpaperPath: Config.options.background?.wallpaperPath || ""
+    onGlobalWallpaperPathChanged: scheduleRefresh()
+    readonly property var wallpapersByMonitorRef: Config.options.background?.wallpapersByMonitor || []
+    onWallpapersByMonitorRefChanged: scheduleRefresh()
+    readonly property var hyprlandMonitorsRef: HyprlandData.monitors
+    onHyprlandMonitorsRefChanged: scheduleRefresh()
+
+    signal changed()
+
+    Timer {
+        id: debounce
+        interval: 80
+        repeat: false
+        onTriggered: root.refresh()
+    }
+
+    function scheduleRefresh() {
+        debounce.restart()
+    }
+
+    function refresh() {
+        const result = {}
+        const globalPath = globalWallpaperPath
+        const byMonitorList = wallpapersByMonitorRef || []
+        const monitors = HyprlandData.monitors || []
+
+        if (!root.multiMonitorEnabled) {
+            for (let i = 0; i < monitors.length; ++i) {
+                const mon = monitors[i]
+                if (globalPath && globalPath.length > 0) {
+                    result[mon.name] = globalPath
+                }
+            }
+            const oldJson = JSON.stringify(root.effectivePerMonitor)
+            const newJson = JSON.stringify(result)
+            if (oldJson !== newJson) {
+                root.effectivePerMonitor = result
+                root.changed()
+            }
+            return
+        }
+
+        const byMonitorMap = {}
+        for (let i = 0; i < byMonitorList.length; ++i) {
+            const entry = byMonitorList[i]
+            if (entry && entry.monitor && entry.path) {
+                byMonitorMap[entry.monitor] = entry.path
+            }
+        }
+
+        for (let i = 0; i < monitors.length; ++i) {
+            const mon = monitors[i]
+            const path = byMonitorMap[mon.name] || globalPath
+            if (path && path.length > 0) {
+                result[mon.name] = path
+            }
+        }
+
+        const oldJson = JSON.stringify(root.effectivePerMonitor)
+        const newJson = JSON.stringify(result)
+        if (oldJson !== newJson) {
+            root.effectivePerMonitor = result
+            root.changed()
+        }
+    }
+
+    Component.onCompleted: refresh()
+}

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -1,3 +1,4 @@
+import qs.services
 import qs.modules.common
 import qs.modules.common.models
 import qs.modules.common.functions
@@ -95,12 +96,12 @@ Singleton {
         selectProc.select(filePath, darkMode, monitorName);
     }
 
-    function randomFromCurrentFolder(darkMode = Appearance.m3colors.darkmode) {
+    function randomFromCurrentFolder(darkMode = Appearance.m3colors.darkmode, monitorName = "") {
         if (folderModel.count === 0) return;
         const randomIndex = Math.floor(Math.random() * folderModel.count);
         const filePath = folderModel.get(randomIndex, "filePath");
         print("Randomly selected wallpaper:", filePath);
-        root.select(filePath, darkMode);
+        root.select(filePath, darkMode, monitorName);
     }
 
     Process {

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -5,6 +5,7 @@ import QtQuick
 import Qt.labs.folderlistmodel
 import Quickshell
 import Quickshell.Io
+import Quickshell.Hyprland
 pragma Singleton
 pragma ComponentBehavior: Bound
 
@@ -39,21 +40,34 @@ Singleton {
     Process {
         id: applyProc
     }
-    
+
     function openFallbackPicker(darkMode = Appearance.m3colors.darkmode) {
-        applyProc.exec([
+        const args = [
             Directories.wallpaperSwitchScriptPath,
             "--mode", (darkMode ? "dark" : "light")
-        ])
+        ]
+
+        if (Config.options.background?.multiMonitor?.enable) {
+            const focusedMonitor = Hyprland.focusedMonitor?.name
+            if (focusedMonitor) {
+                args.push("--monitor", focusedMonitor)
+            }
+        }
+
+        applyProc.exec(args)
     }
 
-    function apply(path, darkMode = Appearance.m3colors.darkmode) {
+    function apply(path, darkMode = Appearance.m3colors.darkmode, monitorName = "") {
         if (!path || path.length === 0) return
-        applyProc.exec([
+        const args = [
             Directories.wallpaperSwitchScriptPath,
             "--image", path,
             "--mode", (darkMode ? "dark" : "light")
-        ])
+        ]
+        if (monitorName !== "") {
+            args.push("--monitor", monitorName)
+        }
+        applyProc.exec(args)
         root.changed()
     }
 
@@ -61,9 +75,11 @@ Singleton {
         id: selectProc
         property string filePath: ""
         property bool darkMode: Appearance.m3colors.darkmode
-        function select(filePath, darkMode = Appearance.m3colors.darkmode) {
+        property string monitorName: ""
+        function select(filePath, darkMode = Appearance.m3colors.darkmode, monitorName = "") {
             selectProc.filePath = filePath
             selectProc.darkMode = darkMode
+            selectProc.monitorName = monitorName
             selectProc.exec(["test", "-d", FileUtils.trimFileProtocol(filePath)])
         }
         onExited: (exitCode, exitStatus) => {
@@ -71,12 +87,12 @@ Singleton {
                 setDirectory(selectProc.filePath);
                 return;
             }
-            root.apply(selectProc.filePath, selectProc.darkMode);
+            root.apply(selectProc.filePath, selectProc.darkMode, selectProc.monitorName);
         }
     }
 
-    function select(filePath, darkMode = Appearance.m3colors.darkmode) {
-        selectProc.select(filePath, darkMode);
+    function select(filePath, darkMode = Appearance.m3colors.darkmode, monitorName = "") {
+        selectProc.select(filePath, darkMode, monitorName);
     }
 
     function randomFromCurrentFolder(darkMode = Appearance.m3colors.darkmode) {

--- a/dots/.config/quickshell/ii/settings.qml
+++ b/dots/.config/quickshell/ii/settings.qml
@@ -22,6 +22,7 @@ ApplicationWindow {
     property string firstRunFileContent: "This file is just here to confirm you've been greeted :>"
     property real contentPadding: 8
     property bool showNextTime: false
+    readonly property string openedScreenName: root.screen?.name || ""
     property var pages: [
         {
             name: Translation.tr("Quick"),


### PR DESCRIPTION
## Describe your changes
Allow users to be able to control the wallpaper on each of their monitors through a dynamically loaded setting. This PR incorporates this functionality by adding new properties in the config.json file and through the modified switch wallpaper script to update only the focused monitor wallpaper when it is triggered through the bindings or the random wallpaper scripts. The old wallpaper setting is preserved and restored when this mode is disabled, the user can toggle between either configuration as they wish.

Additionally, this PR makes some adjustments to the parallax calculation for when this mode is enabled to proportionally scale the range based on the workspace range of each monitor.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Ready for review. Other features like color generation follows the last picked wallpaper as per end-4's suggestions.

<img width="617" height="287" alt="image" src="https://github.com/user-attachments/assets/b198dc5f-42c1-4e92-8d64-7b0bf76041e4" />

https://github.com/user-attachments/assets/f3429db6-7a11-497c-a4e3-b4c09deb6773