### PR TITLE
Show passive items in the system tray

### DIFF
--- a/dots/.config/quickshell/ii/modules/bar/SysTray.qml
+++ b/dots/.config/quickshell/ii/modules/bar/SysTray.qml
@@ -17,7 +17,7 @@ Item {
     property bool showOverflowMenu: true
     property var activeMenu: null
 
-    property bool smartTray: Config.options.bar.tray.smartTray
+    property bool smartTray: Config.options.bar.tray.filterPassive
     property list<var> itemsInUserList: SystemTray.items.values.filter(i => (Config.options.bar.tray.pinnedItems.includes(i.id) && (!smartTray || i.status !== Status.Passive)))
     property list<var> itemsNotInUserList: SystemTray.items.values.filter(i => (!Config.options.bar.tray.pinnedItems.includes(i.id) && (!smartTray || i.status !== Status.Passive)))
 

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -221,7 +221,7 @@ Singleton {
                     property bool showItemId: false
                     property bool invertPinnedItems: true // Makes the below a whitelist for the tray and blacklist for the pinned area
                     property list<string> pinnedItems: [ ]
-                    property bool smartTray: true // Filter passive tray icons or not
+                    property bool filterPassive: true
                 }
                 property JsonObject workspaces: JsonObject {
                     property bool monochromeIcons: true


### PR DESCRIPTION
## Describe your changes

Hiding the passive status apps in the tray can cause some confusion. I spent a couple hours trying to find why some apps weren't showing, and it's because of this line. I removed the filtering of passive items in the system tray to show these apps.

## Is it ready? Questions/feedback needed?

Simple change, ready.

