### PR TITLE
Prepend Noto Sans Arabic in fontconfig

### DIFF
--- a/dots-extra/fontsets/ar/conf.d
+++ b/dots-extra/fontsets/ar/conf.d
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <match target="font">
+    <edit name="rgba" mode="assign">
+      <const>none</const>
+    </edit>
+  </match>
+
+  <!-- Fix for: arabic fonts rendering in Noto Nastaliq Urdu | affects Chromium, Discord (maybe all chromium based apps, but not Spotify somehow) -->
+  <match target="pattern">
+    <test compare="eq" name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Arabic</string>
+    </edit>
+  </match>
+</fontconfig>

--- a/dots/.config/fontconfig/conf.d
+++ b/dots/.config/fontconfig/conf.d
@@ -1,19 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
-  <match target="font">
-    <edit name="rgba" mode="assign">
-      <const>none</const>
-    </edit>
-  </match>
-
-  <!-- Fix for: arabic fonts rendering in Noto Nastaliq Urdu | affects Chromium, Discord (maybe all chromium based apps, but not Spotify somehow) -->
-  <match target="pattern">
-    <test compare="eq" name="family">
-      <string>sans-serif</string>
-    </test>
-    <edit name="family" mode="prepend" binding="strong">
-      <string>Noto Sans Arabic</string>
+    <match target="font">
+        <edit name="rgba" mode="assign">
+        <const>none</const>
     </edit>
   </match>
 </fontconfig>


### PR DESCRIPTION
## Describe your changes
Arabic font rendering by default falls into the first supporting arabic glyph supporting font, which happens to be an urdu font, which is **not** arabic

since the dotfiles alr include a lot of font configs, why not include a good default for arabic too?

edit:
arabic is a special case that needs this setup, cjk fonts will auto load with the installing of noto-fonts-cjk
so no, i don't think this is a personal change, it's more of like a good default for readability ;)