### PR TITLE
Fix: exec wallpaper change as detached process

### DIFF
--- a/dots/.config/quickshell/ii/modules/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/background/Background.qml
@@ -35,7 +35,7 @@ Variants {
         // Hide when fullscreen
         property list<HyprlandWorkspace> workspacesForMonitor: Hyprland.workspaces.values.filter(workspace => workspace.monitor && workspace.monitor.name == monitor.name)
         property var activeWorkspaceWithFullscreen: workspacesForMonitor.filter(workspace => ((workspace.toplevels.values.filter(window => window.wayland?.fullscreen)[0] != undefined) && workspace.active))[0]
-        visible: GlobalStates.screenLocked || (!(activeWorkspaceWithFullscreen != undefined)) || !Config?.options.background.hideWhenFullscreen
+        visible: !wallpaperIsVideo && (GlobalStates.screenLocked || (!(activeWorkspaceWithFullscreen != undefined)) || !Config?.options.background.hideWhenFullscreen)
 
         // Workspaces
         property HyprlandMonitor monitor: Hyprland.monitorFor(modelData)

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -22,8 +22,8 @@ Singleton {
     property url defaultFolder: Qt.resolvedUrl(`${Directories.pictures}/Wallpapers`)
     property alias folderModel: folderModel // Expose for direct binding when needed
     property string searchQuery: ""
-    readonly property list<string> extensions: [ // TODO: add videos
-        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg"
+    readonly property list<string> extensions: [
+        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg", "mp4", "webm", "mkv", "avi", "mov"
     ]
     property list<string> wallpapers: [] // List of absolute file paths (without file://)
     readonly property bool thumbnailGenerationRunning: thumbgenProc.running
@@ -35,13 +35,8 @@ Singleton {
 
     function load () {} // For forcing initialization
 
-    // Executions
-    Process {
-        id: applyProc
-    }
-    
     function openFallbackPicker(darkMode = Appearance.m3colors.darkmode) {
-        applyProc.exec([
+        Quickshell.execDetached([
             Directories.wallpaperSwitchScriptPath,
             "--mode", (darkMode ? "dark" : "light")
         ])
@@ -49,7 +44,7 @@ Singleton {
 
     function apply(path, darkMode = Appearance.m3colors.darkmode) {
         if (!path || path.length === 0) return
-        applyProc.exec([
+        Quickshell.execDetached([
             Directories.wallpaperSwitchScriptPath,
             "--image", path,
             "--mode", (darkMode ? "dark" : "light")


### PR DESCRIPTION
Closes #2281
Closes #2126
Related? #2128 #1703 

## Describe your changes

1. We want to run switchwall.sh script as detached process because after whole script reach its end we still have child process running which is killed with its parent from QS
    - We could also run mpvpaper with nohup but this seems to me like more bulletproof and elegant solution
2. We want remove background layer when mpvpaper is running to not interfere with each other

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
:heavy_check_mark: 

