### PR TITLE
fix: prevent volumeChanged recursion (#2320)

### DIFF
--- a/dots/.config/quickshell/ii/services/Audio.qml
+++ b/dots/.config/quickshell/ii/services/Audio.qml
@@ -29,12 +29,18 @@ Singleton {
         property real lastVolume: 0
         function onVolumeChanged() {
             if (!Config.options.audio.protection.enable) return;
+            const newVolume = sink.audio.volume;
+            // when resuming from suspend, we should not write volume to avoid pipewire volume reset issues
+            if (isNaN(newVolume) || newVolume === undefined || newVolume === null) {
+                lastReady = false;
+                lastVolume = 0;
+                return;
+            }
             if (!lastReady) {
-                lastVolume = sink.audio.volume;
+                lastVolume = newVolume;
                 lastReady = true;
                 return;
             }
-            const newVolume = sink.audio.volume;
             const maxAllowedIncrease = Config.options.audio.protection.maxAllowedIncrease / 100; 
             const maxAllowed = Config.options.audio.protection.maxAllowed / 100;
 
@@ -44,9 +50,6 @@ Singleton {
             } else if (newVolume > maxAllowed || newVolume > root.hardMaxValue) {
                 root.sinkProtectionTriggered(Translation.tr("Exceeded max allowed"));
                 sink.audio.volume = Math.min(lastVolume, maxAllowed);
-            }
-            if (sink.ready && (isNaN(sink.audio.volume) || sink.audio.volume === undefined || sink.audio.volume === null)) {
-                sink.audio.volume = 0;
             }
             lastVolume = sink.audio.volume;
         }


### PR DESCRIPTION
## Describe your changes

Fixed memory leak in Audio.qml by skipping volume writes during PipeWire resume, avoiding the ping-pong effect with PipeWire.
## Is it ready? Questions/feedback needed?

Yes, the change is small and ready for review.

