### PR TITLE
fix(audio): Replace pulseaudio with pipewire-pulseaudio on Arch Linux

### DIFF
--- a/sdata/dist-arch/illogical-impulse-audio/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-audio/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=illogical-impulse-audio
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Illogical Impulse Audio Dependencies'
 arch=(any)
 license=(None)


### PR DESCRIPTION
## Describe your changes

The installation script does not install `pipewire-pulse` on Arch Linux. As a result, should `pulseaudio` exist before the installation of `pipewire`, it may take precedence resulting in broken features such as the sidebar audio widget as well as scrolling to raise/lower audio at the right most corner of the bar.

Upon installation of `pipewire-pulse`, it will automatically replace `pulseaudio` as seen [here](https://wiki.archlinux.org/title/PipeWire). Manual uninstallation of `pulseaudio` is not possible after the installation of this hyprland config due to `pavucontrol-qt` marking it as a required dep and `pavucontrol-qt` is required by `illogical-impulse-audio`.

Hence, I figured it's best to install `pipewire-pulse` right off the bat to address this issue, it's also great for backwards compatibility. This should:
Close #1528 
Close #1507

## Is it ready? Questions/feedback needed?

Should be, since it's just a simple change to the deps list. Should there be any files required to be modified, please do let me know. Thanks!
