### PR TITLE
cheatsheet: added copypad (resolves #2151)

### DIFF
--- a/dots/.config/quickshell/ii/modules/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/ii/modules/cheatsheet/Cheatsheet.qml
@@ -22,6 +22,10 @@ Scope { // Scope
             "icon": "experiment",
             "name": Translation.tr("Elements")
         },
+        {
+            "icon": "toast",
+            "name": Translation.tr("Copypad")
+        }
     ]
 
     Loader {
@@ -184,6 +188,7 @@ Scope { // Scope
 
                         CheatsheetKeybinds {}
                         CheatsheetPeriodicTable {}
+                        CheatsheetCopypad {}
                     }
                 }
             }

--- a/dots/.config/quickshell/ii/modules/cheatsheet/CheatsheetCopypad.qml
+++ b/dots/.config/quickshell/ii/modules/cheatsheet/CheatsheetCopypad.qml
@@ -1,0 +1,128 @@
+pragma ComponentBehavior: Bound
+
+import "copypad.js" as CPad
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Quickshell
+
+Item {
+    id: root
+    readonly property var cpstuff: CPad.padstuff
+    property real spacing: 20
+    property real titleSpacing: 7
+    property real padding: 4
+    implicitWidth: row.implicitWidth + padding * 2
+    implicitHeight: row.implicitHeight + padding * 2
+
+    Row { // Copypad columns
+        id: row
+        spacing: root.spacing
+        
+        Repeater {
+            model: cpstuff
+            
+            delegate: Column { // Copypad sections
+                spacing: root.spacing
+                required property var modelData
+                anchors.top: row.top
+
+                Repeater {
+                    model: modelData
+
+                    delegate: Item { // Section with real copypad entries
+                        id: copypadSection
+                        required property var modelData
+                        implicitWidth: sectionColumn.implicitWidth
+                        implicitHeight: sectionColumn.implicitHeight
+
+                        Column {
+                            id: sectionColumn
+                            anchors.centerIn: parent
+                            spacing: root.titleSpacing
+                            
+                            StyledText {
+                                id: sectionTitle
+                                font.family: Appearance.font.family.title
+                                font.pixelSize: Appearance.font.pixelSize.huge
+                                color: Appearance.colors.colOnLayer0
+                                text: copypadSection.modelData.name
+                            }
+
+                            GridLayout {
+                                id: copypadGrid
+                                columns: 2
+                                columnSpacing: 4
+                                rowSpacing: 4
+
+                                Repeater {
+                                    model: {
+                                        var result = [];
+                                        for (var i = 0; i < copypadSection.modelData.entries.length; i++) {
+                                            const cpEntry = copypadSection.modelData.entries[i];
+                                            result.push({
+                                                "type": "copy",
+                                                "text": cpEntry,
+                                            });
+                                            result.push({
+                                                "type": "entry",
+                                                "text": cpEntry,
+                                            });
+                                        }
+                                        return result;
+                                    }
+                                    delegate: Item {
+                                        required property var modelData
+                                        implicitWidth: copypadLoader.implicitWidth
+                                        implicitHeight: copypadLoader.implicitHeight
+
+                                        Loader {
+                                            id: copypadLoader
+                                            sourceComponent: (modelData.type === "copy") ? copyComponent : entryComponent
+                                        }
+
+                                        Component {
+                                            id: copyComponent
+                                            RippleButton {
+                                                buttonRadius: Appearance.rounding.full
+                                                contentItem: StyledText {
+                                                    text: Translation.tr("Copy")
+                                                }
+                                                onClicked: {
+                                                    Quickshell.execDetached(["wl-copy", modelData.text])
+                                                }
+                                            }
+                                        }
+
+                                        Component {
+                                            id: entryComponent
+                                            Item {
+                                                id: entryItem
+                                                implicitWidth: entryText.implicitWidth + 8 * 2
+                                                implicitHeight: entryText.implicitHeight
+
+                                                StyledText {
+                                                    id: entryText
+                                                    anchors.centerIn: parent
+                                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                                    text: modelData.text
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                }
+                            }
+                        }
+                    }
+
+                }
+            }
+            
+        }
+    }
+    
+}

--- a/dots/.config/quickshell/ii/modules/cheatsheet/copypad.js
+++ b/dots/.config/quickshell/ii/modules/cheatsheet/copypad.js
@@ -1,0 +1,29 @@
+// All copypad stuff go here
+const padstuff = [
+    // Each member is a column
+    [
+        // Each member is a category/section
+        {
+            name: 'Steam',
+            entries: [
+                'FSR4_PROTON_UPDATE',
+                'OBS_VKCAPTURE=1',
+                'WINEDLLOVERRIDES="d3dcompiler_47=n;dxgi=n,b" # reshade'
+            ]
+        },
+        {
+            name: 'General',
+            entries: [
+                'meow'
+            ]
+        }
+    ],
+    [
+        {
+            name: 'idk',
+            entries: [
+                'god help us all'
+            ]
+        }
+    ]
+]


### PR DESCRIPTION
## Describe your changes

Added another tab to the cheatsheet - the copypad. You can edit the associated .js file in order to add entries.
The method of organization is inspired from the keybinds tab: a couple of columns, each containing a couple of sections, each comprised of a title and a list of entries, each entry characterized by a copy button and some text.

## Is it ready? Questions/feedback needed?

It could definitely use some improvements; however, functionality-wise, it seems fine. I'm definitely waiting for practical feedback!

