### PR TITLE
Try kebab over underscores for app icons

### DIFF
--- a/dots/.config/quickshell/ii/services/AppSearch.qml
+++ b/dots/.config/quickshell/ii/services/AppSearch.qml
@@ -86,6 +86,10 @@ Singleton {
         return str.toLowerCase().replace(/\s+/g, "-");
     }
 
+    function getUndescoreToKebabAppName(str) {
+        return str.toLowerCase().replace(/_/g, "-");
+    }
+
     function guessIcon(str) {
         if (!str || str.length == 0) return "image-missing";
 
@@ -124,6 +128,8 @@ Singleton {
         const kebabNormalizedGuess = getKebabNormalizedAppName(str);
         if (iconExists(kebabNormalizedGuess)) return kebabNormalizedGuess;
 
+        const undescoreToKebabGuess = getUndescoreToKebabAppName(str);
+        if (iconExists(undescoreToKebabGuess)) return undescoreToKebabGuess;
 
         // Search in desktop entries
         const iconSearchResults = Fuzzy.go(str, preppedIcons, {


### PR DESCRIPTION
## Describe your changes

This tries using kebab in place of underscores.

## Is it ready? Questions/feedback needed?

It works, I've been using for many weeks, but I don't remember which apps had this problem. It might have fixed other stuff later too.