### PR TITLE
Fix incorrect password placement when fingerprints

### DIFF
--- a/dots/.config/quickshell/ii/modules/lock/LockSurface.qml
+++ b/dots/.config/quickshell/ii/modules/lock/LockSurface.qml
@@ -160,7 +160,7 @@ MouseArea {
                 NumberAnimation { target: passwordBox; property: "x"; to: 30; duration: 50 }
                 NumberAnimation { target: passwordBox; property: "x"; to: -15; duration: 40 }
                 NumberAnimation { target: passwordBox; property: "x"; to: 15; duration: 40 }
-                NumberAnimation { target: passwordBox; property: "x"; to: 0; duration: 30 }
+                NumberAnimation { target: passwordBox; property: "x"; to: root.context.fingerprintsConfigured ? 42 : 0; duration: 30 }
             }
             Connections {
                 target: GlobalStates


### PR DESCRIPTION
## Describe your changes
The incorrect password animation messes up the placement if fingerprints are configured, this fixes that problem.


https://github.com/user-attachments/assets/924eed72-fd71-4ebd-9750-abd48489f91c



## Is it ready? Questions/feedback needed?
Yes it is.

