### PR TITLE
Disable Bluetooth Android button for systems without Bluetooth

### DIFF
--- a/dots/.config/quickshell/ii/modules/sidebarRight/quickToggles/androidStyle/AndroidBluetoothToggle.qml
+++ b/dots/.config/quickshell/ii/modules/sidebarRight/quickToggles/androidStyle/AndroidBluetoothToggle.qml
@@ -8,6 +8,7 @@ import Quickshell.Bluetooth
 
 AndroidQuickToggleButton {
     id: root
+    visible: BluetoothStatus.available
     
     name: Translation.tr("Bluetooth")
     statusText: BluetoothStatus.firstActiveDevice?.name ?? Translation.tr("No device")


### PR DESCRIPTION
## Describe your changes

Basically the exact same of https://github.com/end-4/dots-hyprland/pull/2167, but for the new Android style buttons

## Is it ready? Questions/feedback needed?

Yes

