### PR TITLE
Add option to open task manager when clicking on the resources info widget

### DIFF
--- a/dots/.config/quickshell/ii/modules/bar/Resources.qml
+++ b/dots/.config/quickshell/ii/modules/bar/Resources.qml
@@ -1,3 +1,4 @@
+import Quickshell
 import qs.modules.common
 import qs.services
 import QtQuick
@@ -10,6 +11,11 @@ MouseArea {
     implicitWidth: rowLayout.implicitWidth + rowLayout.anchors.leftMargin + rowLayout.anchors.rightMargin
     implicitHeight: Appearance.sizes.barHeight
     hoverEnabled: true
+    acceptedButtons: Config.options?.resources?.openTaskManagerOnClick ? (Qt.LeftButton | Qt.RightButton) : Qt.NoButton
+
+    onPressed: {
+        Quickshell.execDetached(["bash", "-c", `${Directories.launcherScriptPath} "gnome-system-monitor" "plasma-systemmonitor --page-name Processes" "command -v btop && kitty -1 fish -c btop"`])
+    }
 
     RowLayout {
         id: rowLayout

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -413,6 +413,7 @@ Singleton {
             property JsonObject resources: JsonObject {
                 property int updateInterval: 3000
                 property int historyLength: 60
+                property bool openTaskManagerOnClick: false // Whether to open task manager when user clicks on the resources widgets
             }
 
             property JsonObject musicRecognition: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/Directories.qml
+++ b/dots/.config/quickshell/ii/modules/common/Directories.qml
@@ -43,6 +43,7 @@ Singleton {
     property string aiChats: FileUtils.trimFileProtocol(`${Directories.state}/user/ai/chats`)
     property string aiTranslationScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/ai/gemini-translate.sh`)
     property string recordScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/videos/record.sh`)
+    property string launcherScriptPath: FileUtils.trimFileProtocol(`${Directories.config}/hypr/hyprland/scripts/launch_first_available.sh`)
     // Cleanup on init
     Component.onCompleted: {
         Quickshell.execDetached(["mkdir", "-p", `${shellConfig}`])

--- a/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
@@ -82,7 +82,15 @@ ContentPage {
                 Config.options.resources.updateInterval = value;
             }
         }
-        
+
+        ConfigSwitch {
+            buttonIcon: "speed"
+            text: Translation.tr("Open task manager on mouse click")
+            checked: Config.options.resources.openTaskManagerOnClick
+            onCheckedChanged: {
+                Config.options.resources.openTaskManagerOnClick = checked;
+            }
+        }
     }
 
     ContentSection {


### PR DESCRIPTION
## Describe your changes

One quirk I missed from my old setup was being able to open the task manager with a mouse right click on the current CPU stats. This feature basically replicates this, with a dedicated option in the settings panel for customization:

https://github.com/user-attachments/assets/f44719a1-4d86-4bf6-9cc6-f27b94a5fdef



## Is it ready? Questions/feedback needed?

Yes; this is ready, but a "hack" I had to do to make this generic was to expose the path to the launcherScriptPath, residing in the `hyprland` config folder. If this is not a good approach, I can move the script instead.


