### PR TITLE
Hide resource details on ResourcesPopup if disabled in configuration

### DIFF
--- a/dots/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
+++ b/dots/.config/quickshell/ii/modules/bar/ResourcesPopup.qml
@@ -45,7 +45,7 @@ StyledPopup {
         }
 
         Column {
-            visible: ResourceUsage.swapTotal > 0
+            visible: Config.options.bar.resources.alwaysShowSwap && ResourceUsage.swapTotal > 0
             anchors.top: parent.top
             spacing: 8
 
@@ -74,6 +74,7 @@ StyledPopup {
         }
 
         Column {
+            visible: Config.options.bar.resources.alwaysShowCpu
             anchors.top: parent.top
             spacing: 8
 


### PR DESCRIPTION
## Describe your changes

This also hides detailed CPU & Swap info from the resources popup when they're hidden in the settings:

<img width="314" height="195" alt="image" src="https://github.com/user-attachments/assets/d0127767-7f8a-4862-980b-876b4a77d8af" />


## Is it ready? Questions/feedback needed?


