### PR TITLE
fix fedora install-deps crashing on hyprland-qt-support step

### DIFF
--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -51,7 +51,7 @@ v sudo dnf install --setopt="install_weak_deps=False" "${hyprland_deps[@]}" -y
 # The hyprland-qt-support's GitHub repository requires Qt 6.6 or higher, which I think makes DNF's requirement of Qt 6.9 too strict; it should also support Qt 6.10.
 # On distro like Arch Linux, `hyprland-qtutils` and `hyprland-qt-support` are in dependency chain already so no need to add them as deps explicitly; 
 # However on Fedora, if this package is not installed, a yellow warning⚠️ will appear every time you log in to Hyprland.  
-v dnf download hyprland-qt-support && sudo rpm -ivh --nodeps hyprland-qt-support-*.fc$(rpm -E %fedora).$(uname -m).rpm
+v dnf download hyprland-qt-support && v sudo rpm -ivh --nodeps hyprland-qt-support-*.fc$(rpm -E %fedora).$(uname -m).rpm
 v sudo dnf install hyprland-qtutils -y
 
 # KDE


### PR DESCRIPTION
## Describe your changes

fix a missing v function invocation that leads to a crash if the hyprland-qt-support package is already installed. This can happen if the config ran in the past which would make the script not idempotent anymore.

## Is it ready? Questions/feedback needed?

On the same note: Is it ok that stuff like oneui/microtex... basically anything from the package-installers.sh except for the python part is missing from the fedora installation process? 
