### PR TITLE
fix: quote overlap in locksreen

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
@@ -49,7 +49,7 @@ AbstractBackgroundWidget {
                 }
                 FadeLoader {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    shown: Config.options.background.widgets.clock.quote.enable && Config.options.background.widgets.clock.quote.text !== ""
+                    shown: Config.options.background.widgets.clock.quote.enable && Config.options.background.widgets.clock.quote.text !== ""  && !GlobalStates.screenLocked
                     sourceComponent: CookieQuote {}
                 }
             }
@@ -73,7 +73,7 @@ AbstractBackgroundWidget {
                 }
                 StyledText {
                     // Somehow gets fucked up if made a ClockText???
-                    visible: Config.options.background.widgets.clock.quote.enable && Config.options.background.widgets.clock.quote.text.length > 0
+                    visible: Config.options.background.widgets.clock.quote.enable && Config.options.background.widgets.clock.quote.text.length > 0  && !GlobalStates.screenLocked
                     Layout.fillWidth: true
                     horizontalAlignment: root.textHorizontalAlignment
                     font {


### PR DESCRIPTION
## Describe your changes
the quote & locked text on lockscreen are at the same position causing overlap. I tried changing position but it doesn't look good. I think it would be better to show it only when we're not locked. still let me know if we need both. I'll push in the changes

<img width="117" height="45" alt="image" src="https://github.com/user-attachments/assets/1492cd9c-c26b-4f41-ab31-826cdfee13f3" />

## Is it ready? Questions/feedback needed?
yes, let me know if we need any change


