### PR TITLE
Brightness fix for multiple devices by percentage

### DIFF
--- a/dots/.config/quickshell/ii/services/Brightness.qml
+++ b/dots/.config/quickshell/ii/services/Brightness.qml
@@ -152,7 +152,7 @@ Singleton {
         }
 
         function setBrightness(value: real): void {
-            value = Math.max(0, Math.min(value, 1));
+            value = Math.max(0, Math.min(1, value));
             monitor.brightness = value;
         }
 


### PR DESCRIPTION
## Problem

The brightness module culculates the brightness depending on the default deivce (for me, it is `nvidia_0`), which is not the truly effective one. In my case, the effective one is called `intel_backlight`, the max brightness of which is `496` while `100` for `nvidia_0`. This lead to incorrect brightness calculations because the module uses the maximum brightness of the wrong display(for me, it sets the brightness as the maximum `100` for both `nvida_0` and `intel_backlight`).

## Solution
Use percentage brightness instead, set it to all devices in the class `backlight`. This also make sure that initially it can get the right brightness.

## Changes
`dots/.config/quickshell/ii/services/Brightness.qml`

## Test
My local machine only
```
brightnessctl --list --class backlight
Available devices:
Device 'nvidia_0' of class 'backlight':
	Current brightness: 1 (1%)
	Max brightness: 100

Device 'intel_backlight' of class 'backlight':
	Current brightness: 1 (0%)
	Max brightness: 496
```