### PR TITLE
feat: Add keyboard brightness control keybindings

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.conf
+++ b/dots/.config/hypr/hyprland/keybinds.conf
@@ -44,10 +44,10 @@ bindle=, XF86MonBrightnessDown, exec, qs -c $qsConfig ipc call brightness decrem
 bindle=, XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%+ -l 1.5# [hidden]
 bindle=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%- # [hidden]
 
-bindle = , XF86KbdBrightnessUp, exec,brightnessctl -d "*::kbd_backlight" s 10+ # [hidden]
-bindle = , XF86KbdBrightnessDown, exec, brightnessctl -d "*::kbd_backlight" s 10- # [hidden] 
-bindle = Alt, XF86MonBrightnessUp, exec,brightnessctl -d "*::kbd_backlight" s 10+ # [hidden]
-bindle = Alt, XF86MonBrightnessDown, exec, brightnessctl -d "*::kbd_backlight" s 10- # [hidden]
+bindle =, XF86KbdBrightnessUp, exec,brightnessctl -d "*::kbd_backlight" s 10%+ # [hidden]
+bindle =, XF86KbdBrightnessDown, exec, brightnessctl -d "*::kbd_backlight" s 10%- # [hidden] 
+bindle = Alt, XF86MonBrightnessUp, exec,brightnessctl -d "*::kbd_backlight" s 10%+ # [hidden]
+bindle = Alt, XF86MonBrightnessDown, exec, brightnessctl -d "*::kbd_backlight" s 10%- # [hidden]
 
 bindl = ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_SINK@ toggle # [hidden]
 bindld = Super+Shift,M, Toggle mute, exec, wpctl set-mute @DEFAULT_SINK@ toggle # [hidden]


### PR DESCRIPTION
Added keybindings for keyboard brightness control.

## Describe your changes

Added a binding in `keybindings.conf` to allow keyboard brightness to be changed via:
`Alt`+`XF86MonBrightness{Down,Up}` or
`XF86KbdBrightness{Up,Down}`

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Just need to check if it works with the whole installation process, I won't be doing this.
I don't know how qs ipc works so that is another task to do

