### PR TITLE
fix: Remove deprecated hyprland-qtutils package

### DIFF
--- a/sdata/dist-arch/install-deps.sh
+++ b/sdata/dist-arch/install-deps.sh
@@ -16,7 +16,7 @@ install-yay(){
 # However, let's just keep it as references for other distros writing their `sdata/dist-<DISTRO_ID>/install-deps.sh`, if they need it.
 handle-deprecated-dependencies(){
   printf "${STY_CYAN}[$0]: Removing deprecated dependencies:${STY_RST}\n"
-  for i in illogical-impulse-{microtex,pymyc-aur} {quickshell,hyprutils,hyprpicker,hyprlang,hypridle,hyprland-qt-support,hyprland-qtutils,hyprlock,xdg-desktop-portal-hyprland,hyprcursor,hyprwayland-scanner,hyprland}-git;do try sudo pacman --noconfirm -Rdd $i;done
+  for i in illogical-impulse-{microtex,pymyc-aur} hyprland-qtutils {quickshell,hyprutils,hyprpicker,hyprlang,hypridle,hyprland-qt-support,hyprland-qtutils,hyprlock,xdg-desktop-portal-hyprland,hyprcursor,hyprwayland-scanner,hyprland}-git;do try sudo pacman --noconfirm -Rdd $i;done
 # Convert old dependencies to non explicit dependencies so that they can be orphaned if not in meta packages
   remove_bashcomments_emptylines ./sdata/dist-arch/previous_dependencies.conf ./cache/old_deps_stripped.conf
   readarray -t old_deps_list < ./cache/old_deps_stripped.conf


### PR DESCRIPTION
## Describe your changes

As described in #2418, on Arch Linux, `hyprland-qtutils` has been renamed to `extra/hyprland-guiutils`. The install script should handle and remove the deprecated package in favour of the latest one. Otherwise, if `hyprland-qtutils` was already installed, running `./setup install` will fail with an error due to conflicting files owned by the deprecated package that could not be modified. 

Hence, I included the deprecatd `hyprland-qtutils`  package in the `handle-deps-packages()` function of the `install-deps.sh`.

## Is it ready? Questions/feedback needed?

Yup, I tested it out and it did successfully remove the package and update my system. Closes #2418
