### PR TITLE
Make sure that script to restore video wallpaper is ran on startup (fix #1947)

### DIFF
--- a/dots/.config/hypr/hyprland/execs.conf
+++ b/dots/.config/hypr/hyprland/execs.conf
@@ -1,6 +1,7 @@
 # Bar, wallpaper
 exec-once = ~/.config/hypr/hyprland/scripts/start_geoclue_agent.sh
 exec-once = qs -c $qsConfig &
+exec-once = ~/.config/hypr/custom/scripts/__restore_video_wallpaper.sh
 
 # Input method
 # exec-once = fcitx5


### PR DESCRIPTION
## Describe your changes

This makes sure that the video wallpaper is restored on setup, if a video wallpaper is not set the script should be empty

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Should be(tm)


