### PR TITLE
Consider being plugged in on full charge

### DIFF
--- a/dots/.config/quickshell/ii/services/Battery.qml
+++ b/dots/.config/quickshell/ii/services/Battery.qml
@@ -12,7 +12,7 @@ Singleton {
     property bool available: UPower.displayDevice.isLaptopBattery
     property var chargeState: UPower.displayDevice.state
     property bool isCharging: chargeState == UPowerDeviceState.Charging
-    property bool isPluggedIn: isCharging || chargeState == UPowerDeviceState.PendingCharge
+    property bool isPluggedIn: isCharging || chargeState == UPowerDeviceState.PendingCharge || chargeState == UPowerDeviceState.FullyCharged
     property real percentage: UPower.displayDevice?.percentage ?? 1
     readonly property bool allowAutomaticSuspend: Config.options.battery.automaticSuspend
     readonly property bool soundEnabled: Config.options.sounds.battery


### PR DESCRIPTION
## Describe your changes

I added the FullyCharged state to the isPluggedIn variable, as otherwise it considers as not charging and not connected. FullyCharged also only shows when plugged in, once you disconnect it instantly changes to Discharging.

Maybe this also fixes #1882 ? Everybody there was telling they were at 100%.

## Is it ready? Questions/feedback needed?

I generally don't charge to 100%, so I never noticed that before.
