### PR TITLE
Enhanced keybinds: workspace navigation + safer lock

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.conf
+++ b/dots/.config/hypr/hyprland/keybinds.conf
@@ -194,6 +194,8 @@ bind = Ctrl+Super+Alt, Left, workspace, m-1 # [hidden]
 #/# bind = Super, Page_↑/↓,, # Focus left/right
 bind = Super, Page_Down, workspace, +1 # [hidden]
 bind = Super, Page_Up, workspace, -1 # [hidden]
+bind = Super+Shift, K, workspace, +1 # [hidden]
+bind = Super+Shift, J, workspace, -1 # [hidden]
 bind = Ctrl+Super, Page_Down, workspace, r+1 # [hidden]
 bind = Ctrl+Super, Page_Up, workspace, r-1 # [hidden]
 #/# bind = Super, Scroll ↑/↓,, # Focus left/right
@@ -222,8 +224,8 @@ bind = Super+Alt, f12, exec, bash -c 'RANDOM_IMAGE=$(find ~/Pictures -type f | g
 bind = Super+Alt, Equal, exec, notify-send "Urgent notification" "Ah hell no" -u critical -a 'Hyprland keybind' # [hidden]
 
 ##! Session
-bindd = Super, L, Lock, exec, loginctl lock-session # Lock
-bindld = Super+Shift, L, Suspend system, exec, systemctl suspend || loginctl suspend # Sleep
+bindd = Super+Alt, L, Lock, exec, loginctl lock-session # Lock
+bindld = Super+Shift+Alt, L, Suspend system, exec, systemctl suspend || loginctl suspend # Sleep
 # bindl=,switch:on:Lid Switch, exec, systemctl suspend || loginctl suspend # [hidden] Suspend when laptop lid is closed, uncomment if for whatever reason it's not the default behavior
 bindd = Ctrl+Shift+Alt+Super, Delete, Shutdown, exec, systemctl poweroff || loginctl poweroff # [hidden] Power off
 


### PR DESCRIPTION
Summary:
This update refines keybinds for better workspace navigation and safer lock behavior.

Changes made:

* **Added:**

  ```dots-hyprland/dots/.config/hypr/hyprland/keybinds.conf
  bind = Super+Shift, K, workspace, +1 # [hidden]
  bind = Super+Shift, J, workspace, -1 # [hidden]
  ```

  → Allows quick switching between workspaces using Super+Shift+K/J.

* **Modified:**

  ```dots-hyprland/dots/.config/hypr/hyprland/keybinds.conf
  # Before
  bindd = Super, L, Lock, exec, loginctl lock-session # Lock
  bindld = Super+Shift, L, Suspend system, exec, systemctl suspend || loginctl suspend # Sleep

  # After
  bindd = Super+Alt, L, Lock, exec, loginctl lock-session # Lock
  bindld = Super+Shift+Alt, L, Suspend system, exec, systemctl suspend || loginctl suspend # Sleep
  ```

  → Updated lock/suspend combinations to reduce accidental activation.

**Purpose:**
Improve workflow efficiency when switching workspaces and prevent unintended screen locking.