### PR TITLE
fix: syntax error in 3.files-legacy.sh

### DIFF
--- a/sdata/subcmd-install/3.files-legacy.sh
+++ b/sdata/subcmd-install/3.files-legacy.sh
@@ -42,9 +42,9 @@ case "${INSTALL_FIRSTRUN}" in
   # When not specify --firstrun
   *)
     if test -f "${FIRSTRUN_FILE}"; then
-      ${INSTALL_FIRSTRUN}=false
+      INSTALL_FIRSTRUN=false
     else
-      ${INSTALL_FIRSTRUN}=true
+      INSTALL_FIRSTRUN=true
     fi
     ;;
 esac


### PR DESCRIPTION
## Describe your changes

There have been this syntax error in the install script. I've fixed it inside this pr

```
[./setup]: Command "mkdir -p /home/mannu/.local/bin /home/mannu/.cache /home/mannu/.config /home/mannu/.local/share/icons" finished.
sdata/subcmd-install/3.files-legacy.sh: line 45: =false: command not found
```

## Is it ready? Questions/feedback needed?
yes


