### PR TITLE
Added random wallpaper explicitness rating option in the menu

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -190,6 +190,7 @@ Singleton {
                 }
                 property string wallpaperPath: ""
                 property string thumbnailPath: ""
+                property string randomWallRating: "safe" // "safe", "questionable", "explicit"
                 property bool hideWhenFullscreen: true
                 property JsonObject parallax: JsonObject {
                     property bool vertical: false

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -118,6 +118,26 @@ ContentPage {
                         text: Translation.tr("Random osu! seasonal background\nImage is saved to ~/Pictures/Wallpapers")
                     }
                 }
+                ConfigSelectionArray {
+                    currentValue: Config.options.background.randomWallRating
+                    onSelected: newValue => {
+                        Config.options.background.randomWallRating = newValue;
+                    }
+                    options: [
+                        {
+                            "value": "safe",
+                            "displayName": Translation.tr("Safe")
+                        },
+                        {
+                            "value": "questionable",
+                            "displayName": Translation.tr("Questionable")
+                        },
+                        {
+                            "value": "explicit",
+                            "displayName": Translation.tr("Explicit")
+                        },
+                    ]
+                }
                 RippleButtonWithIcon {
                     Layout.fillWidth: true
                     materialIcon: "wallpaper"

--- a/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
@@ -29,11 +29,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p "$PICTURES_DIR/Wallpapers"
 page=$((1 + RANDOM % 1000));
-response=$(curl "https://konachan.net/post.json?tags=rating%3Asafe&limit=1&page=$page")
+illogicalImpulseConfigPath="$HOME/.config/illogical-impulse/config.json"
+rating=$(jq -r '.background.randomWallRating' $illogicalImpulseConfigPath)
+response=$(curl "https://konachan.net/post.json?tags=rating%3A$rating&limit=1&page=$page")
 link=$(echo "$response" | jq '.[0].file_url' -r);
 ext=$(echo "$link" | awk -F. '{print $NF}')
 downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper.$ext"
-illogicalImpulseConfigPath="$HOME/.config/illogical-impulse/config.json"
 currentWallpaperPath=$(jq -r '.background.wallpaperPath' $illogicalImpulseConfigPath)
 if [ "$downloadPath" == "$currentWallpaperPath" ]; then
     downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper-1.$ext"


### PR DESCRIPTION
Added a content rating selector for random wallpapers in the Wallpaper & Colors settings, allowing users to choose between Safe, Questionable, and Explicit ratings. The selected rating is stored as a config variable (randomWallRating) that can be reused by other random wallpaper scripts, and is currently implemented in the Konachan wallpaper fetcher to filter images based on user preference (defaults to "safe").

Preview:
<img width="668" height="386" alt="image" src="https://github.com/user-attachments/assets/c3b25c56-e333-4a15-aa32-c877f7ed7568" />
