### PR TITLE
Revert #1841

### DIFF
--- a/dots/.config/hypr/hyprland/rules.conf
+++ b/dots/.config/hypr/hyprland/rules.conf
@@ -46,7 +46,6 @@ windowrulev2 = float, title:.*Welcome
 windowrulev2 = float, title:^(illogical-impulse Settings)$
 windowrulev2 = float, title:.*Shell conflicts.*
 windowrulev2 = float, class:org.freedesktop.impl.portal.desktop.kde
-windowrulev2 = size 60% 65%, class:org.freedesktop.impl.portal.desktop.kde
 windowrulev2 = float, class:^(Zotero)$
 windowrulev2 = size 45%, class:^(Zotero)$
 


### PR DESCRIPTION
## Describe your changes

This reverts #1841 since the rule is useless and doesn't fix any issues as it's a bug in the QT implementation not XDG, additionally the QT one can't be easily targeted as it doesn't have a consistent name/class. The only way I can find to fix this is using qt6ct to tell QT apps to use XDG, but this uses KDEs theming system so I have no idea how to fix this

<img width="926" height="842" alt="image" src="https://github.com/user-attachments/assets/b4b07f93-cad7-4217-aad7-424886c331ce" />

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Should be and uh sorry lol

