### PR TITLE
Fix darkly widget style not being applied

### DIFF
--- a/dots/.config/kdeglobals
+++ b/dots/.config/kdeglobals
@@ -148,6 +148,9 @@ toolBarFont=Rubik,10,-1,5,400,0,0,0,0,0,0,0,0,0,0,1
 [Icons]
 Theme=breeze-dark
 
+[KDE]
+widgetStyle=Darkly
+
 [KFileDialog Settings]
 Allow Expansion=false
 Automatically select filename extension=true


### PR DESCRIPTION
While the install script tries to set the darkly theme, it is then overwritten by the kdeglobals file not including it. With the style included on the kdeglobals file, the theme is now applied correctly.

