### PR TITLE
Added command to set Gelbooru API key and user ID

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Anime.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Anime.qml
@@ -83,6 +83,28 @@ Item {
                 Persistent.states.booru.allowNsfw = true;
             }
         },
+        {
+            name: "gelbooru_key",
+            description: Translation.tr("Set Gelbooru API key"),
+            execute: (args) => {
+                if (args.length > 0) {
+                    Booru.setApiKey("gelbooru", args[0]);
+                } else {
+                    Booru.addSystemMessage(Translation.tr("Usage: /gelbooru_key <key>"));
+                }
+            }
+        },
+        {
+            name: "gelbooru_id",
+            description: Translation.tr("Set Gelbooru User ID"),
+            execute: (args) => {
+                if (args.length > 0) {
+                    Booru.setUserId("gelbooru", args[0]);
+                } else {
+                    Booru.addSystemMessage(Translation.tr("Usage: /gelbooru_id <id>"));
+                }
+            }
+        },
     ]
 
     function handleInput(inputText) {

--- a/dots/.config/quickshell/ii/services/Booru.qml
+++ b/dots/.config/quickshell/ii/services/Booru.qml
@@ -307,6 +307,20 @@ Singleton {
         })]
     }
 
+    readonly property var apiKeys: KeyringStorage.keyringData?.apiKeys ?? {}
+
+    function setApiKey(provider, key) {
+        if (!providers[provider]) return;
+        KeyringStorage.setNestedField(["apiKeys", provider], key.trim());
+        root.addSystemMessage(Translation.tr("API key set for %1").arg(providers[provider].name));
+    }
+
+    function setUserId(provider, id) {
+        if (!providers[provider]) return;
+        KeyringStorage.setNestedField(["apiKeys", provider + "_user_id"], id.trim());
+        root.addSystemMessage(Translation.tr("User ID set for %1").arg(providers[provider].name));
+    }
+
     function constructRequestUrl(tags, nsfw=true, limit=20, page=1) {
         var provider = providers[currentProvider]
         var baseUrl = provider.api
@@ -345,6 +359,10 @@ Singleton {
             params.push("limit=" + limit)
             if (currentProvider == "gelbooru") {
                 params.push("pid=" + page)
+                if (root.apiKeys["gelbooru"] && root.apiKeys["gelbooru_user_id"]) {
+                    params.push("api_key=" + root.apiKeys["gelbooru"])
+                    params.push("user_id=" + root.apiKeys["gelbooru_user_id"])
+                }
             }
             else {
                 params.push("page=" + page)


### PR DESCRIPTION
## Describe your changes

This adds a command to set the Gelbooru API key with a command as it requires one and doesn't work without it, the only way of working around this before was editing the Booru.qml file and adding it yourself

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

I made this with Antigravity IDE from Google and Gemini 3 (first try btw). However, I've looked at the code, and it seems fine to me at least, it doesn't appear all that different from anything else and indeed works. Still, I'd really like a second opinion as I don't trust my judgment whatsoever. Other Booru maybe could also benefit from the same treatment, but this PR just focuses on Gelbooru

Sorta closes (need support for other boorus): #1534 
Double closes?: #1664

