### PR TITLE
Fix translator output parsing using trans brief mode

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
@@ -63,10 +63,10 @@ Item {
 
     Process {
         id: translateProc
-        command: ["bash", "-c", `trans -no-theme -no-bidi`
+        command: ["bash", "-c", `trans -brief`
             + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'`
             + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-            + ` -no-ansi '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`]
+            + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`]
         property string buffer: ""
         stdout: SplitParser {
             onRead: data => {
@@ -74,13 +74,8 @@ Item {
             }
         }
         onExited: (exitCode, exitStatus) => {
-            // 1. Split into sections by double newlines
-            const sections = translateProc.buffer.trim().split(/\n\s*\n/);
-            // console.log("BUFFER:", translateProc.buffer);
-            // console.log("SECTIONS:", sections);
-
-            // 2. Extract relevant data
-            root.translatedText = sections.length > 1 ? sections[1].trim() : "";
+            // With -brief mode, we get output with no metadata
+            root.translatedText = translateProc.buffer.trim();
         }
     }
 


### PR DESCRIPTION
## Describe your changes

Fixed parsing of translator output using trans -brief mode.

## Is it ready? Questions/feedback needed?

Ready and tested

old:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6bfaa392-498f-48dc-b674-7e519ed90c7b" />
new:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/387c78c1-1089-430c-aaf4-de0418a38d52" />

