### PR TITLE
Fix: Remove duplicate apps in Quickshell launcher using filter

### DIFF
--- a/dots/.config/quickshell/ii/services/AppSearch.qml
+++ b/dots/.config/quickshell/ii/services/AppSearch.qml
@@ -40,9 +40,14 @@ Singleton {
         }
     ]
 
+    // Deduped list to fix double icons
     readonly property list<DesktopEntry> list: Array.from(DesktopEntries.applications.values)
-        .sort((a, b) => a.name.localeCompare(b.name))
-
+        .filter((app, index, self) => 
+            index === self.findIndex((t) => (
+                t.id === app.id
+            ))
+    )
+    
     readonly property var preppedNames: list.map(a => ({
         name: Fuzzy.prepare(`${a.name} `),
         entry: a


### PR DESCRIPTION
Describe your changes
Closes #2526
I noticed that applications were appearing twice in the launcher because of duplicate entries in the list. I added a .filter() function to AppSearch.qml to dedup apps by their ID. This fixes the double-scan issue on systems like Arch/CachyOS.

Is it ready? Questions/feedback needed?
ready


