### PR TITLE
Added apply to IpcHandler

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelector.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelector.qml
@@ -75,10 +75,6 @@ Scope {
         function random(): void {
             Wallpapers.randomFromCurrentFolder();
         }
-        
-        function apply(path: string): void {
-            Wallpapers.apply(path);
-        }
     }
 
     GlobalShortcut {

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -181,4 +181,12 @@ Singleton {
             root.thumbnailGenerated(thumbgenProc.directory)
         }
     }
+
+    IpcHandler {
+        target: "wallpapers"
+
+        function apply(path: string): void {
+            root.apply(path);
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds a new method to the wallpaper selector module, allowing wallpapers to be applied directly from the terminal by specifying a path.

Enhancement to wallpaper selection:
* Added an `apply(path: string)` function to the `Scope` object in `WallpaperSelector.qml`, enabling wallpapers to be applied programmatically by path.