### PR TITLE
Fix: Flatpak app doesnt appear on app launcher

### DIFF
--- a/dots/.config/hypr/hyprland/env.conf
+++ b/dots/.config/hypr/hyprland/env.conf
@@ -9,6 +9,9 @@
 # ############ Wayland #############
 env = ELECTRON_OZONE_PLATFORM_HINT,auto
 
+######### Applications #########
+env = XDG_DATA_DIRS,$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share
+
 # ############ Themes #############
 env = QT_QPA_PLATFORM, wayland
 env = QT_QPA_PLATFORMTHEME, kde


### PR DESCRIPTION

## Describe your changes
add flatpak paths to XDG_DATA_DIRS 

Adds standard Flatpak export paths to XDG_DATA_DIRS to ensure applications appear in the Quickshell launcher. Explicitly includes /usr/local/share and /usr/share as fallbacks to prevent system applications from disappearing if the variable was previously unset.

## Is it ready? Questions/feedback needed?
it works for me, pls review


