### PR TITLE
Enhance The Translate Service 

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
@@ -5,246 +5,313 @@ import qs.modules.common.functions
 import qs.modules.ii.sidebarLeft.translator
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls 2.15
 import Quickshell
 import Quickshell.Io
 
 /**
- * Translator widget with the `trans` commandline tool.
+ * Translator widget - Final Polished UI (English Comments & Generic Tilde Path)
  */
 Item {
     id: root
 
-    // Sizes
+    // --- Sizes ---
     property real padding: 4
 
-    // Widgets
+    // --- Widgets Reference ---
     property var inputField: inputCanvas.inputTextArea
 
-    // Widget variables
-    property bool translationFor: false // Indicates if the translation is for an autocorrected text
+    // --- Variables ---
+    property bool translationFor: false
     property string translatedText: ""
     property list<string> languages: []
 
-    // Options
+    // --- Options & Config ---
     property string targetLanguage: Config.options.language.translator.targetLanguage
     property string sourceLanguage: Config.options.language.translator.sourceLanguage
-    property string hostLanguage: targetLanguage
+    property string activeSourceLanguage: sourceLanguage
+    property string activeTargetLanguage: targetLanguage
+    property bool useLocalTranslation: Config.options.sidebar?.translator?.useLocal ?? true
+    property string pythonExecutable: Config.options.sidebar?.translator?.pythonBinary ?? "/usr/bin/python3"
 
-    // States
+    // ✅ Generic Path: Using '~' (Tilde expansion) which requires '/bin/sh -c' for execution below.
+    property string localScriptPath: "~/.config/quickshell/ii/modules/ii/sidebarLeft/local_translate.py"
+    property int translateDelay: Math.max(100, Config.options.sidebar.translator.delay - 100)
+
+    // --- States ---
     property bool showLanguageSelector: false
-    property bool languageSelectorTarget: false // true for target language, false for source language
+    property bool languageSelectorTarget: false
+    property bool showIndexManager: false // Controls the management overlay visibility
+    property var availableIndexLanguages: []
 
+    // --- Language Detection Patterns ---
+    readonly property var languageDetectionPatterns: ({
+        "ar": /[\u0600-\u06FF]/, "en": /[A-Za-z]/, "fa": /[\u0600-\u06FF]/,
+        "ru": /[\u0400-\u04FF]/, "tr": /[A-Za-zÇĞİŞÖÜçğışöü]/, "ja": /[\u3040-\u309F\u30A0-\u30FF\u31F0-\u31FF]/,
+        "zh": /[\u4E00-\u9FFF]/, "ko": /[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7AF]/,
+    })
+
+    // ============================================================
+    // Logic Functions
+    // ============================================================
     function showLanguageSelectorDialog(isTargetLang: bool) {
         root.languageSelectorTarget = isTargetLang;
         root.showLanguageSelector = true
     }
 
-    onFocusChanged: (focus) => {
-        if (focus) {
-            root.inputField.forceActiveFocus()
+    function normalizedLanguageCode(name) {
+        if (!name) return "";
+        const trimmed = name.trim().toLowerCase();
+        if (/^[a-z]{2,3}(?:-[a-z]{2,3})?$/.test(trimmed)) return trimmed;
+        if (trimmed.includes("arab") || /[\u0600-\u06FF]/.test(name)) return "ar";
+        if (trimmed.startsWith("en")) return "en";
+        return trimmed.substring(0, 2);
+    }
+
+    function detectLanguageFromText(text) {
+        const trimmed = text?.trim() ?? "";
+        if (!trimmed.length) return root.sourceLanguage;
+        const srcCode = root.normalizedLanguageCode(root.sourceLanguage);
+        const tgtCode = root.normalizedLanguageCode(root.targetLanguage);
+
+        const targetPattern = root.languageDetectionPatterns[tgtCode];
+        if (targetPattern && targetPattern.test(trimmed)) return root.targetLanguage;
+
+        const sourcePattern = root.languageDetectionPatterns[srcCode];
+        if (sourcePattern && sourcePattern.test(trimmed)) return root.sourceLanguage;
+
+        if (/[A-Za-z]/.test(trimmed)) {
+            if (srcCode === 'en') return root.sourceLanguage;
+            if (tgtCode === 'en') return root.targetLanguage;
+            return "English";
+        }
+        if (/[\u0600-\u06FF]/.test(trimmed)) {
+            if (srcCode === 'ar') return root.sourceLanguage;
+            if (tgtCode === 'ar') return root.targetLanguage;
+            return "Arabic";
+        }
+        return root.sourceLanguage;
+    }
+
+    function resolveActiveLanguages(text) {
+        const detectedName = root.detectLanguageFromText(text);
+        const detectedCode = root.normalizedLanguageCode(detectedName);
+        const targetCode = root.normalizedLanguageCode(root.targetLanguage);
+        if (detectedCode === targetCode) {
+            root.activeSourceLanguage = root.targetLanguage;
+            root.activeTargetLanguage = root.sourceLanguage;
+        } else {
+            root.activeSourceLanguage = root.sourceLanguage;
+            root.activeTargetLanguage = root.targetLanguage;
+        }
+    }
+
+    // ---------------- Processes (Backend) ----------------
+    function checkLocalCache(text) {
+        const src = root.normalizedLanguageCode(root.activeSourceLanguage);
+        const tgt = root.normalizedLanguageCode(root.activeTargetLanguage);
+        // Execute via sh -c to expand the '~' path and safely quote the text argument.
+        const cmd = root.pythonExecutable + " " + root.localScriptPath +
+        " get " + src + " " + tgt + " " + JSON.stringify(text);
+        localCheckProc.command = ["/bin/sh", "-c", cmd];
+        localCheckProc.running = true;
+    }
+
+    function fetchOnlineTranslation() {
+        const text = root.inputField.text.trim(); if(!text) return;
+        const src = root.normalizedLanguageCode(root.activeSourceLanguage) || "auto";
+        const tgt = root.normalizedLanguageCode(root.activeTargetLanguage) || "en";
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${src}&tl=${tgt}&dt=t&q=${encodeURIComponent(text)}`);
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === 4 && xhr.status === 200) {
+                try {
+                    const res = JSON.parse(xhr.responseText);
+                    let out = ""; if(res && res[0]) for(let i=0; i<res[0].length; i++) if(res[0][i][0]) out += res[0][i][0];
+                    root.translatedText = out;
+                    saveToLocalCache(text, out);
+                } catch(e) { root.translatedText = "Error"; }
+            }
+        }
+        xhr.send();
+    }
+
+    function saveToLocalCache(orig, trans) {
+        if(!root.useLocalTranslation) return;
+        const src = root.normalizedLanguageCode(root.activeSourceLanguage);
+        const tgt = root.normalizedLanguageCode(root.activeTargetLanguage);
+        // Execute via sh -c to expand the '~' path and safely quote the text and translation arguments.
+        const cmd = root.pythonExecutable + " " + root.localScriptPath +
+        " set " + src + " " + tgt + " " + JSON.stringify(orig) + " " + JSON.stringify(trans);
+        localSaveProc.command = ["/bin/sh", "-c", cmd];
+        localSaveProc.running = true;
+    }
+
+    Process {
+        id: localCheckProc; command: [];
+        stdout: SplitParser { onRead: data => { if(data.trim() && data.trim() !== "__NOT_FOUND__") root.translatedText = data.trim(); else if(data.trim() === "__NOT_FOUND__") fetchOnlineTranslation(); } }
+    }
+    Process { id: localSaveProc; command: [] }
+
+    // Process: Get Available Index Languages - Must also use sh -c
+    Process {
+        id: getAvailableLangsProc
+        property string cmdString: root.pythonExecutable + " " + root.localScriptPath + " get_languages"
+        command: ["/bin/sh", "-c", cmdString]
+        stdout: SplitParser { onRead: data => { try { root.availableIndexLanguages = JSON.parse(data.trim()); } catch(e) { root.availableIndexLanguages = []; } } }
+    }
+
+    // Process: Delete Index Language - Must also use sh -c
+    Process {
+        id: deleteLangProc; command: []
+        onExited: (exitCode, exitStatus) => { getAvailableLangsProc.running = true; } // Refresh list after delete
+        function deleteLanguage(langCode) {
+            const cmd = root.pythonExecutable + " " + root.localScriptPath + " delete_language " + langCode;
+            command = ["/bin/sh", "-c", cmd];
+            running = true;
+        }
+    }
+
+    // Process: Get Supported Languages (using 'trans' tool) - No change needed here
+    Process {
+        id: getLanguagesProc; command: ["trans", "-list-languages", "-no-bidi"]; running: true
+        stdout: SplitParser { onRead: data => getLanguagesProc.bufferList.push(data.trim()) }
+        property list<string> bufferList: ["auto"]
+        onExited: {
+            let langs = bufferList.filter(l => l.trim() && l !== "auto").sort();
+            langs.unshift("auto"); root.languages = langs;
         }
     }
 
     Timer {
-        id: translateTimer
-        interval: Config.options.sidebar.translator.delay
-        repeat: false
-        onTriggered: () => {
-            if (root.inputField.text.trim().length > 0) {
-                // console.log("Translating with command:", translateProc.command);
-                translateProc.running = false;
-                translateProc.buffer = ""; // Clear the buffer
-                translateProc.running = true; // Restart the process
-            } else {
-                root.translatedText = "";
-            }
+        id: translateTimer; interval: root.translateDelay; repeat: false
+        onTriggered: {
+            const txt = root.inputField.text.trim();
+            if(txt) { resolveActiveLanguages(txt); if(root.useLocalTranslation) checkLocalCache(txt); else fetchOnlineTranslation(); }
+            else root.translatedText = "";
         }
     }
 
-    Process {
-        id: translateProc
-        command: ["bash", "-c", `trans -brief`
-            + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'`
-            + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-            + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`]
-        property string buffer: ""
-        stdout: SplitParser {
-            onRead: data => {
-                translateProc.buffer += data + "\n";
-            }
-        }
-        onExited: (exitCode, exitStatus) => {
-            // With -brief mode, we get output with no metadata
-            root.translatedText = translateProc.buffer.trim();
-        }
-    }
+    onSourceLanguageChanged: Config.options.language.translator.sourceLanguage = root.sourceLanguage;
+    onTargetLanguageChanged: Config.options.language.translator.targetLanguage = root.targetLanguage;
 
-    Process {
-        id: getLanguagesProc
-        command: ["trans", "-list-languages", "-no-bidi"]
-        property list<string> bufferList: ["auto"]
-        running: true
-        stdout: SplitParser {
-            onRead: data => {
-                getLanguagesProc.bufferList.push(data.trim());
-            }
-        }
-        onExited: (exitCode, exitStatus) => {
-            // Ensure "auto" is always the first language
-            let langs = getLanguagesProc.bufferList
-                .filter(lang => lang.trim().length > 0 && lang !== "auto")
-                .sort((a, b) => a.localeCompare(b));
-            langs.unshift("auto");
-            root.languages = langs;
-            getLanguagesProc.bufferList = []; // Clear the buffer
-        }
-    }
+    // ============================================================
+    // UI Layout
+    // ============================================================
 
     ColumnLayout {
-        anchors {
-            fill: parent
-            margins: root.padding
-        }
+        anchors.fill: parent
+        anchors.margins: root.padding
 
         StyledFlickable {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            contentHeight: contentColumn.implicitHeight
-
+            Layout.fillWidth: true; Layout.fillHeight: true; contentHeight: contentColumn.implicitHeight
             ColumnLayout {
-                id: contentColumn
-                anchors.fill: parent
-
-                LanguageSelectorButton { // Target language button
-                    id: targetLanguageButton
-                    displayText: root.targetLanguage
-                    onClicked: {
-                        root.showLanguageSelectorDialog(true);
-                    }
+                id: contentColumn; anchors.fill: parent
+                RowLayout {
+                    Layout.fillWidth: true; spacing: root.padding
+                    LanguageSelectorButton { id: sourceLanguageButton; Layout.fillWidth: true; displayText: root.activeSourceLanguage; onClicked: root.showLanguageSelectorDialog(false); }
+                    MaterialSymbol { Layout.alignment: Qt.AlignVCenter; text: "sync_alt"; iconSize: Appearance.font.pixelSize.large; color: Appearance.colors.colOnLayer2 }
+                    LanguageSelectorButton { id: targetLanguageButton; Layout.fillWidth: true; displayText: root.activeTargetLanguage; onClicked: root.showLanguageSelectorDialog(true); }
                 }
-
-                TextCanvas { // Content translation
-                    id: outputCanvas
-                    isInput: false
-                    placeholderText: Translation.tr("Translation goes here...")
-                    property bool hasTranslation: (root.translatedText.trim().length > 0)
-                    text: hasTranslation ? root.translatedText : ""
-                    GroupButton {
-                        id: copyButton
-                        baseWidth: height
-                        buttonRadius: Appearance.rounding.small
-                        enabled: outputCanvas.displayedText.trim().length > 0
-                        contentItem: MaterialSymbol {
-                            anchors.centerIn: parent
-                            horizontalAlignment: Text.AlignHCenter
-                            iconSize: Appearance.font.pixelSize.larger
-                            text: "content_copy"
-                            color: copyButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext
-                        }
-                        onClicked: {
-                            Quickshell.clipboardText = outputCanvas.displayedText
-                        }
-                    }
-                    GroupButton {
-                        id: searchButton
-                        baseWidth: height
-                        buttonRadius: Appearance.rounding.small
-                        enabled: outputCanvas.displayedText.trim().length > 0
-                        contentItem: MaterialSymbol {
-                            anchors.centerIn: parent
-                            horizontalAlignment: Text.AlignHCenter
-                            iconSize: Appearance.font.pixelSize.larger
-                            text: "travel_explore"
-                            color: searchButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext
-                        }
-                        onClicked: {
-                            let url = Config.options.search.engineBaseUrl + outputCanvas.displayedText;
-                            for (let site of Config.options.search.excludedSites) {
-                                url += ` -site:${site}`;
-                            }
-                            Qt.openUrlExternally(url);
-                        }
-                    }
+                TextCanvas {
+                    id: outputCanvas; isInput: false; placeholderText: Translation.tr("Translation goes here..."); text: root.translatedText
+                    GroupButton { id: copyButton; baseWidth: height; buttonRadius: Appearance.rounding.small; enabled: outputCanvas.displayedText.trim().length > 0; contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: "content_copy"; color: copyButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext } onClicked: Quickshell.clipboardText = outputCanvas.displayedText }
+                    GroupButton { id: searchButton; baseWidth: height; buttonRadius: Appearance.rounding.small; enabled: outputCanvas.displayedText.trim().length > 0; contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: "travel_explore"; color: searchButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext } onClicked: Qt.openUrlExternally(Config.options.search.engineBaseUrl + outputCanvas.displayedText) }
                 }
-
-            }    
-        }
-
-        LanguageSelectorButton { // Source language button
-            id: sourceLanguageButton
-            displayText: root.sourceLanguage
-            onClicked: {
-                root.showLanguageSelectorDialog(false);
             }
         }
 
-        TextCanvas { // Content input
-            id: inputCanvas
-            isInput: true
-            placeholderText: Translation.tr("Enter text to translate...")
-            onInputTextChanged: {
-                translateTimer.restart();
-            }
-            GroupButton {
-                id: pasteButton
-                baseWidth: height
-                buttonRadius: Appearance.rounding.small
-                contentItem: MaterialSymbol {
-                    anchors.centerIn: parent
-                    horizontalAlignment: Text.AlignHCenter
-                    iconSize: Appearance.font.pixelSize.larger
-                    text: "content_paste"
-                    color: deleteButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext
+        RowLayout {
+            Layout.fillWidth: true; spacing: root.padding
+            TextCanvas {
+                Layout.fillWidth: true; id: inputCanvas; isInput: true; placeholderText: Translation.tr("Enter text to translate..."); onInputTextChanged: translateTimer.restart();
+                // Manage Button
+                GroupButton {
+                    id: manageCacheButton; baseWidth: height; buttonRadius: Appearance.rounding.small; enabled: root.useLocalTranslation
+                    contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: "folder_managed"; color: Appearance.colors.colOnLayer1 }
+                    onClicked: { getAvailableLangsProc.running = true; root.showIndexManager = true; }
                 }
-                onClicked: {
-                    root.inputField.text = Quickshell.clipboardText
+                GroupButton {
+                    id: localToggleButton; baseWidth: height; buttonRadius: Appearance.rounding.small; toggled: root.useLocalTranslation; enabled: true
+                    contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: root.useLocalTranslation ? "sync_saved_locally" : "cloud_sync"; color: localToggleButton.enabled ? (root.useLocalTranslation ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1) : Appearance.colors.colSubtext }
+                    onClicked: { root.useLocalTranslation = !root.useLocalTranslation; Config.options.sidebar.translator.useLocal = root.useLocalTranslation; }
                 }
-            }
-            GroupButton {
-                id: deleteButton
-                baseWidth: height
-                buttonRadius: Appearance.rounding.small
-                enabled: inputCanvas.inputTextArea.text.length > 0
-                contentItem: MaterialSymbol {
-                    anchors.centerIn: parent
-                    horizontalAlignment: Text.AlignHCenter
-                    iconSize: Appearance.font.pixelSize.larger
-                    text: "close"
-                    color: deleteButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext
-                }
-                onClicked: {
-                    root.inputField.text = ""
-                }
+                GroupButton { id: pasteButton; baseWidth: height; buttonRadius: Appearance.rounding.small; contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: "content_paste"; color: Appearance.colors.colOnLayer1 } onClicked: root.inputField.text = Quickshell.clipboardText }
+                GroupButton { id: deleteButton; baseWidth: height; buttonRadius: Appearance.rounding.small; enabled: inputCanvas.inputTextArea.text.length > 0; contentItem: MaterialSymbol { anchors.centerIn: parent; iconSize: Appearance.font.pixelSize.larger; text: "close"; color: deleteButton.enabled ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext } onClicked: root.inputField.text = "" }
             }
         }
     }
 
+    // --- Dialog Loader (Language Selector) ---
     Loader {
-        anchors.fill: parent
-        active: root.showLanguageSelector
-        visible: root.showLanguageSelector
-        z: 9999
+        anchors.fill: parent; active: root.showLanguageSelector; visible: root.showLanguageSelector; z: 9999
         sourceComponent: SelectionDialog {
-            id: languageSelectorDialog
-            titleText: Translation.tr("Select Language")
-            items: root.languages
-            defaultChoice: root.languageSelectorTarget ? root.targetLanguage : root.sourceLanguage
-            onCanceled: () => {
-                root.showLanguageSelector = false;
-            }
-            onSelected: (result) => {
-                root.showLanguageSelector = false;
-                if (!result || result.length === 0) return; // No selection made
+            id: languageSelectorDialog; titleText: Translation.tr("Select Language"); items: root.languages; defaultChoice: root.languageSelectorTarget ? root.targetLanguage : root.sourceLanguage
+            onCanceled: root.showLanguageSelector = false; onSelected: (result) => { root.showLanguageSelector = false; if(!result) return; if(root.languageSelectorTarget) { root.targetLanguage = result; Config.options.language.translator.targetLanguage = result; } else { root.sourceLanguage = result; Config.options.language.translator.sourceLanguage = result; } translateTimer.restart(); }
+        }
+    }
 
-                if (root.languageSelectorTarget) {
-                    root.targetLanguage = result;
-                    Config.options.language.translator.targetLanguage = result; // Save to config
-                } else {
-                    root.sourceLanguage = result;
-                    Config.options.language.translator.sourceLanguage = result; // Save to config
+    // ✅ Management Overlay (Custom Smooth Design)
+    Rectangle {
+        id: indexManagerOverlay
+        anchors.fill: parent; z: 10000; visible: root.showIndexManager; color: "#AA000000" // Dimmed background
+
+        MouseArea { anchors.fill: parent; onClicked: root.showIndexManager = false } // Prevent clicks behind the window
+
+        // Main Window Box
+        Rectangle {
+            width: parent.width * 0.9; height: parent.height * 0.7; anchors.centerIn: parent
+
+            color: Appearance.colors.colLayer2 // Design: Uses the same color as inner containers (TextCanvas) with no border.
+            radius: Appearance.rounding.normal // Uses a large rounding radius for a smooth, consistent look.
+            border.width: 0 // Removes the sharp white border.
+
+            MouseArea { anchors.fill: parent }
+
+            ColumnLayout {
+                anchors.fill: parent; anchors.margins: 15; spacing: 10
+
+                // Title
+                Text {
+                    Layout.fillWidth: true; text: Translation.tr("Manage Indexes"); font.pixelSize: Appearance.font.pixelSize.large
+                    font.bold: true; color: Appearance.colors.colOnLayer1; horizontalAlignment: Text.AlignHCenter
                 }
 
-                translateTimer.restart(); // Restart translation after language change
+                // Smooth Separator
+                Rectangle { Layout.fillWidth: true; Layout.preferredHeight: 1; color: Appearance.colors.colOnLayer2; opacity: 0.1 }
+
+                // List
+                ListView {
+                    Layout.fillWidth: true; Layout.fillHeight: true; clip: true; model: root.availableIndexLanguages; spacing: 5
+                    delegate: Rectangle {
+                        width: parent.width; height: 45;
+                        color: Appearance.colors.colLayer1; // Item background color (consistent with containers)
+                        radius: Appearance.rounding.small
+                        RowLayout {
+                            anchors.fill: parent; anchors.leftMargin: 15; anchors.rightMargin: 5
+                            Text { Layout.fillWidth: true; text: model.modelData.toUpperCase(); font.pixelSize: Appearance.font.pixelSize.medium; font.bold: true; color: Appearance.colors.colOnLayer1; verticalAlignment: Text.AlignVCenter }
+                            // Transparent Delete Button
+                            GroupButton {
+                                Layout.preferredWidth: 35; Layout.preferredHeight: 35; buttonRadius: Appearance.rounding.small;
+                                background: Item {} // Transparent background to blend the button with the design
+                                contentItem: MaterialSymbol { anchors.centerIn: parent; text: "delete"; iconSize: Appearance.font.pixelSize.larger; color: Appearance.colors.colError }
+                                onClicked: deleteLangProc.deleteLanguage(model.modelData);
+                            }
+                        }
+                    }
+                    // Empty State Message
+                    Text { visible: root.availableIndexLanguages.length === 0; text: Translation.tr("No indexes found."); color: Appearance.colors.colSubtext; anchors.centerIn: parent; font.pixelSize: Appearance.font.pixelSize.medium }
+                }
+
+                // Close Button (Standard Button Design)
+                GroupButton {
+                    Layout.alignment: Qt.AlignHCenter; Layout.topMargin: 5; Layout.preferredWidth: 100; Layout.preferredHeight: 40; buttonRadius: Appearance.rounding.small
+                    background: Rectangle { // Use a distinctive button color
+                        color: Appearance.colors.colSurfaceContainer; radius: parent.buttonRadius
+                    }
+                    contentItem: Text { text: Translation.tr("Close"); color: Appearance.colors.colOnLayer1; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
+                    onClicked: root.showIndexManager = false
+                }
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/local_translate.py
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/local_translate.py
@@ -1,0 +1,229 @@
+import sys
+import os
+import json
+import shutil
+
+# --- Configuration: Size & Cleanup ---
+MAX_CACHE_SIZE = 200 * 1024 * 1024  # 200 MB
+PRUNE_SIZE = 75 * 1024 * 1024       # 75 MB (Amount to delete when full)
+TARGET_SIZE = MAX_CACHE_SIZE - PRUNE_SIZE # Target size after cleanup
+
+# --- Persistent Storage Location ---
+# Uses ~/.local/share/quickshell_translator (Standard XDG path)
+CACHE_DIR = os.path.expanduser("~/.local/share/quickshell_translator")
+
+def get_file_path(source_lang, target_lang, text):
+    """Generates the file path for a specific translation entry."""
+    # Hierarchical structure: .../src/tgt/file.json
+    pair_dir = os.path.join(CACHE_DIR, source_lang, target_lang)
+    os.makedirs(pair_dir, exist_ok=True)
+
+    if not text:
+        return os.path.join(pair_dir, "_.json")
+
+    # Categorize by first character to avoid massive single JSON files
+    first_char = text[0].lower()
+    if not first_char.isalnum():
+        first_char = "symbols"
+
+    return os.path.join(pair_dir, f"{first_char}.json")
+
+def load_cache(filepath):
+    """Loads JSON data from a specific file."""
+    if not os.path.exists(filepath):
+        return {}
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except:
+        return {}
+
+def save_cache(filepath, data):
+    """Saves JSON data to a specific file."""
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except:
+        pass
+
+def get_all_files():
+    """Generator to yield all JSON files in the cache directory."""
+    for root, _, files in os.walk(CACHE_DIR):
+        for file in files:
+            if file.endswith('.json'):
+                yield os.path.join(root, file)
+
+def get_dir_size():
+    """Calculates total size of the cache directory."""
+    total_size = 0
+    for file_path in get_all_files():
+        try:
+            total_size += os.path.getsize(file_path)
+        except OSError:
+            continue
+    return total_size
+
+def cleanup_cache():
+    """
+    Auto-cleanup logic:
+    If cache exceeds MAX_CACHE_SIZE, delete oldest files until TARGET_SIZE is reached.
+    """
+    current_size = get_dir_size()
+    if current_size < MAX_CACHE_SIZE:
+        return # No cleanup needed
+
+    file_list = []
+    for file_path in get_all_files():
+        try:
+            # Use modification time (mtime) to identify old files
+            stat_info = os.stat(file_path)
+            file_list.append((stat_info.st_mtime, stat_info.st_size, file_path))
+        except OSError:
+            continue
+
+    # Sort by time (oldest first)
+    file_list.sort()
+
+    for mtime, size, path in file_list:
+        try:
+            os.remove(path)
+            current_size -= size
+            if current_size < TARGET_SIZE:
+                break # Stop when target size is reached
+        except OSError:
+            continue
+
+# --- Management Functions ---
+
+def get_available_languages():
+    """Returns a list of all languages present in the cache (Source or Target)."""
+    if not os.path.exists(CACHE_DIR):
+        return []
+
+    languages = set()
+
+    # Scan source directories
+    for src_lang in os.listdir(CACHE_DIR):
+        src_dir = os.path.join(CACHE_DIR, src_lang)
+        if os.path.isdir(src_dir) and len(src_lang) in [2, 3]:
+            languages.add(src_lang)
+
+            # Scan target directories within source
+            for tgt_lang in os.listdir(src_dir):
+                if os.path.isdir(os.path.join(src_dir, tgt_lang)) and len(tgt_lang) in [2, 3]:
+                    languages.add(tgt_lang)
+
+    return sorted(list(languages))
+
+def delete_index_language(lang_code):
+    """Deletes the specified language index from both Source and Target locations."""
+    if not lang_code or lang_code.strip() == "" or lang_code == ".":
+        return False
+
+    success = False
+
+    # 1. Delete language as a Source (e.g., delete main 'fr' folder)
+    lang_path_source = os.path.join(CACHE_DIR, lang_code)
+    if os.path.exists(lang_path_source) and os.path.isdir(lang_path_source):
+        try:
+            shutil.rmtree(lang_path_source)
+            success = True
+        except Exception:
+            pass
+
+    # 2. Delete language as a Target (e.g., delete 'fr' inside 'en' folder)
+    if os.path.exists(CACHE_DIR):
+        for src_lang in os.listdir(CACHE_DIR):
+            src_dir = os.path.join(CACHE_DIR, src_lang)
+            if os.path.isdir(src_dir):
+                # Target path: CACHE_DIR/src_lang/lang_code
+                target_path = os.path.join(src_dir, lang_code)
+                if os.path.exists(target_path) and os.path.isdir(target_path):
+                    try:
+                        shutil.rmtree(target_path)
+                        success = True
+                    except Exception:
+                        pass
+
+    return success
+
+def main():
+    # Args: script.py [mode] [src/arg] [tgt] [text] [translation]
+    if len(sys.argv) < 2:
+        print("__NOT_FOUND__")
+        return
+
+    mode = sys.argv[1]
+
+    # Mode: Get available languages list
+    if mode == "get_languages":
+        print(json.dumps(get_available_languages()))
+        return
+
+    # Mode: Delete specific language index
+    if mode == "delete_language":
+        if len(sys.argv) < 3: return
+        lang_code = sys.argv[2]
+        if delete_index_language(lang_code):
+            print(f"DELETED:{lang_code}")
+        else:
+            print(f"ERROR_DELETING:{lang_code}")
+        return
+
+    # Mode: Clear all (Emergency/Legacy)
+    if mode == "clear_all":
+        if os.path.exists(CACHE_DIR):
+            try:
+                shutil.rmtree(CACHE_DIR)
+                print("CACHE_CLEARED")
+            except Exception as e:
+                print(f"ERROR:{e}")
+        return
+
+    # Standard Translation Modes (get/set) require more args
+    if len(sys.argv) < 5:
+        print("__NOT_FOUND__")
+        return
+
+    src = sys.argv[2]
+    tgt = sys.argv[3]
+    text = sys.argv[4].strip()
+
+    if not text:
+        print("__NOT_FOUND__")
+        return
+
+    # Mode: Get translation
+    if mode == "get":
+        filepath = get_file_path(src, tgt, text)
+        cache_data = load_cache(filepath)
+        if text in cache_data:
+            print(cache_data[text])
+        else:
+            print("__NOT_FOUND__")
+
+    # Mode: Set (Save) translation
+    elif mode == "set" and len(sys.argv) >= 6:
+        translation = sys.argv[5].strip()
+        if not translation: return
+
+        # Constraint: Don't save long sentences (more than 3 words)
+        if len(text.split()) > 3: return
+
+        # 1. Save Forward (Source -> Target)
+        fwd_path = get_file_path(src, tgt, text)
+        fwd_data = load_cache(fwd_path)
+        fwd_data[text] = translation
+        save_cache(fwd_path, fwd_data)
+
+        # 2. Save Reverse (Target -> Source) - Bi-directional
+        rev_path = get_file_path(tgt, src, translation)
+        rev_data = load_cache(rev_path)
+        rev_data[translation] = text
+        save_cache(rev_path, rev_data)
+
+        # Trigger auto-cleanup
+        cleanup_cache()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# 1-Reverse translation
I have modified the service to make the translation reverse, instead of modifying the source and target language every time. Now all you have to do is write freely between the two chosen languages, and the service will recognize the language and translate to the opposite.
| en -> ar | ar->en |
|--------|--------|
|  <img width="452" height="853" alt="image" src="https://github.com/user-attachments/assets/04562044-9d88-4038-8121-0dec8e220c54" />|<img width="443" height="856" alt="image" src="https://github.com/user-attachments/assets/7e971f6d-c2f5-4f6d-8c54-9c5a92bd5c3f" />| 

like you see actully I wrote this massage with the service 🤗

# 2-local-Translate-System 
I have designed a system to automatically save the words used in translation daily in the service. If you cancel it, nothing will be saved in it. If the button is activated, any word you write will be saved in the service. 
```
.local/share/quickshell_translator/
```
It is in the form of a tree folder system, and if the size of the index files reaches 200BM, the system automatically cleans part of them, and if you want to delete them manually, you can through the interface, through the bottom button, delete only a specific language.
| on | off | dir-manager |
|--------|--------|--------|
|<img width="43" height="50" alt="image" src="https://github.com/user-attachments/assets/b523c809-8032-485c-9386-d528be0fe8e4" />|<img width="42" height="35" alt="image" src="https://github.com/user-attachments/assets/e9cfa460-2d01-4b06-9ac1-f5f8782619b4" />|<img width="451" height="861" alt="image" src="https://github.com/user-attachments/assets/25bdd1a3-06c5-4b09-a0eb-32fec4cf629d" />| 
# 3-I just modified the interface arrangement a little, I think it's clear

# Is it Ready 
Yes, at least for me, I am waiting for your feedback's