### PR TITLE
Add setting for choosing brightnessctl device

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -360,6 +360,7 @@ Singleton {
             }
 
             property JsonObject light: JsonObject {
+                property string device: ""
                 property JsonObject night: JsonObject {
                     property bool automatic: true
                     property string from: "19:00" // Format: "HH:mm", 24-hour time

--- a/dots/.config/quickshell/ii/services/Brightness.qml
+++ b/dots/.config/quickshell/ii/services/Brightness.qml
@@ -165,8 +165,8 @@ Singleton {
                 } else {
                     cmd.push("--class", "backlight");
                 }
+
                 cmd.push("s", valuePercent, "--quiet");
-                
                 setProc.exec(cmd);
             }
         }

--- a/dots/.config/quickshell/ii/services/Brightness.qml
+++ b/dots/.config/quickshell/ii/services/Brightness.qml
@@ -117,7 +117,10 @@ Singleton {
             const match = root.ddcMonitors.find(m => m.name === screen.name && !root.monitors.slice(0, root.monitors.indexOf(this)).some(mon => mon.busNum === m.busNum));
             isDdc = !!match;
             busNum = match?.busNum ?? "";
-            initProc.command = isDdc ? ["ddcutil", "-b", busNum, "getvcp", "10", "--brief"] : ["sh", "-c", `echo "a b c $(brightnessctl g) $(brightnessctl m)"`];
+
+            const device = Config.options.light.device;
+            const deviceFlag = device ? `-d '${device}'` : "";
+            initProc.command = isDdc ? ["ddcutil", "-b", busNum, "getvcp", "10", "--brief"] : ["sh", "-c", `echo "a b c $(brightnessctl ${deviceFlag} g) $(brightnessctl ${deviceFlag} m)"`];
             initProc.running = true;
         }
 
@@ -153,7 +156,18 @@ Singleton {
                 const valuePercentNumber = Math.floor(brightnessValue * 100);
                 let valuePercent = `${valuePercentNumber}%`;
                 if (valuePercentNumber == 0) valuePercent = "1"; // Prevent fully black
-                setProc.exec(["brightnessctl", "--class", "backlight", "s", valuePercent, "--quiet"])
+
+                const device = Config.options.light.device;
+                const cmd = ["brightnessctl"];
+                
+                if (device) {
+                    cmd.push("-d", device);
+                } else {
+                    cmd.push("--class", "backlight");
+                }
+                cmd.push("s", valuePercent, "--quiet");
+                
+                setProc.exec(cmd);
             }
         }
 


### PR DESCRIPTION
## Describe your changes
I noticed that brightness control wasn't working on my hybrid laptop, and it turned out it was trying to adjust the nvidia backlight instead of the intel_backlight, which is the one that works. I've added a configuration option in settings under services to either leave it at the default, or force brightnessctl to use a specific device. It should autohide the section if there are no brightnessctl compatible devices, but I cannot test that so I would appreciate someone checking it out before merge.
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
I'd appreciate someone making sure the autohide functionality works on a device with no internal displays. It's also my first time writing QML so a quick review would be appreciated as well.

