### PR TITLE
Add Gemini 3 Pro to model list

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -297,7 +297,7 @@ Singleton {
         "gemini-3-pro": aiModelComponent.createObject(this, {
             "name": "Gemini 3.0 Pro",
             "icon": "google-gemini-symbolic",
-            "description": Translation.tr("Online | Google's model\nGoogle's most intelligent model with SOTA reasoning and multimodal understanding."),
+            "description": Translation.tr("Online | Google's model\nGoogle's most intelligent model with state-of-the-art reasoning and multimodal understanding."),
             "homepage": "https://aistudio.google.com",
             "endpoint": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:streamGenerateContent",
             "model": "gemini-3-pro-preview",


### PR DESCRIPTION
## Describe your changes
Small PR. Adds Google's `gemini-3-pro-preview` model to the builtin model list.
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Seems good. I've tested it with text and multimodal and everything works as expected. Tool calling works as well, shell commands, google search, etc.