### PR TITLE
Fix: finger print will still keep running when use password to login

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/lock/LockContext.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockContext.qml
@@ -70,7 +70,7 @@ Scope {
     }
 
     function stopFingerPam() {
-        if (fingerPam.running) {
+        if (fingerPam.active) {
             fingerPam.abort();
         }
     }


### PR DESCRIPTION
## Describe your changes

Use "active" instead of "running" to check if the fingerprint module is still operating.

https://quickshell.org/docs/master/types/Quickshell.Services.Pam/PamContext/

## Is it ready? Questions/feedback needed?
yes

