### PR TITLE
Auto generate colors with qt5ct/qt6ct

### DIFF
--- a/dots/.config/matugen/templates/kde/qt5ct_palette.py
+++ b/dots/.config/matugen/templates/kde/qt5ct_palette.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+from PyQt5 import QtGui, QtWidgets
+
+
+app = QtGui.QGuiApplication(["Dummy"])
+palette = QtWidgets.QStyleFactory.create("Darkly").standardPalette()
+nColorRoles = QtGui.QPalette.ColorRole.NColorRoles
+active_colors = []
+disabled_colors = []
+inactive_colors = []
+
+for i in range(nColorRoles):
+	role = QtGui.QPalette.ColorRole(i)
+	active_colors.append(palette.color(QtGui.QPalette.ColorGroup.Active, role).name(QtGui.QColor.NameFormat.HexArgb))
+	inactive_colors.append(palette.color(QtGui.QPalette.ColorGroup.Inactive, role).name(QtGui.QColor.NameFormat.HexArgb))
+	disabled_colors.append(palette.color(QtGui.QPalette.ColorGroup.Disabled, role).name(QtGui.QColor.NameFormat.HexArgb))
+
+print("[ColorScheme]")
+print("active_colors={}".format(", ".join(active_colors)))
+print("disabled_colors={}".format(", ".join(disabled_colors)))
+print("inactive_colors={}".format(", ".join(inactive_colors)))

--- a/dots/.config/matugen/templates/kde/qt6ct_palette.py
+++ b/dots/.config/matugen/templates/kde/qt6ct_palette.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+from PyQt6 import QtGui, QtWidgets
+
+
+app = QtGui.QGuiApplication(["Dummy"])
+palette = QtWidgets.QStyleFactory.create("Darkly").standardPalette()
+nColorRoles = QtGui.QPalette.ColorRole.NColorRoles.value
+active_colors = []
+disabled_colors = []
+inactive_colors = []
+
+for i in range(nColorRoles):
+	role = QtGui.QPalette.ColorRole(i)
+	active_colors.append(palette.color(QtGui.QPalette.ColorGroup.Active, role).name(QtGui.QColor.NameFormat.HexArgb))
+	inactive_colors.append(palette.color(QtGui.QPalette.ColorGroup.Inactive, role).name(QtGui.QColor.NameFormat.HexArgb))
+	disabled_colors.append(palette.color(QtGui.QPalette.ColorGroup.Disabled, role).name(QtGui.QColor.NameFormat.HexArgb))
+
+print("[ColorScheme]")
+print("active_colors={}".format(", ".join(active_colors)))
+print("disabled_colors={}".format(", ".join(disabled_colors)))
+print("inactive_colors={}".format(", ".join(inactive_colors)))

--- a/dots/.config/matugen/templates/kde/qtct-wrapper.sh
+++ b/dots/.config/matugen/templates/kde/qtct-wrapper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+rm "$XDG_CONFIG_HOME/qt5ct/style-colors.conf"
+rm "$XDG_CONFIG_HOME/qt6ct/style-colors.conf"
+source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
+"$XDG_CONFIG_HOME"/matugen/templates/kde/qt5ct_palette.py > "$XDG_CONFIG_HOME/qt5ct/style-colors.conf"
+"$XDG_CONFIG_HOME"/matugen/templates/kde/qt6ct_palette.py > "$XDG_CONFIG_HOME/qt6ct/style-colors.conf"
+deactivate

--- a/dots/.config/qt5ct/qt5ct.conf
+++ b/dots/.config/qt5ct/qt5ct.conf
@@ -1,0 +1,29 @@
+[Appearance]
+color_scheme_path=~/.config/qt5ct/style-colors.conf
+custom_palette=true
+icon_theme=breeze-plus
+standard_dialogs=xdgdesktopportal
+style=Darkly
+
+[Fonts]
+fixed="JetBrains Mono NF,11,-1,5,50,0,0,0,0,0"
+general="Google Sans Flex,11,-1,5,57,0,0,0,0,0,Medium"
+
+[Interface]
+activate_item_on_single_click=1
+buttonbox_layout=0
+cursor_flash_time=1000
+dialog_buttons_have_icons=1
+double_click_interval=400
+gui_effects=@Invalid()
+keyboard_scheme=2
+menus_have_icons=true
+show_shortcuts_in_context_menus=true
+stylesheets=@Invalid()
+toolbutton_style=4
+underline_shortcut=1
+wheel_scroll_lines=3
+
+[Troubleshooting]
+force_raster_widgets=1
+ignored_applications=@Invalid()

--- a/dots/.config/qt6ct/qt6ct.conf
+++ b/dots/.config/qt6ct/qt6ct.conf
@@ -1,0 +1,29 @@
+[Appearance]
+color_scheme_path=~/.config/qt6ct/style-colors.conf
+custom_palette=true
+icon_theme=breeze-plus
+standard_dialogs=xdgdesktopportal
+style=Darkly
+
+[Fonts]
+fixed="JetBrains Mono NF,11,-1,5,500,0,0,0,0,0,0,0,0,0,0,1,Regular"
+general="Google Sans Flex,11,-1,5,500,0,0,0,0,0,0,0,0,0,0,1,Medium"
+
+[Interface]
+activate_item_on_single_click=1
+buttonbox_layout=0
+cursor_flash_time=1000
+dialog_buttons_have_icons=1
+double_click_interval=400
+gui_effects=@Invalid()
+keyboard_scheme=2
+menus_have_icons=true
+show_shortcuts_in_context_menus=true
+stylesheets=@Invalid()
+toolbutton_style=4
+underline_shortcut=1
+wheel_scroll_lines=3
+
+[Troubleshooting]
+force_raster_widgets=1
+ignored_applications=@Invalid()

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -32,6 +32,7 @@ handle_kde_material_you_colors() {
             ;;
     esac
     "$XDG_CONFIG_HOME"/matugen/templates/kde/kde-material-you-colors-wrapper.sh --scheme-variant "$kde_scheme_variant"
+    "$XDG_CONFIG_HOME"/matugen/templates/kde/qtct-wrapper.sh
 }
 
 pre_process() {

--- a/sdata/dist-arch/illogical-impulse-fonts-themes/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-fonts-themes/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=illogical-impulse-fonts-themes
-pkgver=1.0
-pkgrel=4
+pkgver=1.1
+pkgrel=1
 pkgdesc='Illogical Impulse Fonts and Theming Dependencies'
 arch=(any)
 license=(None)
@@ -21,4 +21,8 @@ depends=(
   ttf-readex-pro
   ttf-rubik-vf
   ttf-twemoji
+)
+optdepends=(
+  'qt5ct: makes qt5 apps follow overall theme'
+  'qt6ct: makes qt6 apps follow overall theme'
 )

--- a/sdata/uv/requirements.in
+++ b/sdata/uv/requirements.in
@@ -13,6 +13,8 @@ click
 loguru
 pycairo
 pygobject
+pyqt5
+pyqt6
 tqdm
 numpy
 opencv-contrib-python

--- a/sdata/uv/requirements.txt
+++ b/sdata/uv/requirements.txt
@@ -49,6 +49,18 @@ pygobject==3.52.3
     # via -r sdata/uv/requirements.in
 pyproject-hooks==1.2.0
     # via build
+pyqt5==5.15.11
+    # via -r sdata/uv/requirements.in
+pyqt5-qt5==5.15.18
+    # via pyqt5
+pyqt5-sip==12.17.1
+    # via pyqt5
+pyqt6==6.10.0
+    # via -r sdata/uv/requirements.in
+pyqt6-qt6==6.10.0
+    # via pyqt6
+pyqt6-sip==13.10.2
+    # via pyqt6
 pywayland==0.4.18
     # via -r sdata/uv/requirements.in
 setproctitle==1.3.4


### PR DESCRIPTION
## Describe your changes

This brings back the qt#ct configs but now changing the accent colour works. I found out, by looking at qt#ct source, that it picks up changes when the file is created, so I only needed to delete and recreate the file.

For qt5 I tested against opensnitch. For qt6 the qt6ct settings app already works, I'm not sure if I have a qt6 app to test. But both work in the same way, so it should work.

## Is it ready? Questions/feedback needed?

It's ready, I've been using it for some months. Don't even need to close the window or anything, seems you need to focus it, but that might be a hyprland thing.
