### PR TITLE
feat: hide user keybinds

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -300,6 +300,7 @@ Singleton {
                     property int key: Appearance.font.pixelSize.smaller
                     property int comment: Appearance.font.pixelSize.smaller
                 }
+                property bool hideUserKeybinds: false
             }
 
             property JsonObject conflictKiller: JsonObject {

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -78,6 +78,18 @@ ContentPage {
 
         }
 
+        ConfigSwitch {
+            buttonIcon: "person"
+            text: Translation.tr("Hide user keybinds")
+            checked: Config.options.cheatsheet.hideUserKeybinds
+            onCheckedChanged: {
+                Config.options.cheatsheet.hideUserKeybinds = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("When enabled, keybinds from your personal/custom Hyprland keybinds file will be hidden from the cheatsheet.")
+            }
+        }
+
         ConfigSpinBox {
             text: Translation.tr("Keybind font size")
             value: Config.options.cheatsheet.fontSize.key

--- a/dots/.config/quickshell/ii/services/HyprlandKeybinds.qml
+++ b/dots/.config/quickshell/ii/services/HyprlandKeybinds.qml
@@ -22,7 +22,8 @@ Singleton {
     property var keybinds: ({
         children: [
             ...(defaultKeybinds.children ?? []),
-            ...(userKeybinds.children ?? []),
+            // Honor the user's preference to hide their custom keybinds
+            ...(Config.options.cheatsheet && Config.options.cheatsheet.hideUserKeybinds ? [] : (userKeybinds.children ?? [])),
         ]
     })
 


### PR DESCRIPTION
## Describe your changes

It'll add option to hide user keybinds in cheatsheet to avoid such issues where too many user keybinds just result in weird behaviour of cheatsheet where it takes over all the screen
<img width="892" height="996" alt="image" src="https://github.com/user-attachments/assets/f81e81f4-635e-4080-8436-59c3ec14e5c3" />


## Is it ready? Questions/feedback needed?
yes


