### PR TITLE
fix(floating-image): Fix gif not showing 

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/utils/ImageDownloaderProcess.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/ImageDownloaderProcess.qml
@@ -18,14 +18,19 @@ Process {
 
     running: true
     command: ["bash", "-c", 
-        `mkdir -p $(dirname '${processFilePath(filePath)}'); [ -f '${processFilePath(filePath)}' ] || curl -sSL '${sourceUrl}' -o '${processFilePath(filePath)}' && magick identify -format '%w %h' '${processFilePath(filePath)}'[0]`
+        `mkdir -p $(dirname '${processFilePath()}'); [ -f '${processFilePath()}' ] || curl -sSL '${sourceUrl}' -o '${processFilePath()}' && file '${processFilePath()}'`
     ]
     stdout: StdioCollector {
         id: imageSizeOutputCollector
         onStreamFinished: {
             const output = imageSizeOutputCollector.text.trim();
-            const [width, height] = output.split(" ").map(Number);
-            root.done(root.filePath, width, height);
+            const match = output.match(/(\d+)\s*x\s*(\d+)/);
+
+            if (match) {
+                const width = Number(match[1]);
+                const height = Number(match[2]);
+                root.done(root.filePath, width, height);
+            }
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

Currently, the `width` and `height` properties were not being read correctly from the `GIF`, resulting in a return value of `0` and a nonfunctional floating image. With these changes it now works as intended.

<details>
<summary> Don't open (working example of gif) </summary>
<img width="1080" height="1120" alt="image" src="https://github.com/user-attachments/assets/1ae6623d-727b-4d2e-86fc-b163c1804ae5" />
</details>

## Is it ready? Questions/feedback needed?
Yes. its a small fix.

