### PR TITLE
Fix CPU frequency detection for non-English locales

### DIFF
--- a/dots/.config/quickshell/ii/services/ResourceUsage.qml
+++ b/dots/.config/quickshell/ii/services/ResourceUsage.qml
@@ -102,7 +102,11 @@ Singleton {
 
     Process {
         id: findCpuMaxFreqProc
-        command: ["bash", "-c", "LANG=en_US.UTF-8 lscpu | grep 'CPU max MHz' | awk '{print $4}'"]
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        command: ["bash", "-c", "lscpu | grep 'CPU max MHz' | awk '{print $4}'"]
         running: true
         stdout: StdioCollector {
             id: outputCollector


### PR DESCRIPTION
## Fix CPU frequency detection for non-English locales

When the system locale is not English, the lscpu command outputs localized text that breaks the CPU frequency parsing in the Resources overlay, causing it to display "NaN GHz" instead of the actual frequency.

<img width="384" height="271" alt="swappy-20251203_180959" src="https://github.com/user-attachments/assets/051073e8-dd3b-49dd-95ee-fc578e2aa8cd" />



### The Problem

The parsing logic expects lscpu to output "CPU max MHz: " in English, but with locales like fr_FR.UTF-8, the output format changes, causing awk '{print $4}' to return an empty string.

###  The Solution

I've fixed this by setting the environment property on the Process component to force English/C locale: 

```
environment: ({  
    LANG: "C",  
    LC_ALL: "C"  
})
```
CPU frequency now correctly displays (e.g., "5 GHz") instead of "NaN GHz"

<img width="381" height="265" alt="swappy-20251203_181622" src="https://github.com/user-attachments/assets/40ec0d17-555c-4894-81e0-4a57c2c021ff" />

## Is it ready? Questions/feedback needed?

Yes

