### PR TITLE
Set PACMAN_AUTH to prevent repeated sudo password prompts

### DIFF
--- a/sdata/dist-arch/install-deps.sh
+++ b/sdata/dist-arch/install-deps.sh
@@ -43,6 +43,11 @@ if ! command -v pacman >/dev/null 2>&1; then
   exit 1
 fi
 
+# Keep makepkg from resetting sudo credentials
+if [[ -z "${PACMAN_AUTH:-}" ]]; then
+  export PACMAN_AUTH="sudo"
+fi
+
 showfun remove_deprecated_dependencies
 v remove_deprecated_dependencies
 


### PR DESCRIPTION
## Describe your changes

- Default `PACMAN_AUTH` to `sudo` in the Arch deps script so makepkg skips its `sudo -k` path and reuses the sudo session kept alive by commit end-4/dots-hyprland@8a9f105, eliminating repeated password prompts (#2624).
- Only set `PACMAN_AUTH` when it was unset, preserving any user-defined value.

## Is it ready? Questions/feedback needed?

Yes, it is ready.

Tested by running `./setup install` and selecting the option to execute all commands automatically. I only needed to input my password once. Without my change, I needed to input my password multiple times.