### PR TITLE
audio: protection: fix weird volume limit behaviors

### DIFF
--- a/dots/.config/quickshell/ii/services/Audio.qml
+++ b/dots/.config/quickshell/ii/services/Audio.qml
@@ -111,9 +111,9 @@ Singleton {
             if (newVolume - lastVolume > maxAllowedIncrease) {
                 sink.audio.volume = lastVolume;
                 root.sinkProtectionTriggered(Translation.tr("Illegal increment"));
-            } else if (newVolume > maxAllowed || newVolume > root.hardMaxValue) {
+            } else if (Math.round(newVolume * 100) / 100 > maxAllowed || newVolume > root.hardMaxValue) {
                 root.sinkProtectionTriggered(Translation.tr("Exceeded max allowed"));
-                sink.audio.volume = Math.min(lastVolume, maxAllowed);
+                sink.audio.volume = maxAllowed;
             }
             lastVolume = sink.audio.volume;
         }


### PR DESCRIPTION
## Describe your changes
Small fixes on the volume limit feature:
1. newVolume is often a weird non-whole float number, making e.g. 1.0002... detect as exceeded the limit of 1, so I rounded it to the hundredth in the check
2. If it goes over, just set it to the limit value instead of the last volume, which fits (I think) most people's intuition better

| Before | After |
|--------|--------|
| <img width="1502" height="425" alt="image" src="https://github.com/user-attachments/assets/5c34b991-f936-4a3d-9def-fcb682db6ceb" /> | <img width="1502" height="425" alt="image (1)" src="https://github.com/user-attachments/assets/28bae3a1-86ed-47d7-98a9-6ab625b47043" /> |
|  | <img width="1502" height="425" alt="image (2)" src="https://github.com/user-attachments/assets/651e9181-5fbc-4958-aaf6-da38ec5929c7" /> |

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Yes, although I found a [previous commit on the line of my second change](https://github.com/end-4/dots-hyprland/commit/92051b88ec3e7778145270913eb88c43a817ecb9). Doesn't make sense to me, but was it intentional?
