### PR TITLE
Fix. Topbar Clock Widget text not centered

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ClockWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClockWidget.qml
@@ -17,6 +17,10 @@ Item {
         spacing: 4
 
         StyledText {
+            anchors {
+                bottom: parent.bottom
+                bottomMargin: (parent.height - height) / 2 - 1
+            }
             font.pixelSize: Appearance.font.pixelSize.large
             color: Appearance.colors.colOnLayer1
             text: DateTime.time


### PR DESCRIPTION
## Describe your changes
The time text isn't centered because of its larger font size, but still sharing the same baseline as the surrounding text, causing vertical misalignment.

## Is it ready? Questions/feedback needed?
yes i've fully tested

