### PR TITLE
Use rm -rf for removing paths in uninstall script

### DIFF
--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -45,7 +45,7 @@ function delete_targets(){
       printf "${STY_YELLOW}Target \"$path\" inexists, skipping...${STY_RST}\n"
       continue
     elif [[ "$path" == "$HOME"* ]]; then
-      x rm -- "$path"
+      x rm -rf -- "$path"
     else
       while true; do
         printf "WARNING: Target \"$path\" is not under \$HOME. Still delete it?\ny=Yes, delete it;\nn=No, skip this one\n"
@@ -53,7 +53,7 @@ function delete_targets(){
         echo
         case "$ans" in
           y|Y)
-            x rm -- "$path"
+            x rm -rf -- "$path"
             break 1
             ;;
           n|N)


### PR DESCRIPTION
... most of these are directories

## Describe your changes

changed to rm -rf instead of rm, tested on system. otherwise gave the error of "rm: cannot remove $file: Is a directory". might be a random error, just creating this pull request 

## Is it ready? Questions/feedback needed?

probably ready, tested on two machines, and it worked great. without it, it would error out. Feedback needed, implementation maybe not needed


