### PR TITLE
Disable custom config sources in hyprland.conf

### DIFF
--- a/dots/.config/hypr/hyprland.conf
+++ b/dots/.config/hypr/hyprland.conf
@@ -14,11 +14,11 @@ source=hyprland/colors.conf
 source=hyprland/keybinds.conf
 
 # Custom 
-source=custom/env.conf
-source=custom/execs.conf
-source=custom/general.conf
-source=custom/rules.conf
-source=custom/keybinds.conf
+# source=custom/env.conf
+# source=custom/execs.conf
+# source=custom/general.conf
+# source=custom/rules.conf
+# source=custom/keybinds.conf
 
 # nwg-displays support
 source=workspaces.conf


### PR DESCRIPTION
Commented out custom configuration sources in hyprland.conf since they produce globbing error if custom folder isn't created correctly (doesn't contain the files).

If someone is configuring far enough to need custom files, they can also uncomment each source line. But for people who don't care, it will reduce possible errors :)

## Describe your changes

Commented out custom configuration sources in hyprland.conf since they produce globbing error if custom folder isn't created correctly (doesn't contain the files).

## Is it ready? Questions/feedback needed?

Yes, it is ready.

