### PR TITLE
fix(overview): correct 4 finger vertical swipes

### DIFF
--- a/dots/.config/hypr/hyprland/general.conf
+++ b/dots/.config/hypr/hyprland/general.conf
@@ -4,8 +4,8 @@ monitor=,preferred,auto,1
 gesture = 3, swipe, move,
 gesture = 3, pinch, float
 gesture = 4, horizontal, workspace
-gesture = 4, up, dispatcher, global, quickshell:overviewToggle
-gesture = 4, down, dispatcher, global, quickshell:overviewClose
+gesture = 4, up, dispatcher, global, quickshell:overviewWorkspacesToggle
+gesture = 4, down, dispatcher, global, quickshell:overviewWorkspacesClose
 gestures {
     workspace_swipe_distance = 700
     workspace_swipe_cancel_ratio = 0.2

--- a/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
@@ -193,6 +193,14 @@ Scope {
         }
     }
     GlobalShortcut {
+        name: "overviewWorkspacesClose"
+        description: "Closes overview on press"
+
+        onPressed: {
+            GlobalStates.overviewOpen = false;
+        }
+    }
+    GlobalShortcut {
         name: "overviewWorkspacesToggle"
         description: "Toggles overview on press"
 


### PR DESCRIPTION
## Describe your changes
The 4-finger vertical swipes configured by default were not working because the quickshell binds did not exist (might have changed at some point). I corrected the upwards one and added the downwards one. 

## Is it ready? Questions/feedback needed?
It's a pretty small change and it just fixes something that did not work, it;s ready.

