### PR TITLE
Enable middle mouse button to pin/unpin tray items

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.conf
+++ b/dots/.config/hypr/hyprland/keybinds.conf
@@ -117,6 +117,7 @@ bind = Super, D, fullscreen, 1 # Maximize
 bind = Super, F, fullscreen, 0 # Fullscreen
 bind = Super+Alt, F, fullscreenstate, 0 3 # Fullscreen spoof
 bind = Super, P, pin # Pin
+bind = Super, mid-mouse, pin # Pin, unpin by mid mouse click on the System Tray icon
 
 #/# bind = Super+Alt, Hash,, # Send to workspace # (1, 2, 3,...)
 # We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`

--- a/dots/.config/quickshell/ii/modules/ii/bar/SysTrayItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/SysTrayItem.qml
@@ -17,7 +17,7 @@ MouseArea {
     signal menuClosed()
 
     hoverEnabled: true
-    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
     implicitWidth: 20
     implicitHeight: 20
     onPressed: (event) => {
@@ -27,6 +27,9 @@ MouseArea {
             break;
         case Qt.RightButton:
             if (item.hasMenu) menu.open();
+            break;
+        case Qt.MiddleButton:
+            TrayService.togglePin(item);
             break;
         }
         event.accepted = true;

--- a/dots/.config/quickshell/ii/services/TrayService.qml
+++ b/dots/.config/quickshell/ii/services/TrayService.qml
@@ -9,8 +9,13 @@ Singleton {
     id: root
 
     property bool smartTray: Config.options.tray.filterPassive
-    property list<var> itemsInUserList: SystemTray.items.values.filter(i => (Config.options.tray.pinnedItems.includes(i.id) && (!smartTray || i.status !== Status.Passive)))
-    property list<var> itemsNotInUserList: SystemTray.items.values.filter(i => (!Config.options.tray.pinnedItems.includes(i.id) && (!smartTray || i.status !== Status.Passive)))
+
+    function getUniqueId(item) {
+        return item.id + "::" + item.tooltipTitle;
+    }
+    
+    property list<var> itemsInUserList: SystemTray.items.values.filter(i => (Config.options.tray.pinnedItems.includes(getUniqueId(i)) && (!smartTray || i.status !== Status.Passive)))
+    property list<var> itemsNotInUserList: SystemTray.items.values.filter(i => (!Config.options.tray.pinnedItems.includes(getUniqueId(i)) && (!smartTray || i.status !== Status.Passive)))
 
     property bool invertPins: Config.options.tray.invertPinnedItems
     property list<var> pinnedItems: invertPins ? itemsNotInUserList : itemsInUserList
@@ -24,21 +29,24 @@ Singleton {
         return result;
     }
 
-    // Pinning
-    function pin(itemId) {
+    /// Pinning
+    function pin(item) {
+        var uniqueId = getUniqueId(item);
         var pins = Config.options.tray.pinnedItems;
-        if (pins.includes(itemId)) return;
-        Config.options.tray.pinnedItems.push(itemId);
+        if (pins.includes(uniqueId)) return;
+        Config.options.tray.pinnedItems.push(uniqueId);
     }
-    function unpin(itemId) {
-        Config.options.tray.pinnedItems = Config.options.tray.pinnedItems.filter(id => id !== itemId);
+    function unpin(item) {
+        var uniqueId = getUniqueId(item);
+        Config.options.tray.pinnedItems = Config.options.tray.pinnedItems.filter(id => id !== uniqueId);
     }
-    function togglePin(itemId) {
+    function togglePin(item) {
+        var uniqueId = getUniqueId(item);
         var pins = Config.options.tray.pinnedItems;
-        if (pins.includes(itemId)) {
-            unpin(itemId)
+        if (pins.includes(uniqueId)) {
+            unpin(item)
         } else {
-            pin(itemId)
+            pin(item)
         }
     }
 


### PR DESCRIPTION
## Describe your changes

- Adds support for pinning and unpinning system tray items via middle mouse button click in SysTrayItem.qml.
-  Updates TrayService to use a unique identifier for items and refactors pin/unpin/togglePin logic to operate on item objects instead of IDs. (Fix unique id SysTray problem)
- Also adds a corresponding keybind in Hyprland for pinning via middle mouse.

