### PR TITLE
Avoid errors ： “are the same file”

### DIFF
--- a/sdata/subcmd-install/3.files-legacy.sh
+++ b/sdata/subcmd-install/3.files-legacy.sh
@@ -66,4 +66,4 @@ case "${SKIP_HYPRLAND}" in
     ;;
 esac
 
-install_file "dots/.local/share/icons/illogical-impulse.svg" "${XDG_DATA_HOME}"/icons/illogical-impulse.svg
+install_file "dots/.local/share/icons/illogical-impulse.svg" "${XDG_DATA_HOME}"/icons/illogical-impulse.svg || exit 0


### PR DESCRIPTION
This pull request makes a minor change to the installation script to improve its robustness. The change ensures that if the `install_file` command for the `illogical-impulse.svg` icon fails, the script will exit gracefully without error.

* Added a conditional exit (`|| exit 0`) to the `install_file` command for `illogical-impulse.svg` in `3.files-legacy.sh` to prevent script failure if the file can't be installed.
[./setup]: Next command:
cp_file dots/.local/share/icons/illogical-impulse.svg /home/lightjunction/.local/share/icons/illogical-impulse.svg [./setup]: Command "mkdir -p /home/lightjunction/.local/share/icons" finished. cp: 'dots/.local/share/icons/illogical-impulse.svg' and '/home/lightjunction/.local/share/icons/illogical-impulse.svg' are the same file [./setup]: Command "cp -f dots/.local/share/icons/illogical-impulse.svg /home/lightjunction/.local/share/icons/illogical-impulse.svg" has failed. You may need to resolve the problem manually BEFORE repeating this command. [Tip] If a certain package is failing to install, try installing it separately in another terminal.
  r = Repeat this command (DEFAULT)
  e = Exit now
  i = Ignore this error and continue (your setup might not work correctly)
 [R/e/i]:

## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

：
[./setup]: Next command:
cp_file dots/.local/share/icons/illogical-impulse.svg /home/lightjunction/.local/share/icons/illogical-impulse.svg
[./setup]: Command "mkdir -p /home/lightjunction/.local/share/icons" finished.
cp: 'dots/.local/share/icons/illogical-impulse.svg' and '/home/lightjunction/.local/share/icons/illogical-impulse.svg' are the same file
[./setup]: Command "cp -f dots/.local/share/icons/illogical-impulse.svg /home/lightjunction/.local/share/icons/illogical-impulse.svg" has failed.
You may need to resolve the problem manually BEFORE repeating this command.
[Tip] If a certain package is failing to install, try installing it separately in another terminal.
  r = Repeat this command (DEFAULT)
  e = Exit now
  i = Ignore this error and continue (your setup might not work correctly)
 [R/e/i]:  
