### PR TITLE
feat: add crypto widget with multi-coin support and settings

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -275,6 +275,12 @@ Singleton {
                 property JsonObject tooltips: JsonObject {
                     property bool clickToShow: false
                 }
+                property JsonObject crypto: JsonObject {
+                    property bool enable: true
+                    property list<string> coins: ["bitcoin"]
+                    property bool monochromeIcon: false
+                    property int refreshRate: 5 // minutes
+                }
             }
 
             property JsonObject battery: JsonObject {

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -327,6 +327,26 @@ Item { // Bar content region
                 Layout.fillHeight: true
             }
 
+            // Crypto
+            Loader {
+                Layout.leftMargin: 4
+                active: Config.options.bar.crypto.enable
+
+                sourceComponent: Row {
+                    spacing: 4
+                    Repeater {
+                        model: Crypto.coinModel
+                        delegate: BarGroup {
+                            CryptoWidget {
+                                imageUrl: model.imageUrl
+                                symbol: model.symbol
+                                price: model.price
+                            }
+                        }
+                    }
+                }
+            }
+
             // Weather
             Loader {
                 Layout.leftMargin: 4

--- a/dots/.config/quickshell/ii/modules/ii/bar/CryptoWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/CryptoWidget.qml
@@ -1,0 +1,80 @@
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+
+MouseArea {
+    id: root
+    implicitWidth: rowLayout.implicitWidth + 10 * 2
+    implicitHeight: Appearance.sizes.barHeight
+
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    
+    onPressed: {
+        if (mouse.button === Qt.RightButton || mouse.button === Qt.LeftButton) {
+            Crypto.getData();
+            Quickshell.execDetached(["notify-send", 
+                "Crypto", 
+                "Refreshing price..."
+                , "-a", "Shell"
+            ])
+        }
+    }
+
+    property string imageUrl: ""
+    property string symbol: ""
+    property string price: ""
+    
+    RowLayout {
+        id: rowLayout
+        anchors.centerIn: parent
+
+        // Show fetched image if available
+        Item {
+            Layout.alignment: Qt.AlignVCenter
+            width: Appearance.font.pixelSize.large
+            height: Appearance.font.pixelSize.large
+            visible: root.imageUrl !== ""
+
+            Image {
+                id: coinImg
+                anchors.fill: parent
+                source: root.imageUrl
+                sourceSize.width: Appearance.font.pixelSize.large
+                sourceSize.height: Appearance.font.pixelSize.large
+                visible: !Crypto.monochromeIcon
+            }
+            
+            Desaturate {
+                anchors.fill: parent
+                source: coinImg
+                desaturation: 1.0
+                visible: Crypto.monochromeIcon
+            }
+        }
+
+        // Fallback to symbol if image is missing
+        StyledText {
+            visible: root.imageUrl === ""
+            font.pixelSize: Appearance.font.pixelSize.small
+            font.bold: true
+            color: Appearance.colors.colOnLayer1
+            // Use fetched symbol
+            text: root.symbol
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        StyledText {
+            visible: true
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colOnLayer1
+            text: root.price
+            Layout.alignment: Qt.AlignVCenter
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
@@ -252,6 +252,52 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "currency_bitcoin"
+        title: Translation.tr("Crypto")
+
+        ConfigSwitch {
+            buttonIcon: "check"
+            text: Translation.tr("Enable")
+            checked: Config.options.bar.crypto.enable
+            onCheckedChanged: {
+                Config.options.bar.crypto.enable = checked;
+            }
+        }
+
+        ConfigRow {
+            MaterialTextField {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("CoinGecko IDs (comma separated, e.g. bitcoin,ethereum)")
+                text: Config.options.bar.crypto.coins.join(",")
+                onEditingFinished: {
+                    Config.options.bar.crypto.coins = text.split(",").map(s => s.trim()).filter(s => s !== "")
+                }
+            }
+        }
+
+        ConfigSwitch {
+            buttonIcon: "colors"
+            text: Translation.tr('Tint icons')
+            checked: Config.options.bar.crypto.monochromeIcon
+            onCheckedChanged: {
+                Config.options.bar.crypto.monochromeIcon = checked;
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "update"
+            text: Translation.tr("Refresh Rate (min)")
+            value: Config.options.bar.crypto.refreshRate
+            from: 1
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.bar.crypto.refreshRate = value;
+            }
+        }
+    }
+
+    ContentSection {
         icon: "workspaces"
         title: Translation.tr("Workspaces")
 

--- a/dots/.config/quickshell/ii/services/Crypto.qml
+++ b/dots/.config/quickshell/ii/services/Crypto.qml
@@ -1,0 +1,100 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+import qs.modules.common
+
+Singleton {
+    id: root
+    
+    // 5 minutes
+    readonly property int fetchInterval: Config.options.bar.crypto.refreshRate * 60 * 1000
+    readonly property list<string> coins: Config.options.bar.crypto.coins
+    readonly property bool monochromeIcon: Config.options.bar.crypto.monochromeIcon
+    readonly property string currency: "usd"
+
+    property ListModel coinModel: ListModel {}
+
+    onCoinsChanged: {
+        root.getData()
+    }
+
+    function getData() {
+        if (root.coins.length === 0) {
+            coinModel.clear();
+            return;
+        }
+        
+        // Fetch markets data for list of IDs
+        let ids = root.coins.join(",");
+        let command = `curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=${root.currency}&ids=${ids}&order=market_cap_desc&sparkline=false&locale=en"`
+        
+        fetcher.command = ["bash", "-c", command]
+        fetcher.running = true
+    }
+
+    Component.onCompleted: {
+        root.getData();
+    }
+
+    Process {
+        id: fetcher
+        command: ["bash", "-c", ""]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (text.length === 0)
+                    return;
+                try {
+                    let data = JSON.parse(text.trim());
+                    
+                    if (!Array.isArray(data)) {
+                         console.error(`[CryptoService] Expected array, got: ${text}`);
+                         return;
+                    }
+
+                    // Create a map for fast lookup
+                    let dataMap = {};
+                    data.forEach(coin => { dataMap[coin.id] = coin; });
+
+                    coinModel.clear();
+                    
+                    // Iterate over configured coins to maintain order
+                    for (let i = 0; i < root.coins.length; ++i) {
+                        let coinId = root.coins[i];
+                        let coinData = dataMap[coinId];
+                        
+                        if (coinData) {
+                            coinModel.append({
+                                "coinId": coinData.id,
+                                "symbol": coinData.symbol.toUpperCase(),
+                                "price": "$" + coinData.current_price.toLocaleString(),
+                                "imageUrl": coinData.image
+                            });
+                        } else {
+                            // Placeholder for loading or invalid ID
+                            coinModel.append({
+                                "coinId": coinId,
+                                "symbol": "...",
+                                "price": "...",
+                                "imageUrl": ""
+                            });
+                        }
+                    }
+                    
+                } catch (e) {
+                    console.error(`[CryptoService] Error parsing JSON: ${e.message} in output: ${text}`);
+                }
+            }
+        }
+    }
+
+    Timer {
+        running: Config.options.bar.crypto.enable
+        repeat: true
+        interval: root.fetchInterval
+        onTriggered: root.getData()
+    }
+}


### PR DESCRIPTION
# feat: Add Crypto Widget with Multi-Coin Support

## Description
This PR introduces a new widget for monitoring cryptocurrencies in the status bar, allowing the display of prices and icons for multiple configurable coins.

## Key Features
- **Multi-Coin Support**: Users can configure a list of cryptocurrencies (e.g., `bitcoin,ethereum,dogecoin`) to be displayed as separate panels on the bar.
- **Automatic Data**: Prices and icons are automatically fetched from the CoinGecko API.
- **Dynamic Icons & Fallback**:
  - Displays the official coin icon fetched from the API.
  - Falls back to the text symbol (e.g., "BTC") if the icon is unavailable or loading.
- **Monochrome Mode**: "Tint icons" option in settings to display icons in grayscale (*Desaturate*). This improves visual integration with dark themes while preserving internal details (e.g., the Bitcoin "B").
- **Full UI Configuration**:
  - New **Crypto** section in `BarConfig`.
  - Text input for a comma-separated list of Coin IDs.
  - Toggles for enabling the widget and monochrome mode.
  - Customizable refresh rate.

## Technical Changes
- **Service**: Added [Crypto.qml](cci:7://file:///home/torvalds/Git/dots-hyprland/dots/.config/quickshell/ii/services/Crypto.qml:0:0-0:0) to handle API calls (`/coins/markets` endpoint) and populate a `ListModel`.
- **UI**: Created a reusable [CryptoWidget.qml](cci:7://file:///home/torvalds/Git/dots-hyprland/dots/.config/quickshell/ii/modules/ii/bar/CryptoWidget.qml:0:0-0:0) component.
- **Layout**: Modified [BarContent.qml](cci:7://file:///home/torvalds/Git/dots-hyprland/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml:0:0-0:0) to use a `Repeater` that dynamically generates widgets based on the configured list.
- **Config**: Updated schema in [Config.qml](cci:7://file:///home/torvalds/Git/dots-hyprland/dots/.config/quickshell/ii/modules/common/Config.qml:0:0-0:0) to support a list of strings (`coins`) instead of a single coin ID string.

## How to Test
1. Open Bar settings (`BarConfig`).
2. Go to the **Crypto** section.
3. Enter a list of IDs, for example: `bitcoin,ethereum`.
4. Verify that two distinct widgets appear on the bar.
5. Enable the **Tint icons** option and verify that icons turn grayscale (black & white) while remaining legible.

<img width="2501" height="48" alt="image" src="https://github.com/user-attachments/assets/8805fc84-83a9-4efe-90a0-c1e1a8cfeb1c" />

<img width="1110" height="760" alt="image" src="https://github.com/user-attachments/assets/a66387b8-0bfd-440d-b54a-2e6fcc447e9c" />

