### PR TITLE
Fix background clock widget's color being obnoxious

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/AbstractBackgroundWidget.qml
@@ -59,7 +59,8 @@ AbstractWidget {
         function onReadyChanged() { refreshPlacementIfNeeded() }
     }
     function refreshPlacementIfNeeded() {
-        if (!Config.ready || (root.placementStrategy === "free" && root.needsColText)) return;
+        if (!Config.ready) return;
+        if (root.placementStrategy === "free" && !root.needsColText) return;
         leastBusyRegionProc.wallpaperPath = root.wallpaperPath;
         leastBusyRegionProc.running = false;
         leastBusyRegionProc.running = true;


### PR DESCRIPTION
## Describe your changes

Fixes the hideous clock widget's color when draggable.

**Before:**
<img width="753" height="437" alt="swappy-20251222_232839" src="https://github.com/user-attachments/assets/9b83a4e6-848f-4be8-8350-3957df54ddf0" />


**Now:**

https://github.com/user-attachments/assets/8e3b2551-bf80-4bd9-87cb-1c913885394b



## Is it ready? Questions/feedback needed?


