### PR TITLE
Feat: Enable saving multiple AI chat sessions

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -905,14 +905,19 @@ Singleton {
         blockLoading: true // Prevent race conditions
     }
 
+    FileView {
+        id: chatWriter
+    }
+
     /**
      * Saves chat to a JSON list of message objects.
      * @param chatName name of the chat
      */
     function saveChat(chatName) {
-        chatSaveFile.chatName = chatName.trim()
+        const filePath = `${Directories.aiChats}/${chatName.trim()}.json`
+        chatWriter.path = filePath
         const saveContent = JSON.stringify(root.chatToJson())
-        chatSaveFile.setText(saveContent)
+        chatWriter.setText(saveContent)
         getSavedChats.running = true;
     }
 


### PR DESCRIPTION
Feat: Enable saving multiple AI chat sessions

## Summary
This feature enhances the `/save` command to support saving multiple distinct AI chat sessions with user-defined names.

## Changes
- Implemented a dedicated `chatWriter` component to handle file writing independently.
- Updated the `saveChat` function to utilize the new writer, ensuring that commands like `/save meeting_notes` and `/save project_ideas` create separate, distinct files (e.g., `meeting_notes.json`, `project_ideas.json`) instead of overwriting the last session.

## Verification
- Validated that `/save [name]` correctly creates a new file with the specified name.
- Confirmed that multiple consequent saves with different names persist as separate files.
