### PR TITLE
Stopwatch and Pomodoro on top bar

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -315,6 +315,8 @@ Item { // Bar content region
                 }
             }
 
+            TimersTray {}
+
             SysTray {
                 visible: root.useShortenedForm === 0
                 Layout.fillWidth: false

--- a/dots/.config/quickshell/ii/modules/ii/bar/TimersTray.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/TimersTray.qml
@@ -15,11 +15,20 @@ BarGroup {
     readonly property bool hasPomo: TimerService.pomodoroSecondsLeft > 0 &&
     (TimerService.pomodoroSecondsLeft < TimerService.pomodoroLapDuration || pRunning)
 
-    visible: hasStop || hasPomo
+    property bool shouldShow: hasStop || hasPomo
 
-    implicitWidth: visible ? (mainRow.implicitWidth + 20) : 0
+    visible: shouldShow
+
+    implicitWidth: shouldShow ? (mainRow.implicitWidth + 20) : 0
+    Behavior on implicitWidth {
+        NumberAnimation {
+            duration: 300
+            easing.type: Easing.OutQuart
+        }
+    }
     implicitHeight: Appearance.sizes.baseBarHeight
     Layout.preferredWidth: implicitWidth
+    Layout.alignment: Qt.AlignVCenter
 
     RowLayout {
         id: mainRow

--- a/dots/.config/quickshell/ii/modules/ii/bar/TimersTray.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/TimersTray.qml
@@ -1,0 +1,76 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick.Controls
+
+BarGroup {
+    id: root
+
+    readonly property bool pRunning: TimerService.pomodoroRunning ?? false
+    readonly property bool sRunning: TimerService.stopwatchRunning ?? false
+    readonly property bool hasStop: TimerService.stopwatchTime > 0
+    readonly property bool hasPomo: TimerService.pomodoroSecondsLeft > 0 &&
+    (TimerService.pomodoroSecondsLeft < TimerService.pomodoroLapDuration || pRunning)
+
+    visible: hasStop || hasPomo
+
+    implicitWidth: visible ? (mainRow.implicitWidth + 20) : 0
+    implicitHeight: Appearance.sizes.baseBarHeight
+    Layout.preferredWidth: implicitWidth
+
+    RowLayout {
+        id: mainRow
+        anchors.centerIn: parent
+        spacing: 15
+
+        // --- POMODORO SECTION ---
+        RowLayout {
+            visible: (root.pRunning && root.sRunning) || (!root.sRunning && root.hasPomo)
+            spacing: 5
+
+            MaterialSymbol {
+                text: "search_activity"
+                iconSize: Appearance.font.pixelSize.large
+                color: Appearance.colors.colOnLayer1
+                Layout.alignment: Qt.AlignVCenter
+            }
+            StyledText {
+                text: {
+                    const t = TimerService.pomodoroSecondsLeft
+                    return Math.floor(t/60).toString().padStart(2,'0') + ":" + (t%60).toString().padStart(2,'0')
+                }
+                color: Appearance.colors.colOnLayer1
+                font.pixelSize: Appearance.font.pixelSize.small
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+
+        // --- STOPWATCH SECTION ---
+        RowLayout {
+            visible: root.sRunning || (root.hasStop && !root.hasPomo)
+            spacing: 5
+
+            MaterialSymbol {
+                text: "timer"
+                iconSize: Appearance.font.pixelSize.large
+                color: Appearance.colors.colOnLayer1
+                Layout.alignment: Qt.AlignVCenter
+            }
+            StyledText {
+                text: {
+                    const t = TimerService.stopwatchTime
+                    const sec = Math.floor(t/100)
+                    return Math.floor(sec/60).toString().padStart(2,'0') + ":" +
+                    (sec%60).toString().padStart(2,'0') + "." +
+                    (t%100).toString().padStart(2,'0')
+                }
+                color: Appearance.colors.colOnLayer1
+                font.pixelSize: Appearance.font.pixelSize.small
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

A dynamic top bar widget that displays Pomodoro and Stopwatch states with real-time updates and dynamic resizing.

- If both are running: Shows both widgets side-by-side.
- If Stopwatch is running: Shows Stopwatch only (prioritized).
- If Pomodoro is active: Shows Pomodoro (unless Stopwatch is running).
- If Paused: Keeps the widget visible if either timer has stored time (> 0).
- If Idle: Widget collapses completely (width: 0).

<img width="271" height="39" alt="image" src="https://github.com/user-attachments/assets/9f213347-6b89-4f6d-8a73-7422e7a9bbb9" />

Solves #2750 
 
## Is it ready? Questions/feedback needed?

Seems so
