### PR TITLE
Fixed SearchWidget.qml to use proper implicitHeight calculation

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -17,7 +17,7 @@ Item { // Wrapper
     property string searchingText: LauncherSearch.query
     property bool showResults: searchingText != ""
     implicitWidth: searchWidgetContent.implicitWidth + Appearance.sizes.elevationMargin * 2
-    implicitHeight: searchBar.implicitHeight + searchBar.verticalPadding * 2 + Appearance.sizes.elevationMargin * 2
+    implicitHeight: searchWidgetContent.implicitHeight + searchBar.verticalPadding * 2 + Appearance.sizes.elevationMargin * 2
 
     function focusFirstItem() {
         appResults.currentIndex = 0;


### PR DESCRIPTION
## Describe your changes

The `SearchWidget.qml` has the wrong `implicitHeight` value. Instead of using `searchWidgetContent.implicitHeight` it uses `searchBar.implicitHeight`. This causes the search bar to ignore mouse clicks and only allows the user to launch apps by pressing Return (Enter). 

This issue isn't present if Overview is enabled, because it expands `columnLayout.implicitHeight`, then gets hidden if search isn't equal to "", allowing the mouse clicks to go through. So, to reproduce this issue, try turning off Overview and launching any app in search results by using mouse.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Yes, just a small fix

