### PR TITLE
FIX: Quick Settings keybinding hint

### DIFF
--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -141,7 +141,7 @@ ContentPage {
                                     key: "Ctrl"
                                 }
                                 KeyboardKey {
-                                    key: "󰖳"
+                                    key: Config.options.cheatsheet.superKey ?? "󰖳"
                                 }
                                 StyledText {
                                     Layout.alignment: Qt.AlignVCenter


### PR DESCRIPTION
## Describe your changes
Changes keybinding hint on the Quick Settings page to show user configured Super key instead of Windows one.

## Is it ready? Questions/feedback needed?
It's ready. 
Though one problem persists: when user changes keybinding in their config, settings will show the same "Ctrl+Super+T" combination.

Before:
<img width="273" height="60" alt="image" src="https://github.com/user-attachments/assets/5c1c4139-a54f-4e31-a1ab-640c75c4445e" />

After:
<img width="265" height="69" alt="image" src="https://github.com/user-attachments/assets/95a8af35-7e1f-40f9-b9cc-b363e88aa3d3" />

