### PR TITLE
Fix when wifi having space in between

### DIFF
--- a/dots/.config/quickshell/ii/services/Network.qml
+++ b/dots/.config/quickshell/ii/services/Network.qml
@@ -90,8 +90,9 @@ Singleton {
         changePasswordProc.exec({
             "environment": {
                 "PASSWORD": password
+                "SSID": network.ssid
             },
-            "command": ["bash", "-c", `nmcli connection modify ${network.ssid} wifi-sec.psk "$PASSWORD"`]
+            "command": ["bash", "-c", 'nmcli connection modify "$SSID" wifi-sec.psk "$PASSWORD"']
         })
     }
 


### PR DESCRIPTION
…modification

## Describe your changes
This change from qt variable to shell environment to prevent code execution like `;shutdown 0;` also adding a quote to SSID to prevent if wifi name have space in it.

## Is it ready? Questions/feedback needed?
Yes, this change is ready

