### PR TITLE
feat: parse sourced keybinds files in get_keybinds.py

### DIFF
--- a/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
+++ b/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
@@ -2,7 +2,6 @@
 import argparse
 import re
 import os
-from os.path import expandvars as os_expandvars
 from typing import Dict, List
 
 TITLE_REGEX = "#+!"
@@ -11,14 +10,9 @@ MOD_SEPARATORS = ['+', ' ']
 COMMENT_BIND_PATTERN = "#/#"
 
 parser = argparse.ArgumentParser(description='Hyprland keybind reader')
-parser.add_argument('--path', type=str, default="$HOME/.config/hypr/hyprland.conf", help='path to keybind file (sourcing isn\'t supported)')
+parser.add_argument('--path', type=str, default="$HOME/.config/hypr/hyprland.conf", help='path to keybind file')
 args = parser.parse_args()
-content_lines = []
-reading_line = 0
-
-# Little Parser made for hyprland keybindings conf file
-Variables: Dict[str, str] = {}
-
+path = os.path.expanduser(os.path.expandvars(args.path))
 
 class KeyBinding(dict):
     def __init__(self, mods, key, dispatcher, params, comment) -> None:
@@ -36,9 +30,9 @@ class Section(dict):
 
 
 def read_content(path: str) -> str:
-    if (not os.access(os.path.expanduser(os.path.expandvars(path)), os.R_OK)):
+    if (not os.access(path, os.R_OK)):
         return ("error")
-    with open(os.path.expanduser(os.path.expandvars(path)), "r") as file:
+    with open(path, "r") as file:
         return file.read()
 
 
@@ -136,9 +130,7 @@ def autogenerate_comment(dispatcher: str, params: str = "") -> str:
         case _:
             return ""
 
-def get_keybind_at_line(line_number, line_start = 0):
-    global content_lines
-    line = content_lines[line_number]
+def get_keybind_at_line(line, line_start = 0):
     _, keys = line.split("=", 1)
     keys, *comment = keys.split("#", 1)
 
@@ -169,12 +161,10 @@ def get_keybind_at_line(line_number, line_start = 0):
 
     return KeyBinding(mods, key, dispatcher, params, comment)
 
-def get_binds_recursive(current_content, scope):
-    global content_lines
-    global reading_line
+def get_binds_recursive(current_content, scope, content_lines, reading_line):
     # print("get_binds_recursive({0}, {1}) [@L{2}]".format(current_content, scope, reading_line + 1))
     while reading_line < len(content_lines): # TODO: Adjust condition
-        line = content_lines[reading_line]
+        line = content_lines[reading_line].lstrip()
         heading_search_result = re.search(TITLE_REGEX, line)
         # print("Read line {0}: {1}\tisHeading: {2}".format(reading_line + 1, content_lines[reading_line], "[{0}, {1}, {2}]".format(heading_search_result.start(), heading_search_result.start() == 0, ((heading_search_result != None) and (heading_search_result.start() == 0))) if heading_search_result != None else "No"))
         if ((heading_search_result != None) and (heading_search_result.start() == 0)): # Found title
@@ -182,41 +172,48 @@ def get_binds_recursive(current_content, scope):
             heading_scope = line.find('!')
             # Lower? Return
             if(heading_scope <= scope):
-                reading_line -= 1
-                return current_content
+                return current_content, reading_line - 1
 
             section_name = line[(heading_scope+1):].strip()
             # print("[[ Found h{0} at line {1} ]] {2}".format(heading_scope, reading_line+1, content_lines[reading_line]))
             reading_line += 1
-            current_content["children"].append(get_binds_recursive(Section([], [], section_name), heading_scope))
+            children_binds, reading_line = get_binds_recursive(Section([], [], section_name), heading_scope, content_lines, reading_line)
+            current_content["children"].append(children_binds)
 
         elif line.startswith(COMMENT_BIND_PATTERN):
-            keybind = get_keybind_at_line(reading_line, line_start=len(COMMENT_BIND_PATTERN))
+            keybind = get_keybind_at_line(line, line_start=len(COMMENT_BIND_PATTERN))
             if(keybind != None):
                 current_content["keybinds"].append(keybind)
 
-        elif line == "" or not line.lstrip().startswith("bind"): # Comment, ignore
-            pass
+        elif line.startswith("source"): # source file
+            _, filepath = line.split("=", 1)
+            filepath = filepath.split("#", 1)[0].strip()
+            if not filepath.startswith("/") and not filepath.startswith("~"):
+                filepath = os.path.join(os.path.dirname(path), filepath)
+            source_file_content_lines = read_content(filepath).splitlines()
+            if source_file_content_lines[0] != "error":
+                section_name = os.path.splitext(os.path.basename(filepath))[0].capitalize()
+                current_content["children"].append(get_binds_recursive(Section([], [], section_name), scope, source_file_content_lines, 0)[0])
 
-        else: # Normal keybind
-            keybind = get_keybind_at_line(reading_line)
+        elif line.startswith("bind"): # Normal keybind
+            keybind = get_keybind_at_line(line)
             if(keybind != None):
                 current_content["keybinds"].append(keybind)
 
         reading_line += 1
 
-    return current_content;
+    return current_content, reading_line
 
-def parse_keys(path: str) -> Dict[str, List[KeyBinding]]:
-    global content_lines
+def parse_keys() -> Dict[str, List[KeyBinding]] | str:
+    global path
     content_lines = read_content(path).splitlines()
     if content_lines[0] == "error":
         return "error"
-    return get_binds_recursive(Section([], [], ""), 0)
+    return get_binds_recursive(Section([], [], ""), 0, content_lines, 0)[0]
 
 
 if __name__ == "__main__":
     import json
 
-    ParsedKeys = parse_keys(args.path)
+    ParsedKeys = parse_keys()
     print(json.dumps(ParsedKeys))


### PR DESCRIPTION
## Describe your changes

I made the `get_keybinds.py` script parse the files sourced from the keybinds file. This way, we can keep our keybinds tidy in several files while having all of them shown on the cheatsheet.
I made it so that sourcing a file automatically creates a subsection, whose name is the basename of the sourced file.

## Is it ready? Questions/feedback needed?

I haven't added support for globbing for now, even though [hyprlang allows it](https://wiki.hypr.land/Configuring/Keywords/#sourcing-multi-file).