### PR TITLE
Fix: Wallpaper selector missing previews

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
@@ -73,7 +73,7 @@ MouseArea {
                             target: Wallpapers
                             function onThumbnailGenerated(directory) {
                                 if (thumbnailImage.status !== Image.Error) return;
-                                if (FileUtils.parentDirectory(thumbnailImage.sourcePath) !== directory) return;
+                                if (FileUtils.parentDirectory(thumbnailImage.sourcePath) !== FileUtils.trimFileProtocol(directory)) return;
                                 thumbnailImage.source = "";
                                 thumbnailImage.source = thumbnailImage.thumbnailPath;
                             }

--- a/dots/.config/quickshell/ii/scripts/thumbnails/thumbgen-venv.sh
+++ b/dots/.config/quickshell/ii/scripts/thumbnails/thumbgen-venv.sh
@@ -3,5 +3,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source $(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate
 GIO_USE_VFS=local "$SCRIPT_DIR/thumbgen.py" "$@"
+THUMBGEN_EXIT_CODE=$?
 deactivate
 
+exit $THUMBGEN_EXIT_CODE


### PR DESCRIPTION
## Describe your changes
Fixes issue where thumbnails in the Wallpaper Selector would fail to generate/load.
Should fix/help to fix issue #1902 

- WallpaperDirectoryItem.qml:
  - Issue:
  directory would have "file://" prepended to the path. 
  - Fix:
  trimmed the file protocol.
- thumbgen-venv.sh:
  - Issue:
  `deactivate` would always result in `thumbgen-venv.sh` having a status code of 0, preventing Wallpapers.qml generateThumbnail command to never fallback on `generate-thumbnails-magick.sh`
  - Fix:
  Stored the exit code of `thumbgen.py` and exited `thumbgen-venv.sh` with that code. Allowing the shell to see that exit code for the python script.


## Is it ready? Questions/feedback needed?
✅ Ready for review. Tested locally for the `generate-thumbnails-magick.sh` fallback since `thumbgen.py` does not work for me (missing GnomeDesktop exception)

