### PR TITLE
Feature(Settings): Terminal Background tone

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -130,6 +130,7 @@ Singleton {
                         property real harmony: 0.6
                         property real harmonizeThreshold: 100
                         property real termFgBoost: 0.35
+                        property real termBgTone: 0.4
                         property bool forceDarkMode: false
                     }
                 }

--- a/dots/.config/quickshell/ii/modules/settings/AdvancedConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/AdvancedConfig.qml
@@ -88,6 +88,17 @@ ContentPage {
                 Config.options.appearance.wallpaperTheming.terminalGenerationProps.termFgBoost = value / 100;
             }
         }
+        ConfigSpinBox {
+            icon: "contrast"
+            text: Translation.tr("Terminal: Background tone (%)")
+            value: Config.options.appearance.wallpaperTheming.terminalGenerationProps.termBgTone * 100
+            from: 0
+            to: 100
+            stepSize: 5
+            onValueChanged: {
+                Config.options.appearance.wallpaperTheming.terminalGenerationProps.termBgTone = value / 100;
+            }
+        }
     }
 
 

--- a/dots/.config/quickshell/ii/scripts/colors/generate_colors_material.py
+++ b/dots/.config/quickshell/ii/scripts/colors/generate_colors_material.py
@@ -22,6 +22,7 @@ parser.add_argument('--termscheme', type=str, default=None, help='JSON file cont
 parser.add_argument('--harmony', type=float , default=0.8, help='(0-1) Color hue shift towards accent')
 parser.add_argument('--harmonize_threshold', type=float , default=100, help='(0-180) Max threshold angle to limit color hue shift')
 parser.add_argument('--term_fg_boost', type=float , default=0.35, help='Make terminal foreground more different from the background')
+parser.add_argument('--term_bg_tone', type=float , default=0.4, help='(0-1) Terminal background darkness/tone (lower = darker)')
 parser.add_argument('--blend_bg_fg', action='store_true', default=False, help='Shift terminal background or foreground towards accent')
 parser.add_argument('--cache', type=str, default=None, help='file path to store the generated color')
 parser.add_argument('--debug', action='store_true', default=False, help='debug mode')
@@ -143,7 +144,7 @@ if args.termscheme is not None:
             term_colors[color] = val
             continue
         if args.blend_bg_fg and color == "term0":
-            harmonized = boost_chroma_tone(hex_to_argb(material_colors['surfaceContainerLow']), 1.2, 0.95)
+            harmonized = boost_chroma_tone(hex_to_argb(material_colors['surfaceContainerLow']), 1.2, args.term_bg_tone)
         elif args.blend_bg_fg and color == "term15":
             harmonized = boost_chroma_tone(hex_to_argb(material_colors['onSurface']), 3, 1)
         else:

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -290,9 +290,11 @@ switch() {
         harmony=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.harmony' "$SHELL_CONFIG_FILE")
         harmonize_threshold=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.harmonizeThreshold' "$SHELL_CONFIG_FILE")
         term_fg_boost=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.termFgBoost' "$SHELL_CONFIG_FILE")
+        term_bg_tone=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.termBgTone' "$SHELL_CONFIG_FILE")
         [[ "$harmony" != "null" && -n "$harmony" ]] && generate_colors_material_args+=(--harmony "$harmony")
         [[ "$harmonize_threshold" != "null" && -n "$harmonize_threshold" ]] && generate_colors_material_args+=(--harmonize_threshold "$harmonize_threshold")
         [[ "$term_fg_boost" != "null" && -n "$term_fg_boost" ]] && generate_colors_material_args+=(--term_fg_boost "$term_fg_boost")
+        [[ "$term_bg_tone" != "null" && -n "$term_bg_tone" ]] && generate_colors_material_args+=(--term_bg_tone "$term_bg_tone")
     fi
 
     matugen "${matugen_args[@]}"


### PR DESCRIPTION
## Describe your changes

Simply add an option to manage the terminal background color from the settings, since I think the hardcoded `0.95` value is awful


https://github.com/user-attachments/assets/637db569-cfab-4f0a-aab6-e194acd6a560



## Is it ready? Questions/feedback needed?


