### PR TITLE
sdata: deps-info: fix typo :3

### DIFF
--- a/sdata/deps-info.md
+++ b/sdata/deps-info.md
@@ -94,7 +94,7 @@ Tips:
   - Font name: `Rubik`, `Rubik Light`
   - Used in Hyprland, kdeglobals, matugen, qt5ct, qt6ct and Quickshell config.
 - `ttf-twemoji`
-  - Not explicitly used, but it may help as fallback for displaying emoji charaters.
+  - Not explicitly used, but it may help as fallback for displaying emoji characters.
 
 ## illogical-impulse-hyprland
 - `hyprland`


### PR DESCRIPTION
## Describe your changes

Fixed the typo on sdata/deps-info.md
<img width="669" height="54" alt="resim" src="https://github.com/user-attachments/assets/2b98ebd0-9b55-4cf2-8dbb-a2640faaebf9" />

## Is it ready? Questions/feedback needed?

Nothing needed. Ready-to-use.
