### PR TITLE
Fix Fedora installation for Hyperland v0.53.1 in Fedora 43

### DIFF
--- a/sdata/dist-fedora/feddeps.toml
+++ b/sdata/dist-fedora/feddeps.toml
@@ -1,5 +1,5 @@
 # COPR repositories list
-# "solopasha/hyprland" is not up to date to the current Hyprland version, replaced with the fork "sdegler/hyprland",
+# "solopasha/hyprland" is not up to date to the current Hyprland version, replaced with the fork "sdegler/hyprland"
 [copr]
 repos = [
   "ririko66z/dots-hyprland",


### PR DESCRIPTION
## Describe your changes

- "solopasha/hyprland" is not up to date to the current Hyprland version. This can be a temporary state, but currently it is making the auto install partially fail and when acessing Hyprland post install, it will have 500+ erros due to wrong syntax in window rules or something like that (must admit I don't fully understand it)
To solve that, I have replace the repo with a fork "sdegler/hyprland". This one is compiled with the latest Hyperland (currently v0.53.1)

- Replaced package "hyprland-qtutils" with "hyprland-guiutils". According to the hyperland repositories, qtutils is archived and guiutils is the sucessor.
https://github.com/hyprwm/hyprland-qtutils
https://github.com/hyprwm/hyprland-guiutils


## Is it ready? Questions/feedback needed?
It's ready. Tested in Fedora Workstation 43 and Fedora KDE Plasma 43.
I'm unsure about the "sdegler/hyprland" repo for long term because I don't know much about it. It's likely solapasha will eventually catch up to Hyperland so this can be just a temporary change.