### PR TITLE
Fix on uninstall script (Fix #2886)

### DIFF
--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -45,7 +45,12 @@ function delete_targets(){
       printf "${STY_YELLOW}Target \"$path\" inexists, skipping...${STY_RST}\n"
       continue
     elif [[ "$path" == "$HOME"* ]]; then
-      x rm -- "$path"
+      if [[ -d "$path" ]]; then
+		x rm -r -- "$path"
+	else
+		x rm -- "$path"
+	fi
+
     else
       while true; do
         printf "WARNING: Target \"$path\" is not under \$HOME. Still delete it?\ny=Yes, delete it;\nn=No, skip this one\n"
@@ -53,7 +58,11 @@ function delete_targets(){
         echo
         case "$ans" in
           y|Y)
-            x rm -- "$path"
+	    if [[ -d "$path" ]]; then
+		    x rm -r -- "$path"
+	    else
+		    x rm -- "$path"
+	    fi
             break 1
             ;;
           n|N)


### PR DESCRIPTION
## Describe your changes

Added a -fr flag on sdata/subcmd-uninstall/0.run.sh to be able to remove  /home/testing/.local/share/fonts/illogical-impulse-google-sans-flex".


## Is it ready? Questions/feedback needed?
It's ready and tested

