### PR TITLE
Feature migrate update script into XDG standards (close #2889)

### DIFF
--- a/sdata/subcmd-exp-update/0.run.sh
+++ b/sdata/subcmd-exp-update/0.run.sh
@@ -45,7 +45,9 @@ if which pacman &>/dev/null; then
   fi
 fi
 UPDATE_IGNORE_FILE="${REPO_ROOT}/.updateignore"
-HOME_UPDATE_IGNORE_FILE="${HOME}/.updateignore"
+XDG_UPDATE_IGNORE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/illogical-impulse/updateignore"
+#TODO: remove in future and add script to migrate to XDG path
+HOME_UPDATE_IGNORE_FILE="${HOME}/.updateignore" # Legacy support 
 
 # Global arrays for cached ignore patterns (performance optimization)
 declare -a IGNORE_PATTERNS=()
@@ -156,7 +158,7 @@ load_ignore_patterns() {
   IGNORE_PATTERNS=()
   IGNORE_SUBSTRING_PATTERNS=()
   
-  for ignore_file in "$UPDATE_IGNORE_FILE" "$HOME_UPDATE_IGNORE_FILE"; do
+  for ignore_file in "$UPDATE_IGNORE_FILE" "$XDG_UPDATE_IGNORE_FILE" "$HOME_UPDATE_IGNORE_FILE"; do
     [[ ! -f "$ignore_file" ]] && continue
     
     while IFS= read -r pattern || [[ -n "$pattern" ]]; do
@@ -450,10 +452,10 @@ handle_file_conflict() {
       i)
         local relative_path_to_home="${home_file#$HOME/}"
         if [[ "$DRY_RUN" == true ]]; then
-          log_info "[DRY-RUN] Would add '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE"
+          log_info "[DRY-RUN] Would add '$relative_path_to_home' to $XDG_UPDATE_IGNORE_FILE"
         else
-          echo "$relative_path_to_home" >>"$HOME_UPDATE_IGNORE_FILE"
-          log_success "Added '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE and skipped."
+          echo "$relative_path_to_home" >>"$XDG_UPDATE_IGNORE_FILE"
+          log_success "Added '$relative_path_to_home' to $XDG_UPDATE_IGNORE_FILE and skipped."
         fi
         break
         ;;
@@ -478,10 +480,10 @@ handle_file_conflict() {
     7)
       local relative_path_to_home="${home_file#$HOME/}"
       if [[ "$DRY_RUN" == true ]]; then
-        log_info "[DRY-RUN] Would add '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE"
+        log_info "[DRY-RUN] Would add '$relative_path_to_home' to $XDG_UPDATE_IGNORE_FILE"
       else
-        echo "$relative_path_to_home" >>"$HOME_UPDATE_IGNORE_FILE"
-        log_success "Added '$relative_path_to_home' to $HOME_UPDATE_IGNORE_FILE and skipped."
+        echo "$relative_path_to_home" >>"$XDG_UPDATE_IGNORE_FILE"
+        log_success "Added '$relative_path_to_home' to $XDG_UPDATE_IGNORE_FILE and skipped."
       fi
       break
       ;;
@@ -1158,11 +1160,11 @@ if [[ "$process_files" == true ]]; then
   echo "- New files created: $files_created"
 fi
 
-if [[ ! -f "$HOME_UPDATE_IGNORE_FILE" && ! -f "$UPDATE_IGNORE_FILE" ]]; then
+if [[ ! -f "$XDG_UPDATE_IGNORE_FILE" && ! -f "$UPDATE_IGNORE_FILE" ]]; then
   echo
   log_info "Tip: Create ignore files to exclude files from updates:"
   echo "  - Repository ignore: ${REPO_ROOT}/.updateignore"
-  echo "  - User ignore: ~/.updateignore"
+  echo "  - User ignore: ${XDG_UPDATE_IGNORE_FILE}"
   echo
   echo "Example patterns:"
   echo "  *.log                 # Ignore all .log files"

--- a/sdata/subcmd-exp-update/exp-update-tester.sh
+++ b/sdata/subcmd-exp-update/exp-update-tester.sh
@@ -469,7 +469,7 @@ test_shellcheck() {
     return 0
   fi
   
-  if shellcheck -e SC1090,SC1091,SC2148,SC2034,SC2155,SC2164 setup then
+  if shellcheck -e SC1090,SC1091,SC2148,SC2034,SC2155,SC2164 setup; then
     log_pass "shellcheck passed"
     return 0
   else


### PR DESCRIPTION
## Describe your changes
this pr add the feature included in the issue #2889
ii have chnged the updateignore home from the user home to the XDG_CONFIG_HOME path to align with xdg  standards
- update path  for updateignore
- fixed typo in the test script
- kept legacy support for old path for ppl who want to keep it in the home dir
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

i think it is ready i have tested using the test script 
=== Updating Script Permissions ===
[INFO] [DRY-RUN] Would update script permissions in ~/.local/bin

=== Update Complete ===
[WARNING] DRY-RUN MODE: No changes were actually made
[INFO] Run without -n/--dry-run to apply changes

Summary:
- Repository: 88a9b76 - Add test config (3 seconds ago)
- Branch: master
- Structure: dots/.config dots/.local/share
- Mode: Normal
- Package checking: Disabled
- Files processed: 947
- Files updated/conflicted: 21
- New files created: 4

[PASS] Dry-run mode detected in output
[PASS] No files created in home during dry-run
✓ test_dry_run passed

[TEST] Testing command-line flags
[TEST]   ✓ -h recognized
[TEST]   ✓ --help recognized
[PASS] Help flags recognized correctly
✓ test_flags passed

[TEST] Running shellcheck (if available)
[TEST] shellcheck not found, skipping static analysis
✓ test_shellcheck passed

[TEST] Testing lock file mechanism
[PASS] Lock file mechanism works (detected stale lock)
✓ test_lock_file passed

[TEST] Testing directory creation caching
[PASS] Directory creation caching works
✓ test_directory_caching passed

[TEST] Testing safe_read in non-interactive mode
[PASS] Enhanced safe_read handles non-interactive mode correctly
✓ test_safe_read_noninteractive passed

================================
  Test Summary
================================
Passed: 14
Failed: 0
Total:  14

All tests passed! 🎉

Cleaning up test files...
