### PR TITLE
Custom time for pomodoro timer

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
@@ -32,15 +32,38 @@ Item {
                 anchors.centerIn: parent
                 spacing: 0
 
-                StyledText {
+                Item {
                     Layout.alignment: Qt.AlignHCenter
-                    text: {
-                        let minutes = Math.floor(TimerService.pomodoroSecondsLeft / 60).toString().padStart(2, '0');
-                        let seconds = Math.floor(TimerService.pomodoroSecondsLeft % 60).toString().padStart(2, '0');
-                        return `${minutes}:${seconds}`;
+                    implicitWidth: timeText.implicitWidth
+                    implicitHeight: timeText.implicitHeight
+
+                    StyledText {
+                        id: timeText
+                        anchors.centerIn: parent
+                        text: {
+                            let minutes = Math.floor(TimerService.pomodoroSecondsLeft / 60).toString().padStart(2, '0');
+                            let seconds = Math.floor(TimerService.pomodoroSecondsLeft % 60).toString().padStart(2, '0');
+                            return `${minutes}:${seconds}`;
+                        }
+                        font.pixelSize: 40
+                        color: Appearance.m3colors.m3onSurface
                     }
-                    font.pixelSize: 40
-                    color: Appearance.m3colors.m3onSurface
+
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.MiddleButton
+                        onClicked: (mouse) => {
+                            if (mouse.button === Qt.MiddleButton) {
+                                if (mouse.modifiers & Qt.ShiftModifier) {
+                                    // Shift + middle click: decrement by 10 minutes
+                                    TimerService.adjustPomodoroTime(-600);
+                                } else {
+                                    // Middle click: increment by 10 minutes
+                                    TimerService.adjustPomodoroTime(600);
+                                }
+                            }
+                        }
+                    }
                 }
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
@@ -79,7 +102,7 @@ Item {
                 contentItem: StyledText {
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
-                    text: TimerService.pomodoroRunning ? Translation.tr("Pause") : (TimerService.pomodoroSecondsLeft === TimerService.focusTime) ? Translation.tr("Start") : Translation.tr("Resume")
+                    text: TimerService.pomodoroRunning ? Translation.tr("Pause") : (TimerService.pomodoroSecondsLeft === TimerService.pomodoroLapDuration) ? Translation.tr("Start") : Translation.tr("Resume")
                     color: TimerService.pomodoroRunning ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnPrimary
                 }
                 implicitHeight: 35


### PR DESCRIPTION
## Describe your changes

Currently, the Pomodoro timer is locked at 25 minutes (as per [definition of a pomodoro timer](https://en.wikipedia.org/wiki/Pomodoro_Technique#:~:text=typically%2025%20minutes%20in%20length)). However, I would love to have a custom timer that is still a bit rigid to preserve the principle. This commit introduces additional functionality to modify the timer in 10 minutes changes. 
Middle-Mouse-click the Timer text area for incrementing 10 minutes.
Shift+Middle-Mouse-click  the Timer text area for decrementing 10 minutes.

## Is it ready? Questions/feedback needed?
It is ready. But the exact interaction can be up for discussion. I would love to hear back how you would perhaps implement this. Waybar uses the mouse wheel to do the increment/decrement on a minute-wise basis. Would love to hear what would be ideal. I understand this is also quite a cosmetic change, so I don't want to burden the contributors with this minor feature. Thanks.

