### PR TITLE
fix(LauncherSearch): don't concatenate command in a single string

### DIFF
--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -250,7 +250,7 @@ Singleton {
                     if (!entry.runInTerminal)
                         entry.execute();
                     else {
-                        Quickshell.execDetached([Config.options.apps.terminal, "-e", ...entry.command]);
+                        Quickshell.execDetached([...Config.options.apps.terminal.trim().split(/\s+/), "-e", ...entry.command]);
                     }
                 },
                 comment: entry.comment,
@@ -266,7 +266,7 @@ Singleton {
                             if (!action.runInTerminal)
                                 action.execute();
                             else {
-                                Quickshell.execDetached([Config.options.apps.terminal, "-e", ...action.command]);
+                                Quickshell.execDetached([...Config.options.apps.terminal.trim().split(/\s+/), "-e", ...action.command]);
                             }
                         }
                     });


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->
See #2816.
 [Here in LauncherSearch.qml](https://github.com/end-4/dots-hyprland/blob/20ec7717a4c67bcc074dec0cd28638f4f22516f0/dots/.config/quickshell/ii/services/LauncherSearch.qml#L254), a shell is spawned for seemingly no reason and is asked to execute the terminal emulator which in turn is asked to execute a command, but the command is concatenated in a single string; but terminals (or at least some of them) expect the command they should execute not to be concatenated in a space-separated string, but to be splitted across different arguments instead, preventing any `.desktop` file whose `Exec` contains several words (e.g. a command with a flag) and which runs in the terminal (for other apps it's fine) from running correctly.

## Is it ready? Questions/feedback needed?
Currently there are still issues I'm running into: the main one being that single quotes are removed from `entry.command`. For instance, with a desktop file containing the following:
```desktop
Exec=nvim -c "lua require('notmuch.send').compose(string.sub( %u, 8, -1))"
```
If I add a logging statement in `LauncherSearch.qml`:
```qml
console.log(JSON.stringify(entry.command))
```
then I get the following in my logs:
```
DEBUG qml: ["nvim","-c","lua require(notmuch.send).compose(string.sub( %u, 8, -1))"]
```
Single quotes are nowhere to be found, and the command fails to execute as expected (despite working fine with e.g. fuzzel).
That's another issue that needs to be fixed, but which is not directly related to this PR.