### PR TITLE
fix: improve media player deduplication and sorting logic

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/MediaControls.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/MediaControls.qml
@@ -72,7 +72,7 @@ Scope {
                  // Round to 10s to catch lagging instances
                  let d = Math.round(p.length / 10);
                  let pos = Math.round(p.position / 10);
-                 key = "empty:" + d + "|" + pos;
+                 key = "empty:" + clean(p.identity) + "|" + d + "|" + pos;
              }
              
              // Since 'active' (playing) is first in list, it claims the key first.


### PR DESCRIPTION
This PR improves how media players are processed to prevent duplicates and ensure the active player is correctly prioritized.

### Changes
- **Refactor**: Renamed and rewritten `filterDuplicatePlayers` to `processPlayers` for clarity and better logic.
- **Active Player Priority**: The `activePlayer` is now explicitly added to the distinct list first. This ensures the player currently being controlled is never filtered out by the deduplication logic.
- **Smart Deduplication**:
  - Players with valid metadata are now deduplicated based on a normalized `Title + Artist` key.
  - Players without metadata (ghost players) are deduplicated by grouping them based on approximate duration and position (rounded to 10s intervals).

This fixes issues where duplicate entries would appear for the same media source or where the active player might be hidden by a background instance.