### PR TITLE
feat: add regex patterns for CS2 (wayland) and Hytale

### DIFF
--- a/dots/.config/quickshell/ii/services/AppSearch.qml
+++ b/dots/.config/quickshell/ii/services/AppSearch.qml
@@ -27,6 +27,14 @@ Singleton {
             "replace": "steam_icon_$1"
         },
         {
+            "regex": /cs2/,
+            "replace": "steam_icon_730"
+        },
+        {
+            "regex": /HytaleClient/,
+            "replace": "com.hypixel.HytaleLauncher.png"
+        },
+        {
             "regex": /Minecraft.*/,
             "replace": "minecraft"
         },


### PR DESCRIPTION
## Describe your changes

Properly handle Counter Strike running directly under wayland and the Hytale Client not having an icon from another program.

Also yes, the game still uses the CS:GO icon for some reason.

| Before | After |
|:-|:-|
|<img width="495" height="300" alt="image" src="https://github.com/user-attachments/assets/360013a6-ef00-415f-b024-bd10b2d984d8" />|<img width="487" height="290" alt="image" src="https://github.com/user-attachments/assets/e6cd7c8e-599d-4e47-93fc-260c3143444a" />|
|<img width="497" height="289" alt="image" src="https://github.com/user-attachments/assets/39c3ae14-1c3a-49e4-9b19-f9b85fa0d93d" />|<img width="494" height="271" alt="image" src="https://github.com/user-attachments/assets/890864b9-e51e-4fde-84cf-4261293ea49b" />|

## Is it ready? Questions/feedback needed?

Seems ready to me.
