### PR TITLE
fix: cross typos, see details below.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./cache,./diagnose.result,./LICENSE,./licenses,./dots/.config/quickshell/ii/modules/common/widgets/shapes
+ignore-words-list = ags,AGS,ans,rime

--- a/sdata/dist-arch/illogical-impulse-hyprland/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-hyprland/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=illogical-impulse-hyprland
 pkgver=1.0
 pkgrel=4
-pkgdesc='Illogical Impulse Hyprland relatated packages'
+pkgdesc='Illogical Impulse Hyprland related packages'
 arch=(any)
 license=(None)
 depends=(

--- a/sdata/dist-nix/README.md
+++ b/sdata/dist-nix/README.md
@@ -105,6 +105,6 @@ Find out a good method to avoid what @end-4 [mentioned](https://github.com/end-4
 
 Some information may help, e.g. @darsh032 [commented](https://github.com/end-4/dots-hyprland/issues/1061#issuecomment-3336839862):
 
-> I mean thats not really needed you can use mkOutOfStoreSymlink or use hjem-impure to change the configs without rebuilding
+> I mean that's not really needed you can use mkOutOfStoreSymlink or use hjem-impure to change the configs without rebuilding
 
-And also the "hmrice" [mentioned](https://github.com/end-4/dots-hyprland/issues/1061#issuecomment-3353345504) by @Markus328 , and the `flake.nix` (for quickshell only) [mentioned](https://github.com/end-4/dots-hyprland/issues/1061#issuecomment-3354387126) by @darsh032 .
+And also the "hmrice" [mentioned](https://github.com/end-4/dots-hyprland/issues/1061#issuecomment-3354725029) by @Markus328 , and the `flake.nix` (for quickshell only) [mentioned](https://github.com/end-4/dots-hyprland/issues/1061#issuecomment-3354387126) by @darsh032 .

--- a/sdata/subcmd-exp-merge/0.run.sh
+++ b/sdata/subcmd-exp-merge/0.run.sh
@@ -102,7 +102,7 @@ copy_and_commit_user_config() {
     return
   fi
 
-  # chekc for rebase in progress
+  # check for rebase in progress
   if git status | grep -q "rebase in progress"; then
     log_error "Rebase already in progress, resolve it first"
     return 1

--- a/sdata/subcmd-install/3.files-exp.sh
+++ b/sdata/subcmd-install/3.files-exp.sh
@@ -7,7 +7,7 @@
 # TODO: Properly handle hyprland config, ~/.config/hypr/hyprland.conf should be overwritten only when firstrun
 # TODO: add --exp-files-path <path>   Use <path> instead of the default yaml config
 # TODO: add --exp-files-regen         Force copy the default config to ${EXP_FILE_PATH} (auto do this when not existed)
-# TODO: Implement versioning, i.e. when user-defined yaml config file has version number mismatch with the default one, produce error. If only minor version number is not the same, the error can be ommitted via --exp-file-no-strict .
+# TODO: Implement versioning, i.e. when user-defined yaml config file has version number mismatch with the default one, produce error. If only minor version number is not the same, the error can be omitted via --exp-file-no-strict .
 # TODO: add --exp-files-no-strict     Ignore error when minor version number is not the same
 # TODO: When --via-nix is specified, use dots-extra/vianix/hypridle.conf instead
 #

--- a/sdata/subcmd-install/3.files-exp.yaml
+++ b/sdata/subcmd-install/3.files-exp.yaml
@@ -2,8 +2,8 @@
 # - `sync`: Make the destination completely the same as the source.
 # - `soft`: Skip existing files when copying
 # - `hard`: Overwrite existing files when copying
-# - `soft-backup`: If target file exists, copy source file to `*.new`. Do not create `*.new` but skip coyping when source and target HASH values are exactly the same.
-# - `hard-backup`: If target file exists, create backup by renaming it to `*.old.<n>` where `<n>` is a number increment from 1 to prevent backup gets overwritten when running twice. (Keep in mind that this script must be idempotent.) Also must compare the actual file content by using MD5 HASH value to prevent generating lots of `*.old.<n>`s when runnng multiple times. Do not create backup but skip coyping when source and target HASH values are exactly the same.
+# - `soft-backup`: If target file exists, copy source file to `*.new`. Do not create `*.new` but skip copying when source and target HASH values are exactly the same.
+# - `hard-backup`: If target file exists, create backup by renaming it to `*.old.<n>` where `<n>` is a number increment from 1 to prevent backup gets overwritten when running twice. (Keep in mind that this script must be idempotent.) Also must compare the actual file content by using MD5 HASH value to prevent generating lots of `*.old.<n>`s when running multiple times. Do not create backup but skip copying when source and target HASH values are exactly the same.
 # - `skip`: Skip this step
 # - `skip-if-exists`: Skip this step if target exists
 version: "1.0"
@@ -42,7 +42,7 @@ patterns:
     condition:
       type: "terminal"
       value: "kitty"
-  # Hyprland    
+  # Hyprland
   - from: "dots/.config/hypr"
     to: "$XDG_CONFIG_HOME/hypr"
     mode: "sync"

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -85,7 +85,7 @@ function deletion_prompt(){
     echo
     case "$choice" in
       q|Q)
-        printf "Quiting...\n"
+        printf "Quitting...\n"
         break
         ;;
       y|Y)
@@ -137,7 +137,7 @@ printf "${STY_CYAN}Undo install step 1...\n${STY_RST}"
 if test -f sdata/dist-$OS_GROUP_ID/uninstall-deps.sh; then
   source sdata/dist-$OS_GROUP_ID/uninstall-deps.sh
 else
-  printf "${STY_YELLOW}Automatic depedencies uninstallation is not yet avaible for your distro. Skipping...${STY_RST}\n"
+  printf "${STY_YELLOW}Automatic dependencies uninstallation is not yet available for your distro. Skipping...${STY_RST}\n"
 fi
 
 printf "${STY_CYAN}Uninstall script finished.\n${STY_RST}"


### PR DESCRIPTION
Repository rules / “do not edit” findings
Submodule present at dots/.config/quickshell/ii/modules/common/widgets/shapes (from .gitmodules). I treated this as third-party and excluded it from typo editing and from future codespell scans. .gitignore mainly ignores runtime artifacts (cache/, diagnose.result, etc.). No extra “don’t touch X” rules beyond that. Typos fixed (safe edits)
sdata/subcmd-exp-merge/0.run.sh
chekc -> check
sdata/subcmd-install/3.files-exp.sh
ommitted -> omitted
sdata/subcmd-install/3.files-exp.yaml
coyping -> copying (2 occurrences)
runnng -> running
sdata/subcmd-uninstall/0.run.sh
Quiting -> Quitting
depedencies -> dependencies
avaible -> available
sdata/dist-nix/README.md
thats -> that's
sdata/dist-arch/illogical-impulse-hyprland/PKGBUILD relatated -> related
Words NOT changed (handled via codespell ignore)
These appeared as codespell “typos” but are clearly intentional in this repo context:

AGS / ags: the “Aylur’s Gtk Shell” project name
rime: Rime input method name
ans: variable name used for prompt input in subcmd-uninstall Added .codespellrc (future-proofing)
Created: /.codespellrc with:

skip: .git, cache, diagnose.result, LICENSE, licenses/, and the submodule path
ignore-words-list: ags,AGS,ans,rime

## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?


