### PR TITLE
Allow centering widgets in overlay using right-click

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overlay/OverlayContext.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overlay/OverlayContext.qml
@@ -5,6 +5,8 @@ import Quickshell
 Singleton {
     id: root
     
+    signal requestCenter(string identifier)
+
     readonly property list<var> availableWidgets: [
         { identifier: "crosshair", materialSymbol: "point_scan" },
         { identifier: "fpsLimiter", materialSymbol: "animation" },

--- a/dots/.config/quickshell/ii/modules/ii/overlay/OverlayTaskbar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overlay/OverlayTaskbar.qml
@@ -119,6 +119,7 @@ Rectangle {
         Layout.alignment: Qt.AlignVCenter
 
         toggled: Persistent.states.overlay.open.includes(identifier)
+        altAction: () => OverlayContext.requestCenter(identifier)
         onClicked: {
             if (widgetButton.toggled) {
                 Persistent.states.overlay.open = Persistent.states.overlay.open.filter(type => type !== identifier);

--- a/dots/.config/quickshell/ii/modules/ii/overlay/StyledOverlayWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overlay/StyledOverlayWidget.qml
@@ -105,6 +105,15 @@ AbstractOverlayWidget {
         reportClickableState();
     }
 
+    Connections {
+        target: OverlayContext
+        function onRequestCenter(identifier) {
+            if (identifier === root.identifier) {
+                root.center()
+            }
+        }
+    }
+
     // Hooks
     onPressed: (event) => {
         // We're only interested in handling resize here


### PR DESCRIPTION
## Describe your changes

the issue of widgets getting off-screen due to resolution changes (due to using external monitor etc.). added a function to centered em by right clicking their taskbar icons

## Is it ready? Questions/feedback needed?

yes

## demo gif

![ezgif-7f859a1d3fc44d94](https://github.com/user-attachments/assets/44869c6a-3c64-43be-a179-fc35eda5b349)

