### PR TITLE
feat(screenshot): add option to auto-open annotation tool on copy

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -449,6 +449,7 @@ Singleton {
                 }
                 property JsonObject annotation: JsonObject {
                     property bool useSatty: false
+                    property bool autoOpenTool: true
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/common/utils/ScreenshotAction.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/ScreenshotAction.qml
@@ -44,8 +44,11 @@ Singleton {
         switch (action) {
             case ScreenshotAction.Action.Copy:
                 if (saveDir === "") {
-                    // not saving the screenshot, just copy to clipboard
-                    return ["bash", "-c", `${cropToStdout} | wl-copy && ${cleanup}`]
+                    // copy to clipboard and open in swappy
+                    const cmd = Config.options.regionSelector.annotation.autoOpenTool
+                        ? `${cropToStdout} | tee >(wl-copy) | ${annotationCommand}`
+                        : `${cropToStdout} | wl-copy`;
+                    return ["bash", "-c", `${cmd} && ${cleanup}`]
                     break;
                 }
                 return [

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -435,6 +435,19 @@ ContentPage {
                 }
             }
         }
+
+        ContentSubsection {
+            title: Translation.tr("Annotation")
+            
+            ConfigSwitch {
+                buttonIcon: "edit"
+                text: Translation.tr("Open annotation tool after copy")
+                checked: Config.options.regionSelector.annotation.autoOpenTool
+                onCheckedChanged: {
+                    Config.options.regionSelector.annotation.autoOpenTool = checked;
+                }
+            }
+        }
     }
 
     ContentSection {

--- a/dots/.config/quickshell/ii/translations/de_DE.json
+++ b/dots/.config/quickshell/ii/translations/de_DE.json
@@ -604,5 +604,7 @@
   "Recognize music": "Musik erkennen",
   "Stroke width": "Strichstärke",
   "Use varying shapes for password characters": "Verschiedene Formen für Passwort-Zeichen verwenden",
-  "Battery full": "Batterie voll"
+  "Battery full": "Batterie voll",
+  "Annotation": "Anmerkung",
+  "Open annotation tool after copy": "Anmerkungswerkzeug nach Kopieren öffnen"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -13,6 +13,8 @@
   "Attach a file. Only works with Gemini.": "Attach a file. Only works with Gemini.",
   "Reboot": "Reboot",
   "API key:\n\n```txt\n%1\n```": "API key:\n\n```txt\n%1\n```",
+  "Annotation": "Annotation",
+  "Open annotation tool after copy": "Open annotation tool after copy",
   "Pinned on startup": "Pinned on startup",
   "Right": "Right",
   "Reboot to firmware settings": "Reboot to firmware settings",

--- a/dots/.config/quickshell/ii/translations/he_HE.json
+++ b/dots/.config/quickshell/ii/translations/he_HE.json
@@ -385,7 +385,7 @@
   "Connected": "מחובר",
   "Hit \"/\" to search": "לחץ \"/\" לחיפוש",
   "Wallpaper & Colors": "רקע וצבעים",
-  "Change any time later with /dark, /light, /wallpaper in the launcher\nIf the shell's colors aren't changing:\n    1. Open the right sidebar with Super+N\n    2. Click \"Reload Hyprland & Quickshell\" in the top-right corner":   "ניתן לשנות בכל עת עם /dark, /light, /wallpaper במפעיל\nאם צבעי ה-shell לא משתנים:\n    1. פתח את הסרגל הצדדי הימני עם Super+N\n    2. לחץ על \"טען מחדש Hyprland & Quickshell\" בפינה הימנית העליונה",
+  "Change any time later with /dark, /light, /wallpaper in the launcher\nIf the shell's colors aren't changing:\n    1. Open the right sidebar with Super+N\n    2. Click \"Reload Hyprland & Quickshell\" in the top-right corner": "ניתן לשנות בכל עת עם /dark, /light, /wallpaper במפעיל\nאם צבעי ה-shell לא משתנים:\n    1. פתח את הסרגל הצדדי הימני עם Super+N\n    2. לחץ על \"טען מחדש Hyprland & Quickshell\" בפינה הימנית העליונה",
   "Launch on startup": "הפעל בעת הפעלה",
   "Terminal: Harmonize threshold": "טרמינל: Harmonize threshold",
   "Quick": "מהיר",
@@ -410,7 +410,7 @@
   "Thin": "דק",
   "Sides": "צדדים",
   "Hollow": "חלול",
-  "Usage: <tt>%1superpaste NUM_OF_ENTRIES[i]</tt>\nSupply <tt>i</tt> when you want images\nExamples:\n<tt>%1superpaste 4i</tt> for the last 4 images\n<tt>%1superpaste 7</tt> for the last 7 entries":   "שימוש: <tt>%1superpaste NUM_OF_ENTRIES[i]</tt>\nהוסף <tt>i</tt> כאשר תרצה תמונות\nדוגמאות:\n<tt>%1superpaste 4i</tt> עבור 4 התמונות האחרונות\n<tt>%1superpaste 7</tt> עבור 7 הערכים האחרונים",
+  "Usage: <tt>%1superpaste NUM_OF_ENTRIES[i]</tt>\nSupply <tt>i</tt> when you want images\nExamples:\n<tt>%1superpaste 4i</tt> for the last 4 images\n<tt>%1superpaste 7</tt> for the last 7 entries": "שימוש: <tt>%1superpaste NUM_OF_ENTRIES[i]</tt>\nהוסף <tt>i</tt> כאשר תרצה תמונות\nדוגמאות:\n<tt>%1superpaste 4i</tt> עבור 4 התמונות האחרונות\n<tt>%1superpaste 7</tt> עבור 7 הערכים האחרונים",
   "Center clock": "מרכוז השעון",
   "Tip: Close a window with Super+Q": "טיפ: סגור חלון עם Super+Q",
   "Clock style": "סגנון השעון",
@@ -501,5 +501,7 @@
   "Fr": "Fr/*keep*/",
   "Tu": "Tu/*keep*/",
   "Th": "Th/*keep*/",
-  "We": "We/*keep*/"
+  "We": "We/*keep*/",
+  "Annotation": "הערה",
+  "Open annotation tool after copy": "פתח כלי הערות לאחר העתקה"
 }

--- a/dots/.config/quickshell/ii/translations/id_ID.json
+++ b/dots/.config/quickshell/ii/translations/id_ID.json
@@ -488,5 +488,7 @@
   "Colors": "Warna",
   "Monitors": "Monitor",
   "Fuzzy": "Fuzzy",
-  "Discord": "Discord"
+  "Discord": "Discord",
+  "Annotation": "Anotasi",
+  "Open annotation tool after copy": "Buka alat anotasi setelah menyalin"
 }

--- a/dots/.config/quickshell/ii/translations/it_IT.json
+++ b/dots/.config/quickshell/ii/translations/it_IT.json
@@ -359,5 +359,7 @@
   "**Instructions**: Log into Mistral account, go to Keys on the sidebar, click Create new key": "**Istruzioni**: Accedi al tuo account Mistral, vai nella sezione \"Keys\" dal menu laterale, clicca \"Create new key\"",
   "Gives the model search capabilities (immediately)": "Abilita modalità ricerca del modello (immediatamente)",
   "Commands, edit configs, search.\nTakes an extra turn to switch to search mode if that's needed": "Comanda, modifica la richiesta, cerca.\nRichiede un turno in più per attivare la modalità ricerca se richiesta",
-  "Online | %1's model | Delivers fast, responsive and well-formatted answers. Disadvantages: not very eager to do stuff; might make up unknown function calls": "Online | Modello di %1 | Ritorna risposte veloci e formattate correttamente. Svantaggi: poca voglia di svolgere compiti; potrebbe fare chiamate di funzioni inesistenti"
+  "Online | %1's model | Delivers fast, responsive and well-formatted answers. Disadvantages: not very eager to do stuff; might make up unknown function calls": "Online | Modello di %1 | Ritorna risposte veloci e formattate correttamente. Svantaggi: poca voglia di svolgere compiti; potrebbe fare chiamate di funzioni inesistenti",
+  "Annotation": "Annotazione",
+  "Open annotation tool after copy": "Apri strumento di annotazione dopo la copia"
 }

--- a/dots/.config/quickshell/ii/translations/ja_JP.json
+++ b/dots/.config/quickshell/ii/translations/ja_JP.json
@@ -199,7 +199,7 @@
   "Use Levenshtein distance-based algorithm instead of fuzzy": "あいまい検索の代わりにレーベンシュタイン距離アルゴリズムを使用",
   "System prompt": "システムプロンプト",
   "12h AM/PM": "12時間（AM/PM）",
-  "Could be better if you make a ton of typos,\nbut results can be weird and might not work with acronyms\n(e.g. \"GIMP\" might not give you the paint program)":"入力ミスが多い場合に便利ですが、結果が意図しないものになったり、略語（例：GIMP）が正しく検索できないことがあります",
+  "Could be better if you make a ton of typos,\nbut results can be weird and might not work with acronyms\n(e.g. \"GIMP\" might not give you the paint program)": "入力ミスが多い場合に便利ですが、結果が意図しないものになったり、略語（例：GIMP）が正しく検索できないことがあります",
   "Critical warning": "重大な警告",
   "User agent (for services that require it)": "ユーザーエージェント（必要なサービス用）",
   "Such regions could be images or parts of the screen that have some containment.\nMight not always be accurate.\nThis is done with an image processing algorithm run locally and no AI is used.": "これらの領域は、画像や画面の一部など、まとまりのある部分を指します。\n必ずしも正確ではありません。\nAIではなく、ローカルで実行される画像処理アルゴリズムによって検出されます。",
@@ -428,5 +428,7 @@
   "Lap": "ラップ",
   "Horizontal": "水平",
   "Region width": "領域の幅",
-  "Vertical": "垂直"
+  "Vertical": "垂直",
+  "Annotation": "注釈",
+  "Open annotation tool after copy": "コピー後に注釈ツールを開く"
 }

--- a/dots/.config/quickshell/ii/translations/pt_BR.json
+++ b/dots/.config/quickshell/ii/translations/pt_BR.json
@@ -733,5 +733,7 @@
   "Tint app icons": "Colorir ícones de app",
   "Color picker": "Seletor de cores",
   "Night Light | Right-click to toggle Auto mode": "Luz Noturna | Botão direito para alternar modo Auto",
-  "Inactive": "Inativo"
+  "Inactive": "Inativo",
+  "Annotation": "Anotação",
+  "Open annotation tool after copy": "Abrir ferramenta de anotação após copiar"
 }

--- a/dots/.config/quickshell/ii/translations/ru_RU.json
+++ b/dots/.config/quickshell/ii/translations/ru_RU.json
@@ -387,5 +387,7 @@
   "When enabled keeps the content of the right sidebar loaded to reduce the delay when opening,\nat the cost of around 15MB of consistent RAM usage. Delay significance depends on your system's performance.\nUsing a custom kernel like linux-cachyos might help": "При включении этого параметра содержимое правой боковой панели сохраняется загруженным, что сокращает задержку при открытии,\nзатрачивая около 15 МБ постоянного использования оперативной памяти. Длительность задержки зависит от производительности вашей системы.\nИспользование пользовательского ядра, например, linux-cachyos, может помочь.",
   "High": "Высокий",
   "Focus": "Фокус",
-  "Load:": "Load:"
+  "Load:": "Load:",
+  "Annotation": "Аннотация",
+  "Open annotation tool after copy": "Открыть инструмент аннотаций после копирования"
 }

--- a/dots/.config/quickshell/ii/translations/tr_TR.json
+++ b/dots/.config/quickshell/ii/translations/tr_TR.json
@@ -604,5 +604,7 @@
   "Recognize music": "Müziği tanı",
   "Stroke width": "Çizgi genişliği",
   "Use varying shapes for password characters": "Şifre karakterleri için değişen şekiller kullan",
-  "Battery full": "Pil dolu"
+  "Battery full": "Pil dolu",
+  "Annotation": "Ek Açıklama",
+  "Open annotation tool after copy": "Kopyalamadan sonra ek açıklama aracını aç"
 }

--- a/dots/.config/quickshell/ii/translations/uk_UA.json
+++ b/dots/.config/quickshell/ii/translations/uk_UA.json
@@ -338,5 +338,7 @@
   "Tool set to: %1": "Інструмет вказано: %1",
   "Commands, edit configs, search.\nTakes an extra turn to switch to search mode if that's needed": "Команди, редагування конфігурацій, пошук.\nВиконує додаткову дію для переходу в режим пошуку, якщо це потрібно",
   "To set an API key, pass it with the %4 command\n\nTo view the key, pass \"get\" with the command<br/>\n\n### For %1:\n\n**Link**: %2\n\n%3": "Щоб задати ключ API, передайте його командою %4\n\nЩоб переглянути ключ, передайте \"get\" командою<br/>\n\n### Для %1:\n\n**Лінк**: %2\n\n%3",
-  "Online | Google's model\nNewer model that's slower than its predecessor but should deliver higher quality answers": "Онлайн | Модель Google\nНовіша модель, яка повільніша за свою попередницю, але має надавати якісніші відповіді"
+  "Online | Google's model\nNewer model that's slower than its predecessor but should deliver higher quality answers": "Онлайн | Модель Google\nНовіша модель, яка повільніша за свою попередницю, але має надавати якісніші відповіді",
+  "Annotation": "Анотація",
+  "Open annotation tool after copy": "Відкрити інструмент анотацій після копіювання"
 }

--- a/dots/.config/quickshell/ii/translations/vi_VN.json
+++ b/dots/.config/quickshell/ii/translations/vi_VN.json
@@ -369,5 +369,7 @@
   "illogical-impulse Settings": "Cài đặt illogical-impulse",
   "Online | Google's model\nNewer model that's slower than its predecessor but should deliver higher quality answers": "Trực tuyến | Model của Google\nMới hơn nhưng chậm hơn so với phiên bản trước nhưng nên cung cấp câu trả lời chất lượng cao hơn",
   "Preferred wallpaper zoom (%)": "Tỷ lệ thu phóng hình nền (%)",
-  "Function Response": "Phản hồi function"
+  "Function Response": "Phản hồi function",
+  "Annotation": "Chú thích",
+  "Open annotation tool after copy": "Mở công cụ chú thích sau khi sao chép"
 }

--- a/dots/.config/quickshell/ii/translations/zh_CN.json
+++ b/dots/.config/quickshell/ii/translations/zh_CN.json
@@ -718,5 +718,7 @@
   "No applications": "没有应用",
   "Creativity": "创意",
   "Move left": "左移",
-  "Pin to Start": "固定到“开始”屏幕"
+  "Pin to Start": "固定到“开始”屏幕",
+  "Annotation": "标注",
+  "Open annotation tool after copy": "复制后打开标注工具"
 }


### PR DESCRIPTION
This PR introduces a user-configurable option to control the automatic opening of the annotation tool (e.g., Swappy) when copying a screenshot to the clipboard.

### Changes:
- Added `regionSelector.annotation.autoOpenTool` to `Config.qml` (default: `true`).
- Updated `ScreenshotAction.qml` to conditionally pipe output to the annotation command based on this setting.
- Added a toggle switch in the "Region selector" section of `InterfaceConfig.qml`.
- Added translation keys for "Annotation" and "Open annotation tool after copy" in all supported languages.

### Motivation:
Some users prefer to copy the raw screenshot directly to the clipboard without the interruption of an annotation tool. This option provides that flexibility while maintaining the existing behavior as the default.