### PR TITLE
fix(quickshell): mpris not detecting browser players when plasma-browser-integration is installed

### DIFF
--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -25,22 +25,16 @@ Singleton {
 
 	property var activeTrack;
 
-	property bool hasPlasmaIntegration: false
-    Process {
-        id: plasmaIntegrationAvailabilityCheckProc
-        running: true
-        command: ["bash", "-c", "command -v plasma-browser-integration-host"]
-        onExited: (exitCode, exitStatus) => {
-            root.hasPlasmaIntegration = (exitCode === 0);
-        }
-    }
+	readonly property bool hasActivePlasmaIntegration: Mpris.players.values.some(
+		p => p.dbusName?.startsWith('org.mpris.MediaPlayer2.plasma-browser-integration')
+	)
 	function isRealPlayer(player) {
         if (!Config.options.media.filterDuplicatePlayers) {
             return true;
         }
         return (
-            // Remove unecessary native buses from browsers if there's plasma integration
-            !(hasPlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.firefox')) && !(hasPlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.chromium')) &&
+            // Remove native browser buses only if plasma-browser-integration is actually active on D-Bus
+            !(hasActivePlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.firefox')) && !(hasActivePlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.chromium')) &&
             // playerctld just copies other buses and we don't need duplicates
             !player.dbusName?.startsWith('org.mpris.MediaPlayer2.playerctld') &&
             // Non-instance mpd bus


### PR DESCRIPTION
## Describe your changes

The bar media widget (and media controls) wouldn't detect browser MPRIS players (Firefox, Chromium) if `plasma-browser-integration-host` was installed on the system — even if Plasma integration wasn't actually running.

The old code spawned a process to check if the binary exists on disk. If it did, it filtered out all native browser MPRIS buses, assuming Plasma would provide duplicates. But just having the package installed (e.g. pulled as a dependency) doesn't mean it's active, so the filter would kill the only player available.

This replaces the subprocess check with a reactive property that looks at whether a `plasma-browser-integration` player is actually registered on D-Bus among the current `Mpris.players`. Native browser buses only get filtered when there's genuinely a duplicate to filter.

Also gets rid of the bash subprocess spawn on startup which is nice.

## Is it ready? Questions/feedback needed?

Tested on Arch with Firefox + `plasma-browser-integration` installed but not running. Media shows up properly now.