### PR TITLE
feat: Add support for ctrl+p and ctrl+n for up/down navigation

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -95,6 +95,25 @@ Item { // Wrapper
                 root.focusFirstItem();
             }
         }
+
+        // Ctrl+N / Ctrl+P navigation
+        if (event.modifiers & Qt.ControlModifier) {
+            if (event.key === Qt.Key_N) {
+                if (appResults.visible && appResults.count > 0) {
+                    // Wrap around the list rather than the default arrow key behaviour
+                    appResults.currentIndex = appResults.count - 1 == appResults.currentIndex ? 0 : appResults.currentIndex + 1
+                    event.accepted = true;
+                    return;
+                }
+            } else if (event.key === Qt.Key_P) {
+                if (appResults.visible && appResults.count > 0) {
+                    // Wrap around too
+                    appResults.currentIndex = 0 == appResults.currentIndex ? appResults.count-1 : appResults.currentIndex - 1
+                    event.accepted = true;
+                    return;
+                }
+            }
+        }
     }
 
     StyledRectangularShadow {


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

For lists in SearchWidget.qml, user can now navigate the list using ctrl+p and ctrl+n
## Is it ready? Questions/feedback needed?

This is a simple change and I don't think it will conflict with anything. Also this gesture is pretty universal for list navigation, so I think users will find this useful. Any feedback is welcome of course.

