### PR TITLE
Remove [hidden] comment for zoom keybinds

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.conf
+++ b/dots/.config/hypr/hyprland/keybinds.conf
@@ -230,8 +230,8 @@ bindd = Ctrl+Shift+Alt+Super, Delete, Shutdown, exec, systemctl poweroff || logi
 
 ##! Screen
 # Zoom
-binde = Super, Minus, exec, ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.3 # [hidden] Zoom out
-binde = Super, Equal, exec, ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.3 # [hidden] Zoom in
+binde = Super, Minus, exec, ~/.config/hypr/hyprland/scripts/zoom.sh decrease 0.3 # Zoom out
+binde = Super, Equal, exec, ~/.config/hypr/hyprland/scripts/zoom.sh increase 0.3 # Zoom in
 # Zoom with keypad
 binde = Super, code:82, exec, qs -c $qsConfig ipc call zoom zoomOut # [hidden] Zoom out
 binde = Super, code:86, exec, qs -c $qsConfig ipc call zoom zoomIn # [hidden] Zoom in


### PR DESCRIPTION
## Describe your changes

Remove [hidden] comment for zoom keybinds to appear in cheatsheet.

<img width="326" height="327" alt="image" src="https://github.com/user-attachments/assets/dda13c1b-8c1a-47a8-9773-7563e929f2f7" />

## Is it ready? Questions/feedback needed?

Its a tiny change, so yes

