### PR TITLE
fix(quickshell): fix severe wallpaper pixelation with fractional scaling

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -174,9 +174,11 @@ Variants {
                     }
                 }
                 sourceSize {
-                    width: bgRoot.screen.width * bgRoot.effectiveWallpaperScale * bgRoot.monitor.scale
-                    height: bgRoot.screen.height * bgRoot.effectiveWallpaperScale * bgRoot.monitor.scale
+                    width: 0
+                    height: 0
                 }
+                smooth: true
+                mipmap: true
                 width: bgRoot.wallpaperWidth / bgRoot.wallpaperToScreenRatio * bgRoot.effectiveWallpaperScale
                 height: bgRoot.wallpaperHeight / bgRoot.wallpaperToScreenRatio * bgRoot.effectiveWallpaperScale
             }

--- a/dots/.config/quickshell/ii/modules/waffle/background/WaffleBackground.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/background/WaffleBackground.qml
@@ -41,6 +41,10 @@ Variants {
             anchors.fill: parent
             source: Config.options.background.wallpaperPath
             fillMode: Image.PreserveAspectCrop
+            sourceSize.width: 0
+            sourceSize.height: 0
+            smooth: true
+            mipmap: true
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/waffle/lock/WaffleLock.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/lock/WaffleLock.qml
@@ -46,7 +46,10 @@ LockScreen {
                     openAnim.restart();
                 }
             }
-            sourceSize: Qt.size(lockSurfaceItem.width, lockSurfaceItem.height)
+            sourceSize.width: 0
+            sourceSize.height: 0
+            smooth: true
+            mipmap: true
             source: Config.options.background.wallpaperPath
             fillMode: Image.PreserveAspectCrop
 


### PR DESCRIPTION
Allow original image bounds to decode properly via sourceSize: 0 and enable smooth/mipmap filtering to elegantly handle downscaling and fractional rendering on Wayland.

## Describe your changes
Fixes #3036

 **Root Cause Analysis**
I investigated the Quickshell QML files and found that the pixelation is caused by how the wallpaper rendering and scaling are handled:
1. `sourceSize` is aggressively forced to match the screen's bounds. If the wallpaper has a different aspect ratio, it gets downscaled prematurely to fit.
2. `smooth: false` is explicitly set in the QML code. Because of this, when Quickshell tries to render the prematurely downscaled image (or handle the fractional Wayland scale), it uses nearest-neighbor interpolation, resulting in severe blockiness.

 **Proposed Solution / Fix**
The fix involves two QML property changes to allow proper texture filtering and decoding:
1. Allow `sourceSize` to decode to the exact bounds of the rendered image rather than strictly the screen bounds, preventing premature cropping/downscaling.
2. Set `smooth: true` and `mipmap: true` to enable proper linear texture filtering, which elegantly handles fractional scaling.

## Is it ready? Questions/feedback needed?
I've tested on my own desktop, and it fixed the issue, but it still requires a review since I used AI to fix it, and not sure about the `sourceSize` changes.
