### PR TITLE
fix: sudo keepalive cleanup leaking exit code 143

### DIFF
--- a/sdata/lib/functions.sh
+++ b/sdata/lib/functions.sh
@@ -119,8 +119,8 @@ function sudo_init_keepalive(){
 # Stop the sudo keepalive background process
 function sudo_stop_keepalive(){
   if [[ -n "$SUDO_KEEPALIVE_PID" ]] && kill -0 "$SUDO_KEEPALIVE_PID" 2>/dev/null; then
-    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null
-    wait "$SUDO_KEEPALIVE_PID" 2>/dev/null
+    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    wait "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
     SUDO_KEEPALIVE_PID=""
   fi
 }


### PR DESCRIPTION
## Describe your changes

The EXIT trap running `sudo_stop_keepalive` causes `./setup install` to exit with code 143 instead of 0, even on a fully successful install.

`wait` on a SIGTERM-killed background process returns 143 (128+15). With `set -e` active, this leaks into the script's final exit code, so the user's shell prompt shows it as a failure.

Fix: add `|| true` after `kill` and `wait` in `sudo_stop_keepalive()`, matching the existing convention used elsewhere in the codebase.

## Is it ready? Questions/feedback needed?

Ready. Tested across multiple scenarios (normal exit, Ctrl-C, already-dead process, real failures still propagate correctly).