### PR TITLE
[small bug fix] fixed thumbnail urlencode for file names with (,),*

### DIFF
--- a/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
+++ b/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
@@ -36,7 +36,7 @@ urlencode() {
     for ((i=0; i<${#str}; i++)); do
         c="${str:$i:1}"
         case "$c" in
-            [a-zA-Z0-9.~_-]|/) encoded+="$c" ;;
+            [a-zA-Z0-9.~_-]|/|'('|')'|'*') encoded+="$c" ;;
             *) printf -v hex '%%%02X' "'${c}'"; encoded+="$hex" ;;
         esac
     done


### PR DESCRIPTION


## Describe your changes
matched output of urlencode function with

gio info "/home/su/Pictures/Wallpapers/as()*[].png" | grep "uri:"

uri: file:///home/su/Pictures/Wallpapers/as()*%5B%5D.png

it seems that the file uri specification is different from generic uri

## Is it ready? Questions/feedback needed?
thumbnails are now generating for me with filename with '(',')','*' but not with '[' and ']' i am not sure why 


