### PR TITLE
feat(dock): context menu and drag-to-reorder for pinned apps

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Icons.qml
+++ b/dots/.config/quickshell/ii/modules/common/Icons.qml
@@ -19,6 +19,17 @@ Singleton {
         return "battery_android_0";
     }
 
+    function getDesktopActionMaterialSymbol(icon: string): string {
+        // Some apps ship custom icon names in their desktop-entry actions
+        // (e.g. VS Code uses "vscode", Telegram uses non-Material names).
+        // Map known cases to Material Symbols; fall through unchanged otherwise.
+        switch (icon) {
+            case "vscode": return "code";
+            case "application-exit": return "exit_to_app";
+        }
+        return icon;
+    }
+
     function getBluetoothDeviceMaterialSymbol(systemIconName: string): string {
         if (systemIconName.includes("headset") || systemIconName.includes("headphones"))
             return "headphones";

--- a/dots/.config/quickshell/ii/modules/common/Icons.qml
+++ b/dots/.config/quickshell/ii/modules/common/Icons.qml
@@ -19,15 +19,36 @@ Singleton {
         return "battery_android_0";
     }
 
+    // Desktop-entry actions carry themed icon names, not Material Symbols, and
+    // actions without an Icon key inherit the parent entry's icon (e.g.
+    // "co.anysphere.cursor"). Anything that isn't a known Material Symbol name
+    // would render as literal text in the symbol font, so fall back to a
+    // generic bullet instead of passing the name through.
+    readonly property string desktopActionFallbackSymbol: "chevron_right"
+
+    readonly property var desktopActionSymbolMap: ({
+        "vscode": "code",
+        "code": "code",
+        "application-exit": "exit_to_app",
+        "window-new": "open_in_new",
+        "document-new": "note_add",
+        "list-add": "add",
+        "media-playback-start": "play_arrow",
+        "media-playback-pause": "pause",
+        "media-skip-forward": "skip_next",
+        "media-skip-backward": "skip_previous",
+        "view-private": "visibility_off",
+        "user-trash": "delete",
+        "preferences-system": "settings",
+        "help-about": "info"
+    })
+
     function getDesktopActionMaterialSymbol(icon: string): string {
-        // Some apps ship custom icon names in their desktop-entry actions
-        // (e.g. VS Code uses "vscode", Telegram uses non-Material names).
-        // Map known cases to Material Symbols; fall through unchanged otherwise.
-        switch (icon) {
-            case "vscode": return "code";
-            case "application-exit": return "exit_to_app";
-        }
-        return icon;
+        if (!icon) return root.desktopActionFallbackSymbol;
+        const mapped = root.desktopActionSymbolMap[icon];
+        // Whitelist only: any unmapped name is a themed icon name
+        // ("firefox", "co.anysphere.cursor", "/path/to.png"), never a ligature.
+        return mapped ?? root.desktopActionFallbackSymbol;
     }
 
     function getBluetoothDeviceMaterialSymbol(systemIconName: string): string {

--- a/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
@@ -38,6 +38,8 @@ Button {
             colBackground), root.enabled ? 0 : 1)
     property color rippleColor: root.toggled ? colRippleToggled : colRipple
 
+    function cancelRipple() { rippleFadeAnim.restart(); }
+
     function startRipple(x, y) {
         const stateY = buttonBackground.y;
         rippleAnim.x = x;

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
@@ -11,6 +11,7 @@ DockButton {
     id: root
     property var appToplevel
     property var appListRoot
+    property int delegateIndex: -1
     property int lastFocused: -1
     property real iconSize: 35
     property real countDotWidth: 10
@@ -27,6 +28,31 @@ DockButton {
 
         function onApplicationsChanged() {
             root.desktopEntry = DesktopEntries.heuristicLookup(appToplevel.appId);
+        }
+    }
+
+    // Drag-to-reorder
+    readonly property bool isDragged: appListRoot.dragging && delegateIndex === appListRoot.dragSourceIndex
+    readonly property real dragTranslateX: {
+        if (!appListRoot.dragging) return 0;
+        if (isDragged) return appListRoot.dragCursorX - appListRoot.dragStartCursorX;
+        if (!appToplevel.pinned || isSeparator) return 0;
+        var src = appListRoot.dragSourceIndex;
+        var tgt = appListRoot.dragTargetIndex;
+        var idx = delegateIndex;
+        if (src < tgt && idx > src && idx <= tgt) return -appListRoot.slotWidth;
+        if (src > tgt && idx >= tgt && idx < src) return appListRoot.slotWidth;
+        return 0;
+    }
+    z: isDragged ? 100 : 0
+    opacity: isDragged ? 0.85 : (enabled ? 1 : 0.4)
+    scale: isDragged ? 1.05 : 1
+
+    transform: Translate {
+        x: root.dragTranslateX
+        Behavior on x {
+            enabled: !root.isDragged && !appListRoot._suppressTranslateAnim
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
         }
     }
 
@@ -61,6 +87,66 @@ DockButton {
         }
     }
 
+    // Drag overlay for pinned non-separator items
+    Loader {
+        anchors.fill: parent
+        z: 10
+        active: appToplevel.pinned && !isSeparator
+        sourceComponent: MouseArea {
+            id: dragOverlay
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton
+            preventStealing: true
+            property real pressX: 0
+            property bool dragActive: false
+
+            onPressed: (event) => {
+                pressX = event.x;
+                root.down = true;
+                root.startRipple(event.x, event.y);
+            }
+            onPositionChanged: (event) => {
+                if (!pressed) return;
+                var dist = Math.abs(event.x - pressX);
+                if (!dragActive && dist > 5) {
+                    dragActive = true;
+                    root.cancelRipple();
+                    root.down = false;
+                    appListRoot.buttonHovered = false;
+                    // Set all state BEFORE enabling drag to avoid stale computations
+                    appListRoot.dragSourceIndex = root.delegateIndex;
+                    var mapped = mapToItem(appListRoot, event.x, event.y);
+                    appListRoot.dragStartCursorX = mapped.x;
+                    appListRoot.dragCursorX = mapped.x;
+                    appListRoot.slotWidth = root.width + 2; // width + listView spacing
+                    appListRoot.dragging = true;
+                }
+                if (dragActive) {
+                    var mapped = mapToItem(appListRoot, event.x, event.y);
+                    appListRoot.dragCursorX = mapped.x;
+                }
+            }
+            onReleased: (event) => {
+                if (dragActive) {
+                    dragActive = false;
+                    appListRoot.finishDrag();
+                } else {
+                    root.down = false;
+                    root.cancelRipple();
+                    root.click();
+                }
+            }
+            onCanceled: {
+                if (dragActive) {
+                    dragActive = false;
+                    appListRoot.cancelDrag();
+                }
+                root.down = false;
+                root.cancelRipple();
+            }
+        }
+    }
+
     onClicked: {
         if (appToplevel.toplevels.length === 0) {
             root.desktopEntry?.execute();
@@ -75,7 +161,7 @@ DockButton {
     }
 
     altAction: () => {
-        TaskbarApps.togglePin(appToplevel.appId);
+        appListRoot.openContextMenu(root, appToplevel);
     }
 
     contentItem: Loader {
@@ -128,7 +214,7 @@ DockButton {
                     delegate: Rectangle {
                         required property int index
                         radius: Appearance.rounding.full
-                        implicitWidth: (appToplevel.toplevels.length <= 3) ? 
+                        implicitWidth: (appToplevel.toplevels.length <= 3) ?
                             root.countDotWidth : root.countDotHeight // Circles when too many
                         implicitHeight: root.countDotHeight
                         color: appIsActive ? Appearance.colors.colPrimary : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
@@ -31,6 +31,18 @@ DockButton {
         }
     }
 
+    Timer {
+        // Fallback: retry lookup if desktop entry remained null (e.g. applicationsChanged fired before this component existed)
+        property int retryCount: 5
+        interval: 1000
+        running: !root.isSeparator && root.desktopEntry === null && retryCount > 0
+        repeat: true
+        onTriggered: {
+            retryCount--;
+            root.desktopEntry = DesktopEntries.heuristicLookup(root.appToplevel.appId);
+        }
+    }
+
     // Drag-to-reorder
     readonly property bool isDragged: appListRoot.dragging && delegateIndex === appListRoot.dragSourceIndex
     readonly property real dragTranslateX: {

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockApps.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockApps.qml
@@ -20,11 +20,52 @@ Item {
 
     property Item lastHoveredButton: null
     property bool buttonHovered: false
-    property bool requestDockShow: previewPopup.show
+    property bool requestDockShow: previewPopup.show || contextMenu.isOpen
 
-    Layout.fillHeight: true
-    Layout.topMargin: Appearance.sizes.hyprlandGapsOut
-    implicitWidth: listView.implicitWidth
+    // Drag-to-reorder state
+    property bool dragging: false
+    property bool _reordering: false
+    property bool _suppressTranslateAnim: false
+    property int dragSourceIndex: -1
+    property real dragCursorX: 0
+    property real dragStartCursorX: 0
+    property real slotWidth: 0
+    property int dragTargetIndex: {
+        if (!dragging || slotWidth <= 0) return dragSourceIndex;
+        var delta = dragCursorX - dragStartCursorX;
+        var slots = Math.round(delta / slotWidth);
+        var pinnedCount = Config.options.dock.pinnedApps.length;
+        return Math.max(0, Math.min(dragSourceIndex + slots, pinnedCount - 1));
+    }
+
+    function finishDrag() {
+        _suppressTranslateAnim = true;
+        if (dragging && dragSourceIndex !== dragTargetIndex) {
+            _reordering = true;
+            TaskbarApps.reorderPinned(dragSourceIndex, dragTargetIndex);
+        }
+        dragging = false;
+        dragSourceIndex = -1;
+        dragCursorX = 0;
+        dragStartCursorX = 0;
+        Qt.callLater(function() {
+            _reordering = false;
+            _suppressTranslateAnim = false;
+        });
+    }
+
+    function cancelDrag() {
+        _suppressTranslateAnim = true;
+        dragging = false;
+        dragSourceIndex = -1;
+        dragCursorX = 0;
+        dragStartCursorX = 0;
+        Qt.callLater(function() { _suppressTranslateAnim = false; });
+    }
+
+    function openContextMenu(button, appToplevelData) {
+        contextMenu.open(button, appToplevelData);
+    }
 
     function popupCenterXForButton(button) {
         if (!button || !root.QsWindow)
@@ -32,9 +73,16 @@ Item {
         return root.QsWindow.mapFromItem(button, button.width / 2, 0).x;
     }
 
+    Layout.fillHeight: true
+    Layout.topMargin: Appearance.sizes.hyprlandGapsOut
+    implicitWidth: listView.implicitWidth
+
     StyledListView {
         id: listView
         spacing: 2
+        clip: false
+        interactive: false
+        animateAppearance: !root._reordering
         orientation: ListView.Horizontal
         anchors {
             top: parent.top
@@ -52,8 +100,10 @@ Item {
         }
         delegate: DockAppButton {
             required property var modelData
+            required property int index
             appToplevel: modelData
             appListRoot: root
+            delegateIndex: index
 
             topInset: Appearance.sizes.hyprlandGapsOut + root.buttonPadding
             bottomInset: Appearance.sizes.hyprlandGapsOut + root.buttonPadding
@@ -63,15 +113,13 @@ Item {
     PopupWindow {
         id: previewPopup
         property var appTopLevel: root.lastHoveredButton?.appToplevel
-
-        property bool shouldShow: (popupMouseArea.containsMouse || root.buttonHovered) && appTopLevel && appTopLevel.toplevels && appTopLevel.toplevels.length > 0
-
-        property bool show: false
+        property bool allPreviewsReady: false
         property real cachedCenterX: 0
 
         Connections {
             target: root
             function onLastHoveredButtonChanged() {
+                previewPopup.allPreviewsReady = false; // Reset readiness when the hovered button changes
                 if (root.lastHoveredButton && root.QsWindow)
                     previewPopup.cachedCenterX = root.popupCenterXForButton(root.lastHoveredButton);
             }
@@ -81,6 +129,24 @@ Item {
                 updateTimer.restart();
             }
         }
+
+        function updatePreviewReadiness() {
+            for(var i = 0; i < previewRowLayout.children.length; i++) {
+                const view = previewRowLayout.children[i];
+                if (view.hasContent === false) {
+                    allPreviewsReady = false;
+                    return;
+                }
+            }
+            allPreviewsReady = true;
+        }
+
+        property bool shouldShow: {
+            if (root.dragging) return false;
+            const hoverConditions = (popupMouseArea.containsMouse || root.buttonHovered)
+            return hoverConditions && allPreviewsReady;
+        }
+        property bool show: false
 
         onShouldShowChanged: {
             updateTimer.restart();
@@ -170,13 +236,18 @@ Item {
 
                                 ButtonGroup {
                                     contentWidth: parent.width - anchors.margins * 2
-                                    StyledText {
-                                        Layout.margins: 5
+                                    WrapperRectangle {
                                         Layout.fillWidth: true
-                                        font.pixelSize: Appearance.font.pixelSize.small
-                                        text: windowButton.modelData?.title
-                                        elide: Text.ElideRight
-                                        color: Appearance.m3colors.m3onSurface
+                                        color: ColorUtils.transparentize(Appearance.colors.colSurfaceContainer)
+                                        radius: Appearance.rounding.small
+                                        margin: 5
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            font.pixelSize: Appearance.font.pixelSize.small
+                                            text: windowButton.modelData?.title
+                                            elide: Text.ElideRight
+                                            color: Appearance.m3colors.m3onSurface
+                                        }
                                     }
                                     GroupButton {
                                         id: closeButton
@@ -196,25 +267,21 @@ Item {
                                         }
                                     }
                                 }
-                                Item {
-                                    Layout.fillWidth: true
-                                    Layout.fillHeight: true
-                                    implicitHeight: screencopyView.height
-                                    implicitWidth: screencopyView.width
-                                    ScreencopyView {
-                                        id: screencopyView
-                                        anchors.centerIn: parent
-                                        captureSource: windowButton.modelData
-                                        live: true
-                                        paintCursor: true
-                                        constraintSize: Qt.size(root.maxWindowPreviewWidth, root.maxWindowPreviewHeight)
-                                        layer.enabled: true
-                                        layer.effect: OpacityMask {
-                                            maskSource: Rectangle {
-                                                width: screencopyView.width
-                                                height: screencopyView.height
-                                                radius: Appearance.rounding.small
-                                            }
+                                ScreencopyView {
+                                    id: screencopyView
+                                    captureSource: previewPopup ? windowButton.modelData : null
+                                    live: true
+                                    paintCursor: true
+                                    constraintSize: Qt.size(root.maxWindowPreviewWidth, root.maxWindowPreviewHeight)
+                                    onHasContentChanged: {
+                                        previewPopup.updatePreviewReadiness();
+                                    }
+                                    layer.enabled: true
+                                    layer.effect: OpacityMask {
+                                        maskSource: Rectangle {
+                                            width: screencopyView.width
+                                            height: screencopyView.height
+                                            radius: Appearance.rounding.small
                                         }
                                     }
                                 }
@@ -224,5 +291,9 @@ Item {
                 }
             }
         }
+    }
+
+    DockContextMenu {
+        id: contextMenu
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockApps.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockApps.qml
@@ -142,7 +142,7 @@ Item {
         }
 
         property bool shouldShow: {
-            if (root.dragging) return false;
+            if (root.dragging || contextMenu.isOpen) return false;
             const hoverConditions = (popupMouseArea.containsMouse || root.buttonHovered)
             return hoverConditions && allPreviewsReady;
         }
@@ -269,7 +269,15 @@ Item {
                                 }
                                 ScreencopyView {
                                     id: screencopyView
-                                    captureSource: previewPopup ? windowButton.modelData : null
+                                    // Gate capture on actual visibility: hover or popup-mouse, AND not in
+                                    // a state that's about to tear down the popup (context menu, drag).
+                                    // Hyprland 0.54.0 asserts in CScreenshareFrame::copyDmabuf if a frame
+                                    // is in flight when the popup is destroyed — that crashed the session
+                                    // on right-click before this gate.
+                                    captureSource: (root.buttonHovered || popupMouseArea.containsMouse)
+                                        && !contextMenu.isOpen
+                                        && !root.dragging
+                                        ? windowButton.modelData : null
                                     live: true
                                     paintCursor: true
                                     constraintSize: Qt.size(root.maxWindowPreviewWidth, root.maxWindowPreviewHeight)

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
@@ -1,0 +1,262 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Hyprland
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+
+Item {
+    id: root
+
+    property var appToplevel
+    property Item targetButton
+    property alias isOpen: menuLoader.active
+    readonly property var desktopEntry: appToplevel ? DesktopEntries.heuristicLookup(appToplevel.appId) : null
+    readonly property bool hasWindows: (appToplevel?.toplevels.length ?? 0) > 0
+    readonly property bool hasDesktopActions: (desktopEntry?.actions.length ?? 0) > 0
+
+    function open(button, appToplevelData) {
+        if (menuLoader.active) {
+            menuLoader.active = false;
+        }
+        targetButton = button;
+        appToplevel = appToplevelData;
+        menuLoader.active = true;
+    }
+
+    function close() {
+        menuLoader.active = false;
+    }
+
+    Loader {
+        id: menuLoader
+        active: false
+        sourceComponent: PopupWindow {
+            id: contextPopup
+            visible: true
+
+            anchor {
+                item: root.targetButton
+                gravity: Edges.Top
+                edges: Edges.Top
+                adjustment: PopupAdjustment.SlideX
+            }
+
+            HyprlandFocusGrab {
+                active: true
+                windows: [contextPopup]
+                onCleared: root.close()
+            }
+
+            color: "transparent"
+            implicitWidth: menuBackground.implicitWidth + Appearance.sizes.elevationMargin * 2
+            implicitHeight: menuBackground.implicitHeight + Appearance.sizes.elevationMargin * 2
+
+            StyledRectangularShadow {
+                target: menuBackground
+            }
+
+            Rectangle {
+                id: menuBackground
+                property real padding: 4
+
+                anchors {
+                    bottom: parent.bottom
+                    horizontalCenter: parent.horizontalCenter
+                    bottomMargin: Appearance.sizes.elevationMargin
+                }
+                color: Appearance.m3colors.m3surfaceContainer
+                radius: Appearance.rounding.normal
+                implicitWidth: menuColumn.implicitWidth + padding * 2
+                implicitHeight: menuColumn.implicitHeight + padding * 2
+
+                ColumnLayout {
+                    id: menuColumn
+                    anchors {
+                        fill: parent
+                        margins: parent.padding
+                    }
+                    spacing: 0
+
+                    // Desktop entry actions
+                    Repeater {
+                        model: root.hasDesktopActions ? root.desktopEntry.actions : []
+                        delegate: ContextMenuItem {
+                            required property var modelData
+                            Layout.fillWidth: true
+                            iconName: modelData.icon ?? ""
+                            label: modelData.name
+                            onClicked: {
+                                modelData.execute();
+                                root.close();
+                            }
+                        }
+                    }
+
+                    // Separator after desktop actions
+                    Loader {
+                        active: root.hasDesktopActions
+                        Layout.fillWidth: true
+                        sourceComponent: ContextMenuSeparator {}
+                    }
+
+                    // Open new instance
+                    ContextMenuItem {
+                        Layout.fillWidth: true
+                        iconName: "open_in_new"
+                        label: "Open new instance"
+                        enabled: root.desktopEntry !== null
+                        onClicked: {
+                            root.desktopEntry?.execute();
+                            root.close();
+                        }
+                    }
+
+                    // Separator
+                    ContextMenuSeparator {
+                        Layout.fillWidth: true
+                    }
+
+                    // Move to workspace (only when has windows)
+                    Loader {
+                        active: root.hasWindows
+                        Layout.fillWidth: true
+                        sourceComponent: ColumnLayout {
+                            spacing: 0
+
+                            ContextMenuItem {
+                                Layout.fillWidth: true
+                                iconName: "move_item"
+                                label: "Move to workspace"
+                                enabled: false
+                                pointingHandCursor: false
+                            }
+
+                            RowLayout {
+                                Layout.leftMargin: 8
+                                Layout.rightMargin: 8
+                                Layout.bottomMargin: 4
+                                spacing: 2
+
+                                Repeater {
+                                    model: 10
+                                    delegate: RippleButton {
+                                        id: wsButton
+                                        required property int index
+                                        implicitWidth: 28
+                                        implicitHeight: 28
+                                        buttonRadius: Appearance.rounding.small
+                                        contentItem: StyledText {
+                                            anchors.centerIn: parent
+                                            text: String(wsButton.index + 1)
+                                            font.pixelSize: Appearance.font.pixelSize.small
+                                            horizontalAlignment: Text.AlignHCenter
+                                            color: Appearance.m3colors.m3onSurface
+                                        }
+                                        onClicked: {
+                                            const ws = wsButton.index + 1;
+                                            for (const toplevel of root.appToplevel.toplevels) {
+                                                const addr = `0x${toplevel.HyprlandToplevel?.address}`;
+                                                Hyprland.dispatch(`movetoworkspacesilent ${ws},address:${addr}`);
+                                            }
+                                            root.close();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Pin / Unpin
+                    ContextMenuItem {
+                        Layout.fillWidth: true
+                        iconName: TaskbarApps.isPinned(root.appToplevel?.appId ?? "") ? "keep_off" : "keep"
+                        label: TaskbarApps.isPinned(root.appToplevel?.appId ?? "") ? "Unpin" : "Pin to dock"
+                        onClicked: {
+                            TaskbarApps.togglePin(root.appToplevel.appId);
+                            root.close();
+                        }
+                    }
+
+                    // Separator before close (only when has windows)
+                    Loader {
+                        active: root.hasWindows
+                        Layout.fillWidth: true
+                        sourceComponent: ContextMenuSeparator {}
+                    }
+
+                    // Close window(s) (only when has windows)
+                    Loader {
+                        active: root.hasWindows
+                        Layout.fillWidth: true
+                        sourceComponent: ContextMenuItem {
+                            iconName: "close"
+                            label: (root.appToplevel?.toplevels.length ?? 0) > 1 ? "Close all windows" : "Close window"
+                            onClicked: {
+                                for (const toplevel of root.appToplevel.toplevels) {
+                                    toplevel.close();
+                                }
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    component ContextMenuItem: RippleButton {
+        id: menuItemRoot
+        property string iconName
+        property string label
+        implicitHeight: 36
+        implicitWidth: Math.max(itemRow.implicitWidth + 20, 180)
+        buttonRadius: Appearance.rounding.small
+
+        contentItem: RowLayout {
+            id: itemRow
+            anchors {
+                fill: parent
+                leftMargin: 10
+                rightMargin: 14
+            }
+            spacing: 8
+
+            MaterialSymbol {
+                text: menuItemRoot.iconName
+                iconSize: Appearance.font.pixelSize.normal
+                color: menuItemRoot.enabled ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3outline
+                visible: menuItemRoot.iconName !== ""
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: menuItemRoot.label
+                horizontalAlignment: Text.AlignLeft
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: menuItemRoot.enabled ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3outline
+                elide: Text.ElideRight
+            }
+        }
+    }
+
+    component ContextMenuSeparator: Item {
+        Layout.fillWidth: true
+        implicitHeight: 9
+
+        Rectangle {
+            anchors {
+                left: parent.left
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                leftMargin: 10
+                rightMargin: 10
+            }
+            implicitHeight: 1
+            color: ColorUtils.transparentize(Appearance.m3colors.m3outline, 0.7)
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
@@ -86,7 +86,7 @@ Item {
                         delegate: ContextMenuItem {
                             required property var modelData
                             Layout.fillWidth: true
-                            iconName: modelData.icon ?? ""
+                            iconName: Icons.getDesktopActionMaterialSymbol(modelData.icon ?? "")
                             label: modelData.name
                             onClicked: {
                                 modelData.execute();

--- a/dots/.config/quickshell/ii/services/TaskbarApps.qml
+++ b/dots/.config/quickshell/ii/services/TaskbarApps.qml
@@ -12,6 +12,13 @@ Singleton {
         return Config.options.dock.pinnedApps.indexOf(appId) !== -1;
     }
 
+    function reorderPinned(from, to) {
+        var arr = Config.options.dock.pinnedApps.slice();
+        var item = arr.splice(from, 1)[0];
+        arr.splice(to, 0, item);
+        Config.options.dock.pinnedApps = arr;
+    }
+
     function togglePin(appId) {
         if (root.isPinned(appId)) {
             Config.options.dock.pinnedApps = Config.options.dock.pinnedApps.filter(id => id !== appId)

--- a/dots/.config/quickshell/ii/services/TaskbarApps.qml
+++ b/dots/.config/quickshell/ii/services/TaskbarApps.qml
@@ -27,6 +27,13 @@ Singleton {
         }
     }
 
+    // Keyed by appId so unchanged apps keep the same TaskbarAppEntry identity
+    // across recomputation. Recreating every entry from scratch on each
+    // rebuild (e.g. on every window open/close) made ScriptModel see the
+    // whole dock list as removed+re-added, since it can only diff QObject
+    // values by pointer identity, not by their objectProp.
+    property var _entryCache: new Map()
+
     property list<var> apps: {
         var map = new Map();
 
@@ -57,10 +64,28 @@ Singleton {
             map.get(toplevel.appId.toLowerCase()).toplevels.push(toplevel);
         }
 
+        // Mutate the cache object in place (never reassign root._entryCache)
+        // so this binding doesn't depend on its own writes and loop.
+        var cache = root._entryCache;
         var values = [];
 
         for (const [key, value] of map) {
-            values.push(appEntryComp.createObject(null, { appId: key, toplevels: value.toplevels, pinned: value.pinned }));
+            var entry = cache.get(key);
+            if (entry) {
+                entry.toplevels = value.toplevels;
+                entry.pinned = value.pinned;
+            } else {
+                entry = appEntryComp.createObject(null, { appId: key, toplevels: value.toplevels, pinned: value.pinned });
+                cache.set(key, entry);
+            }
+            values.push(entry);
+        }
+
+        for (const oldKey of cache.keys()) {
+            if (!map.has(oldKey)) {
+                cache.get(oldKey).destroy();
+                cache.delete(oldKey);
+            }
         }
 
         return values;

--- a/sdata/dist-arch/illogical-impulse-quickshell-git/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-quickshell-git/PKGBUILD
@@ -15,7 +15,7 @@ url='https://git.outfoxxed.me/quickshell/quickshell'
 options=(!strip)
 license=('LGPL-3.0-only')
 depends=(
-  'cpptrace'
+  # 'cpptrace'  # not in repos; source doesn't actually use it (grep'd; ldd empty on prior build)
   'jemalloc'
   'mesa'
   'qt6-declarative'
@@ -69,7 +69,8 @@ build() {
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DDISTRIBUTOR="AUR (package: quickshell-git)" \
     -DDISTRIBUTOR_DEBUGINFO_AVAILABLE=NO \
-    -DINSTALL_QML_PREFIX=lib/qt6/qml
+    -DINSTALL_QML_PREFIX=lib/qt6/qml \
+    -DVENDOR_CPPTRACE=TRUE
 
   cmake --build build
 }
@@ -79,4 +80,24 @@ package() {
   cd "$_pkgname"
   DESTDIR="$pkgdir" cmake --install build
   install -Dm644 "LICENSE" -t "$pkgdir/usr/share/licenses/$_pkgname"
+
+  # cpptrace's FetchContent transitively installs libdwarf + zstd artifacts
+  # that conflict with the system packages. cpptrace itself is statically
+  # linked into the quickshell binary, so we only need the binary — strip
+  # everything libdwarf/zstd brought in, plus cpptrace dev files we don't need.
+  rm -f  "$pkgdir/usr/include/dwarf.h" \
+         "$pkgdir/usr/include/libdwarf.h" \
+         "$pkgdir/usr/include/zdict.h" \
+         "$pkgdir/usr/include/zstd.h" \
+         "$pkgdir/usr/include/zstd_errors.h"
+  rm -rf "$pkgdir/usr/include/cpptrace" \
+         "$pkgdir/usr/lib/cmake/cpptrace" \
+         "$pkgdir/usr/lib/cmake/libdwarf" \
+         "$pkgdir/usr/lib/cmake/zstd" \
+         "$pkgdir/usr/share/cpptrace"
+  rm -f  "$pkgdir/usr/lib/libcpptrace.a" \
+         "$pkgdir/usr/lib/libdwarf.a" \
+         "$pkgdir/usr/lib/libzstd.a" \
+         "$pkgdir/usr/lib/pkgconfig/libdwarf.pc" \
+         "$pkgdir/usr/lib/pkgconfig/libzstd.pc"
 }


### PR DESCRIPTION
## Summary

Two dock enhancements:

### 1. Right-click context menu
Right-clicking a dock item opens a context menu with:
- **Desktop entry actions** (from `.desktop` files, e.g. "New Window", "New Incognito Window")
- **Open new instance**
- **Move to workspace** (1-10) — moves all windows of that app
- **Pin / Unpin**
- **Close window(s)**

The dock stays visible while the context menu is open. Uses `HyprlandFocusGrab` to dismiss on outside click.

### 2. Drag-to-reorder pinned apps
Click and drag a pinned dock icon horizontally to reorder it. Displaced icons animate smoothly aside. New order persists to `config.json` on release.

**Implementation:** Uses `transform: Translate { x }` on each delegate rather than ListView move transitions (which don't work well with ScriptModel). The dragged item follows the cursor instantly; displaced items animate via `Behavior on x`. ListView transitions are suppressed during reorder to prevent conflicts.

## Demo

https://github.com/user-attachments/assets/20b577c2-1a0b-4730-9541-d2c90ae6c2eb


## Files changed
- **`TaskbarApps.qml`** — `reorderPinned(from, to)` function
- **`RippleButton.qml`** — `cancelRipple()` function (needed by drag overlay)
- **`DockApps.qml`** — drag state management, context menu integration, preview popup suppression during drag
- **`DockAppButton.qml`** — drag interaction overlay, Translate transforms, visual feedback, context menu wiring
- **`DockContextMenu.qml`** — new file, the full context menu component

## Test plan
- [ ] Clicking a pinned app still activates/cycles windows
- [ ] Right-click opens context menu with correct actions
- [ ] Middle-click still launches new instance
- [ ] Drag a pinned app left/right — other pinned icons shift smoothly
- [ ] Release after drag persists new order in config
- [ ] Dragging doesn't affect separator or unpinned running apps
- [ ] Preview popup doesn't appear during drag
- [ ] Context menu "Move to workspace" moves all app windows
- [ ] Context menu pin/unpin works correctly