### PR TITLE
[SIMPLE REGEX FIX] fix(network): correct regex escaping for Wi-Fi signal strength retrieval

### DIFF
--- a/dots/.config/quickshell/ii/services/Network.qml
+++ b/dots/.config/quickshell/ii/services/Network.qml
@@ -233,7 +233,7 @@ Singleton {
     Process {
         id: updateNetworkStrength
         running: true
-        command: ["sh", "-c", "nmcli -f IN-USE,SIGNAL,SSID device wifi | awk '/^\*/{if (NR!=1) {print $2}}'"]
+        command: ["sh", "-c", "nmcli -f IN-USE,SIGNAL,SSID device wifi | awk '/^\\*/{if (NR!=1) {print $2}}'"]
         stdout: SplitParser {
             onRead: data => {
                 root.networkStrength = parseInt(data);


### PR DESCRIPTION
## 🚀 Describe Your Changes

Fixes an issue where the Wi-Fi icon could appear empty (0 bars) even when a stable connection is active.

---

## 🐛 Root Cause

The `awk` regex in `Network.qml` was written as:

```qml
awk '/^\*/'
```

Because this command is inside a QML/JavaScript string, the backslash is consumed during parsing and the shell actually receives:

```bash
awk '/^*/'
```

This causes `awk` to match **all lines** instead of only the active connection (`*`).  
As a result, non-numeric SSID values are parsed, producing `NaN`. Quickshell converts `NaN` to `0`, which leads to the empty Wi-Fi icon.

---

## ⚠️ Why This Issue Appears Intermittently

This bug depends on how `nmcli` orders nearby networks.

By default, `nmcli` lists networks by signal strength (strongest → weakest).  
Because the broken regex matched every line:

- If the connected network appears **last**, the correct signal value remains → icon looks correct.
- If other networks appear **after** the connected network, their SSIDs overwrite the value → `NaN → 0` → empty icon.

### More likely to occur in:
- environments with many nearby Wi-Fi networks  
- apartment buildings / dense urban areas  
- offices or crowded wireless environments  
- when connected to a strong network (listed near the top)

### Less likely to occur when:
- few networks are nearby  
- the connected network appears last in the list  

---

## ✅ Fix

Escape the backslash so it reaches the shell correctly:

```diff
- awk '/^\*/'
+ awk '/^\\*/'
```

This ensures only the active connection line is matched and the correct signal strength is displayed.

---

## 🧪 How to Test

1. Connect to a Wi-Fi network.
2. Reload Quickshell.
3. Verify the Wi-Fi icon reflects the correct signal strength.

---

## ✔️ Status

- [x] Ready for review
- [ ] Breaking change
- [ ] Documentation update needed