### PR TITLE
refactor(musicRecognition): replace parec/ffmpeg pipeline with songrec listen fix:#3057

### DIFF
--- a/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
+++ b/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-INTERVAL=10
+INTERVAL=2
 TOTAL_DURATION=30
 SOURCE_TYPE="monitor"  # monitor | input
+FIFO=$(mktemp -u /tmp/songrec_out_XXXXXX)
 
 while getopts "i:t:s:" opt; do
   case $opt in
@@ -30,19 +31,25 @@ if [ -z "$AUDIO_DEVICE" ] || ! pactl list short sources | grep -q "$AUDIO_DEVICE
     exit 1
 fi
 
+mkfifo "$FIFO"
+
 cleanup() {
     kill "$SONGREC_PID" 2>/dev/null || true
+    wait "$SONGREC_PID" 2>/dev/null
+    rm -f "$FIFO"
 }
 trap cleanup EXIT
 
-songrec listen --audio-device "$AUDIO_DEVICE" --request-interval "$INTERVAL" --json --disable-mpris | while IFS= read -r line; do
-    if echo "$line" | grep -q '"matches": \['; then
-        echo "$line"
-        kill "$SONGREC_PID" 2>/dev/null || true
-        exit 0
-    fi
-done &
+songrec listen --audio-device "$AUDIO_DEVICE" --request-interval "$INTERVAL" --json --disable-mpris > "$FIFO" &
 SONGREC_PID=$!
 
-sleep "$TOTAL_DURATION"
+( sleep "$TOTAL_DURATION" && kill "$SONGREC_PID" 2>/dev/null ) &
+
+while IFS= read -r line; do
+    if echo "$line" | grep -q '"matches": \['; then
+        echo "$line"
+        exit 0
+    fi
+done < "$FIFO"
+
 exit 0


### PR DESCRIPTION


## Describe your changes
Use `songrec listen --audio-device` instead of manually capturing audio with parec, converting with ffmpeg, and passing to audio-file-to-recognized-song. Drops temp file handling and simplifies the recognition loop.

## It is not ready. Need a professional to review the code.