### PR TITLE
fix(quickshell): fix qs crashing when sidebar is detached while in use

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/SidebarLeft.qml
@@ -67,6 +67,7 @@ Scope { // Scope
 
     onDetachChanged: {
         if (root.detach) {
+            GlobalFocusGrab.removeDismissable(sidebarLoader.item) // Remove sidebar from the focus grab system
             sidebarContent.parent = null; // Detach content from sidebar
             sidebarLoader.active = false; // Unload sidebar
             detachedSidebarLoader.active = true; // Load detached window


### PR DESCRIPTION
This is a small fix that removes the left sidebar from the focus grab system before destroying the panel.

## Describe your changes

Fixes #2841 

## Is it ready? Questions/feedback needed?

Tested it on my system and it doesn't seem to cause any issues. I used Devin to debug and make the fix, so it might need some human polish.