### PR TITLE
fix(quickshell): load extraModels properly in AI sidebar

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -305,14 +305,18 @@ Singleton {
     }
     property ApiStrategy currentApiStrategy: apiStrategies[models[currentModelId]?.api_format || "openai"]
 
+    function addUserModels() {
+        (Config?.options.ai?.extraModels ?? []).forEach(model => {
+            const safeModelName = root.safeModelName(model["model"]);
+            root.addModel(safeModelName, model)
+        });
+    }
+
     Connections {
         target: Config
         function onReadyChanged() {
             if (!Config.ready) return;
-            (Config?.options.ai?.extraModels ?? []).forEach(model => {
-                const safeModelName = root.safeModelName(model["model"]);
-                root.addModel(safeModelName, model)
-            });
+            root.addUserModels()
         }
     }
 
@@ -321,13 +325,7 @@ Singleton {
 
     Component.onCompleted: {
         setModel(currentModelId, false, false); // Do necessary setup for model
-        // Load extra models from config (onReadyChanged may not fire if Config is already ready)
-        if (Config?.options?.ai?.extraModels) {
-            Config.options.ai.extraModels.forEach(model => {
-                const safeModelName = root.safeModelName(model["model"]);
-                root.addModel(safeModelName, model)
-            });
-        }
+        root.addUserModels() // Config onReadyChanged above might not fire if config is loaded before this service
     }
 
     function guessModelLogo(model) {


### PR DESCRIPTION
## Summary
Fix extraModels from config.json not showing up in AI sidebar model selection.
## Root cause
1. `addModel()` was directly assigning to `root.models[modelName]`, which doesn't trigger QML binding recalculation
2. `onReadyChanged` signal doesn't fire when Config is already ready before Ai component loads
## Fix
- Use `Object.assign()` to create new object reference, triggering QML binding
- Load extraModels in `Component.onCompleted` as fallback
## Testing
Added model in `~/.config/illogical-impulse/config.json` → extraModels now shows in sidebar
Fixes #2073