### PR TITLE
theming: kitty theme without terminal escape codes

### DIFF
--- a/dots/.config/kitty/kitty.conf
+++ b/dots/.config/kitty/kitty.conf
@@ -1,3 +1,6 @@
+# Theming
+include ~/.local/state/quickshell/user/generated/terminal/kitty-theme.conf
+
 # Font
 font_family      JetBrains Mono Nerd Font
 font_size 11.0

--- a/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
@@ -27,7 +27,22 @@ IFS=$'\n'
 colorlist=($colornames)     # Array of color names
 colorvalues=($colorstrings) # Array of color values
 
-apply_term() {
+apply_kitty() {  
+  # Check if terminal escape sequence template exists
+  if [ ! -f "$SCRIPT_DIR/terminal/kitty-theme.conf" ]; then
+    echo "Template file not found for Kitty theme. Skipping that."
+    return
+  fi
+  # Copy template
+  mkdir -p "$STATE_DIR"/user/generated/terminal
+  cp "$SCRIPT_DIR/terminal/kitty-theme.conf" "$STATE_DIR"/user/generated/terminal/kitty-theme.conf
+  # Apply colors
+  for i in "${!colorlist[@]}"; do
+    sed -i "s/${colorlist[$i]} #/${colorvalues[$i]#\#}/g" "$STATE_DIR"/user/generated/terminal/kitty-theme.conf
+  done
+}
+
+apply_anyterm() {
   # Check if terminal escape sequence template exists
   if [ ! -f "$SCRIPT_DIR/terminal/sequences.txt" ]; then
     echo "Template file not found for Terminal. Skipping that."
@@ -50,6 +65,11 @@ apply_term() {
       } & disown || true
     fi
   done
+}
+
+apply_term() {
+  apply_kitty
+  apply_anyterm
 }
 
 apply_qt() {

--- a/dots/.config/quickshell/ii/scripts/colors/terminal/kitty-theme.conf
+++ b/dots/.config/quickshell/ii/scripts/colors/terminal/kitty-theme.conf
@@ -1,0 +1,27 @@
+background            #$term0 #
+
+color0                #$term0 #
+color1                #$term1 #
+color2                #$term2 #
+color3                #$term3 #
+color4                #$term4 #
+color5                #$term5 #
+color6                #$term6 #
+color7                #$term7 #
+color8                #$term8 #
+color9                #$term9 #
+color10               #$term10 #
+color11               #$term11 #
+color12               #$term12 #
+color13               #$term13 #
+color14               #$term14 #
+color15               #$term15 #
+
+color232              #$term7 #
+
+cursor                #$term7 #
+
+foreground            #$term7 #
+
+selection_background  #$term7 #
+selection_foreground  #$term0 #


### PR DESCRIPTION
Fixes #2992 

## Describe your changes

Up until now, colors were applied with the help of terminal escape codes, ran from the fish config. This still happens (so theming will still kinda also work for other terminals), but, for kitty specifically, I've also added a way to apply the theme on startup, without the need for loading the fish config.

In `applycolor.sh`, before the terminal color sequences are applied, an attempt is also made to create a special kitty theming config file, `kitty-theme.conf`, also in the `~/.local/state/quickshell/user/generated/terminal` folder. This makes it so that the kitty theme is applied as soon as the terminal appears on the screen.

Note: the "alpha" component in the `applycolor.sh` didn't seem to work before either, as there was nothing suitable to replace in the terminal sequences template file. So, I haven't implemented it for kitty either. Users could still manually add a `background_opacity` setting to their `kitty.conf` (after including the special `kitty-theme.conf` file). For example, if you want their terminal to be 80% opaque (20% transparent), you could add:
`background_opacity 0.8`
to the `kitty.conf`.

## Is it ready? Questions/feedback needed?

It's ready, waiting for any possible feedback!
