### PR TITLE
click-to-mute on app icons in the volume mixer

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
@@ -7,10 +7,8 @@ import Quickshell
 import Quickshell.Services.Pipewire
 import Qt5Compat.GraphicalEffects
 
-MouseArea {
+Item {
     id: root
-    cursorShape: Qt.PointingHandCursor
-    onClicked: root.node.audio.muted = !root.node.audio.muted
     required property PwNode node
     PwObjectTracker {
         objects: [root.node]
@@ -23,11 +21,20 @@ MouseArea {
         anchors.fill: parent
         spacing: 6
 
-        Item {
+        MouseArea {
             property real size: 36
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.preferredWidth: size
             Layout.preferredHeight: size
+
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.node.audio.muted = !root.node.audio.muted
+
+            hoverEnabled: true
+            property bool hovered: containsMouse
+            StyledToolTip {
+                text: root.node?.audio.muted ? Translation.tr("Click to unmute") : Translation.tr("Click to mute")
+            }
 
             Image {
                 id: iconImg


### PR DESCRIPTION
## Describe your changes
This PR introduces the ability to selectively mute individual app audio streams directly from the Volume Mixer overlay without lowering their volume sliders. This preserves their original volume levels when unmuting.

<img width="353" height="294" alt="image" src="https://github.com/user-attachments/assets/12436d91-b000-49fc-a808-3567547976ab" />
<img width="359" height="303" alt="image" src="https://github.com/user-attachments/assets/7d40a094-4ae1-4ab7-947d-3b2f24d9ec42" />


## Is it ready? Questions/feedback needed?
Yes, it is fully tested and ready to merge
