### PR TITLE
Clear text input on searchWidget.cancelSearch();

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -37,7 +37,7 @@ Item { // Wrapper
     }
 
     function cancelSearch() {
-        searchBar.searchInput.selectAll();
+        searchBar.searchInput.text = "";
         LauncherSearch.query = "";
         searchBar.animateWidth = true;
     }


### PR DESCRIPTION
I sometimes used windows + V to open history panel. After a while, if I pressed windows key and used arrow keys to change workspace, it would move cursor on text input panel instead of changing workspace. I think we should disable one of them when we use arrow keys: changing workspace or editing input text. This change will remove input text automatically.
