### PR TITLE
Add XWayland configuration to fix blurry fonts while using fractional scale

### DIFF
--- a/dots/.config/hypr/hyprland/general.conf
+++ b/dots/.config/hypr/hyprland/general.conf
@@ -166,3 +166,6 @@ cursor {
     hotspot_padding = 1
 }
 
+xwayland {
+  force_zero_scaling = true
+}


### PR DESCRIPTION
It will disable windows scaling on xwayland software to prevent blurry fonts. Source: https://wiki.hypr.land/Configuring/XWayland/
