### PR TITLE
Update gtk4 styles for Material 3 Expressive

### DIFF
--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -266,6 +266,7 @@ banner widget {
 }
 
 .boxed-list {
+  box-shadow: none;
   background-color: @window_bg_color;
 }
 

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -7,6 +7,7 @@
     /* Accents */
     @define-color accent_color {{colors.primary.light.hex}};
     @define-color accent_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.08);
+    @define-color accent_vibrant_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.14);
     @define-color accent_active_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.1);
     @define-color accent_fg_color {{colors.on_primary.light.hex}};
     @define-color accent_bg_color {{colors.primary.light.hex}};
@@ -53,6 +54,7 @@
     /* Accents */
     @define-color accent_color {{colors.primary.dark.hex}};
     @define-color accent_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.08);
+    @define-color accent_vibrant_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.14);
     @define-color accent_active_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.1);
     @define-color accent_fg_color {{colors.on_primary.dark.hex}};
     @define-color accent_bg_color {{colors.primary.dark.hex}};

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -378,7 +378,7 @@ switch:checked slider {
 
 toast {
   border-radius: 999px;
-  padding: 3px 6px;
+  padding: 3px 3px 3px 6px;
   background-color: @inverse_surface;
   color: @inverse_on_surface;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -1,6 +1,6 @@
 /*
-* GTK Colors
-* Generated with Matugen
+* GTK colors generated with Matugen
+* The source template is here: ~/.config/matugen/templates/gtk-4.0/gtk.css
 */
 
 @media (prefers-color-scheme: light) {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -470,10 +470,10 @@ modelbutton:hover {
 }
 
 tooltip {
-  background-color: #e3e1e9;
+  background-color: @inverse_surface;
+  color: @inverse_on_surface;
   font-size: 11px;
   padding: 5px 9px;
-  color: #393a40;
 }
 
 /* search */

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -52,6 +52,9 @@
 
     @define-color scrollbar_color {{colors.outline.light.hex}};
     @define-color scrollbar_hover_color {{colors.outline_variant.light.hex}};
+
+    /* Material */
+    @define-color outline {{colors.outline.light.hex}};
 }
 
 @media (prefers-color-scheme: dark) {
@@ -103,6 +106,9 @@
 
     @define-color scrollbar_color {{colors.outline.dark.hex}};
     @define-color scrollbar_hover_color {{colors.outline_variant.dark.hex}};
+
+    /* Material */
+    @define-color outline {{colors.outline.dark.hex}};
 }
 
 * {
@@ -345,7 +351,7 @@ button.back:active {
 
 switch {
   background: @secondary_sidebar_bg_color;
-  border: #90878f 2px solid;
+  border: @outline 2px solid;
   padding: 0;
 }
 
@@ -355,8 +361,8 @@ switch:checked {
 }
 
 switch slider {
-  background: #90878f;
-  margin: 2px;
+  background: @outline;
+  margin: 3px;
   min-width: 0;
   min-height: 0;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -154,13 +154,12 @@ viewswitcher button:hover {
 }
 
 #NautilusPathBar #NautilusPathButton.current-dir.current-dir {
-	background: @accent_bg_color;
-	color: @accent_fg_color;
+	background: @accent_active_color;
 	border-radius: 999px;
 }
 
 #NautilusPathBar #NautilusPathButton.current-dir.current-dir * {
-	color: @accent_fg_color;
+	color: @sidebar_row_active_fg_color;
 	opacity: 1;
 }
 

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -378,9 +378,13 @@ switch:checked slider {
 
 toast {
   border-radius: 999px;
-  padding: 6px;
+  padding: 3px 6px;
   background-color: @inverse_surface;
   color: @inverse_on_surface;
+}
+
+toast .heading {
+  font-weight: 400;
 }
 
 toast button {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -47,14 +47,19 @@
     @define-color dialog_fg_color {{colors.on_surface.light.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.light.hex}};
     @define-color thumbnail_fg_color {{colors.on_surface.light.hex}};
-    @define-color toast_bg_color {{colors.primary_container.light.hex}};
-    @define-color toast_gg_color {{colors.on_primary_container.light.hex}};
-
-    @define-color scrollbar_color {{colors.outline.light.hex}};
-    @define-color scrollbar_hover_color {{colors.outline_variant.light.hex}};
 
     /* Material */
+    @define-color inverse_on_surface {{colors.inverse_on_surface.light.hex}};
+    @define-color inverse_primary {{colors.inverse_primary.light.hex}};
+    @define-color inverse_surface {{colors.inverse_surface.light.hex}};
+
     @define-color outline {{colors.outline.light.hex}};
+
+    /* Material state layers */
+    @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.08);
+    @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.18);
+    @define-color inverse_primary_hover rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.08);
+    @define-color inverse_primary_active rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.18);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -101,14 +106,19 @@
     @define-color dialog_fg_color {{colors.on_surface.dark.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.dark.hex}};
     @define-color thumbnail_fg_color {{colors.on_surface.dark.hex}};
-    @define-color toast_bg_color {{colors.primary_container.dark.hex}};
-    @define-color toast_gg_color {{colors.on_primary_container.dark.hex}};
-
-    @define-color scrollbar_color {{colors.outline.dark.hex}};
-    @define-color scrollbar_hover_color {{colors.outline_variant.dark.hex}};
 
     /* Material */
+    @define-color inverse_on_surface {{colors.inverse_on_surface.dark.hex}};
+    @define-color inverse_primary {{colors.inverse_primary.dark.hex}};
+    @define-color inverse_surface {{colors.inverse_surface.dark.hex}};
+
     @define-color outline {{colors.outline.dark.hex}};
+
+    /* Material state layers */
+    @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.08);
+    @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.18);
+    @define-color inverse_primary_hover rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.08);
+    @define-color inverse_primary_active rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.18);
 }
 
 * {
@@ -356,16 +366,35 @@ switch:checked slider {
 /* toast */
 
 toast {
-  border-radius: 999px;
-  padding: 2px 6px;
-  margin: 8px;
-  background-color: @toast_bg_color;
-  color: @toast_fg_color;
+  border-radius: 4px;
+  padding: 6px;
+  background-color: @inverse_surface;
+  color: @inverse_on_surface;
 }
 
-toast * {
-  font-weight: 400;
-  font-size: 12px;
+toast button {
+  background-color: transparent;
+  color: @inverse_primary;
+}
+
+toast button:hover {
+  background-color: @inverse_primary_hover;
+}
+
+toast button:active {
+  background-color: @inverse_primary_active;
+}
+
+toast button:last-child {
+  color: @inverse_on_surface;
+}
+
+toast button:last-child:hover {
+  background-color: @inverse_on_surface_hover;
+}
+
+toast button:last-child:active {
+  background-color: @inverse_on_surface_active;
 }
 
 .collapse-spacing.vertical {
@@ -443,5 +472,5 @@ tooltip {
 	padding: 0;
 }
 .image-button.flat arrow {
-background: transparent;
+  background: transparent;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -452,9 +452,24 @@ tab:selected .tab-title label {
 
 /* popup menu */
 
+popover listview.view row,
+popover listview.view row:first-child,
+popover listview.view row:last-child {
+  background: transparent;
+  border-radius: 8px;
+}
+
 popover contents,
 popover arrow {
   background: @secondary_sidebar_bg_color;
+}
+
+popover listview.view row:hover {
+  background: @popover_fg_hover_color;
+}
+
+popover listview.view row:active {
+  background: @popover_fg_active_color;
 }
 
 modelbutton {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -399,7 +399,7 @@ switch:checked slider {
 
 toast {
   border-radius: 999px;
-  padding: 3px 3px 3px 6px;
+  padding: 6px 6px 6px 10px;
   background-color: @inverse_surface;
   color: @inverse_on_surface;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -7,8 +7,9 @@
     /* Accents */
     @define-color accent_color {{colors.primary.light.hex}};
     @define-color accent_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.08);
-    @define-color accent_vibrant_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.14);
+    @define-color accent_vibrant_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.18);
     @define-color accent_active_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.1);
+    @define-color accent_vibrant_active_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.26);
     @define-color accent_fg_color {{colors.on_primary.light.hex}};
     @define-color accent_bg_color {{colors.primary.light.hex}};
     @define-color destructive_bg_color {{colors.error_container.light.hex}};
@@ -48,14 +49,18 @@
     @define-color thumbnail_fg_color {{colors.on_surface.light.hex}};
     @define-color toast_bg_color {{colors.primary_container.light.hex}};
     @define-color toast_gg_color {{colors.on_primary_container.light.hex}};
+
+    @define-color scrollbar_color {{colors.outline.light.hex}};
+    @define-color scrollbar_hover_color {{colors.outline_variant.light.hex}};
 }
 
 @media (prefers-color-scheme: dark) {
     /* Accents */
     @define-color accent_color {{colors.primary.dark.hex}};
     @define-color accent_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.08);
-    @define-color accent_vibrant_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.14);
+    @define-color accent_vibrant_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.18);
     @define-color accent_active_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.1);
+    @define-color accent_vibrant_active_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.2);
     @define-color accent_fg_color {{colors.on_primary.dark.hex}};
     @define-color accent_bg_color {{colors.primary.dark.hex}};
     @define-color destructive_bg_color {{colors.error_container.dark.hex}};
@@ -95,10 +100,33 @@
     @define-color thumbnail_fg_color {{colors.on_surface.dark.hex}};
     @define-color toast_bg_color {{colors.primary_container.dark.hex}};
     @define-color toast_gg_color {{colors.on_primary_container.dark.hex}};
+
+    @define-color scrollbar_color {{colors.outline.dark.hex}};
+    @define-color scrollbar_hover_color {{colors.outline_variant.dark.hex}};
 }
 
 window {
   background: @window_bg_color;
+}
+
+scrollbar * {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+ 
+
+scrollbar slider {
+  background: @scrollbar_color;
+  border-radius: 999px;
+  min-width: 4px;
+}
+
+scrollbar trough {
+  background: transparent;
+  padding: 1px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .text-button {
@@ -127,8 +155,20 @@ window {
   margin-right: 2px;
 }
 
+.nautilus-window headerbar button:hover {
+  background: @accent_hover_color;
+}
+
+.nautilus-window headerbar button:active {
+  background: @accent_active_color;
+}
+
 #NautilusPathBar #NautilusPathButton:hover {
   background: @accent_vibrant_hover_color;
+}
+
+#NautilusPathBar #NautilusPathButton:active {
+  background: @accent_vibrant_active_color;
 }
 
 #NautilusPathBar {
@@ -160,8 +200,25 @@ window {
   opacity: 100%;
 }
 
+#NautilusPathBar button {
+  border-radius: 8px;
+}
+
+
+#NautilusPathBar button:checked {
+  background: @accent_vibrant_hover_color;
+}
+
+headerbar >windowhandle box stack > box:nth-child(2) {
+	background: @accent_active_color;
+	border-radius: 8px;
+}
+
 .nautilus-list-view,
 .nautilus-grid-view {
+  
+  /* search */
+  
   background: @secondary_sidebar_bg_color;
   border-radius: 16px;
 }
@@ -367,7 +424,8 @@ tab:selected .tab-title label {
 
 /* popup menu */
 
-popover contents {
+popover contents,
+popover arrow {
   background: @secondary_sidebar_bg_color;
 }
 
@@ -388,4 +446,13 @@ tooltip {
   font-size: 11px;
   padding: 5px 9px;
   color: #393a40;
+}
+
+/* search */
+
+.entry-completion.entry-completion.entry-completion contents {
+	padding: 0;
+}
+.image-button.flat arrow {
+background: transparent;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -138,6 +138,28 @@ window {
   font-weight: 500;
 }
 
+splitbutton {
+  background-color: transparent;
+}
+
+splitbutton button {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+splitbutton separator {
+  color: transparent;
+}
+
+splitbutton menubutton {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
 .popup-menu-item {
   background-color: transparent;
   border-radius: 999px;

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -43,7 +43,6 @@
     @define-color popover_bg_color {{colors.surface_container_highest.light.hex}};
     @define-color popover_fg_color {{colors.on_surface.light.hex}};
     @define-color popover_fg_hover_color rgba({{colors.on_surface.light.red}}, {{colors.on_surface.light.green}}, {{colors.on_surface.light.blue}}, 0.08);
-    @define-color popover_fg_active_color rgba({{colors.on_surface.light.red}}, {{colors.on_surface.light.green}}, {{colors.on_surface.light.blue}}, 0.18);
     @define-color dialog_bg_color {{colors.surface_container_high.light.hex}};
     @define-color dialog_fg_color {{colors.on_surface.light.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.light.hex}};
@@ -54,15 +53,13 @@
     @define-color inverse_primary {{colors.inverse_primary.light.hex}};
     @define-color inverse_surface {{colors.inverse_surface.light.hex}};
 
-    @define-color on_surface {{colors.on_surface.light.hex}};
     @define-color outline {{colors.outline.light.hex}};
-    @define-color surface_container_high {{colors.surface_container_high.light.hex}};
 
     /* Material state layers */
     @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.08);
     @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.18);
-    @define-color inverse_on_primary_hover rgba({{colors.on_inverse_primary.light.red}}, {{colors.on_inverse_primary.light.green}}, {{colors.on_inverse_primary.light.blue}}, 0.08);
-    @define-color inverse_on_primary_active rgba({{colors.on_inverse_primary.light.red}}, {{colors.on_inverse_primary.light.green}}, {{colors.on_inverse_primary.light.blue}}, 0.18);
+    @define-color inverse_primary_hover rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.08);
+    @define-color inverse_primary_active rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.18);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -105,7 +102,6 @@
     @define-color popover_bg_color {{colors.surface_container_highest.dark.hex}};
     @define-color popover_fg_color {{colors.on_surface.dark.hex}};
     @define-color popover_fg_hover_color rgba({{colors.on_surface.dark.red}}, {{colors.on_surface.dark.green}}, {{colors.on_surface.dark.blue}}, 0.08);
-    @define-color popover_fg_active_color rgba({{colors.on_surface.dark.red}}, {{colors.on_surface.dark.green}}, {{colors.on_surface.dark.blue}}, 0.18);
     @define-color dialog_bg_color {{colors.surface_container_high.dark.hex}};
     @define-color dialog_fg_color {{colors.on_surface.dark.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.dark.hex}};
@@ -116,15 +112,13 @@
     @define-color inverse_primary {{colors.inverse_primary.dark.hex}};
     @define-color inverse_surface {{colors.inverse_surface.dark.hex}};
 
-    @define-color on_surface {{colors.on_surface.dark.hex}};
     @define-color outline {{colors.outline.dark.hex}};
-    @define-color surface_container_high {{colors.surface_container_high.dark.hex}};
 
     /* Material state layers */
     @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.08);
     @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.18);
-    @define-color inverse_on_primary_hover rgba({{colors.on_inverse_primary.dark.red}}, {{colors.on_inverse_primary.dark.green}}, {{colors.on_inverse_primary.dark.blue}}, 0.08);
-    @define-color inverse_on_primary_active rgba({{colors.on_inverse_primary.dark.red}}, {{colors.on_inverse_primary.dark.green}}, {{colors.on_inverse_primary.dark.blue}}, 0.18);
+    @define-color inverse_primary_hover rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.08);
+    @define-color inverse_primary_active rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.18);
 }
 
 * {
@@ -394,11 +388,11 @@ toast button {
 }
 
 toast button:hover {
-  background-color: @inverse_on_primary_hover;
+  background-color: @inverse_primary_hover;
 }
 
 toast button:active {
-  background-color: @inverse_on_primary_active;
+  background-color: @inverse_primary_active;
 }
 
 toast button:last-child {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -43,6 +43,7 @@
     @define-color popover_bg_color {{colors.surface_container_highest.light.hex}};
     @define-color popover_fg_color {{colors.on_surface.light.hex}};
     @define-color popover_fg_hover_color rgba({{colors.on_surface.light.red}}, {{colors.on_surface.light.green}}, {{colors.on_surface.light.blue}}, 0.08);
+    @define-color popover_fg_active_color rgba({{colors.on_surface.light.red}}, {{colors.on_surface.light.green}}, {{colors.on_surface.light.blue}}, 0.18);
     @define-color dialog_bg_color {{colors.surface_container_high.light.hex}};
     @define-color dialog_fg_color {{colors.on_surface.light.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.light.hex}};
@@ -53,13 +54,15 @@
     @define-color inverse_primary {{colors.inverse_primary.light.hex}};
     @define-color inverse_surface {{colors.inverse_surface.light.hex}};
 
+    @define-color on_surface {{colors.on_surface.light.hex}};
     @define-color outline {{colors.outline.light.hex}};
+    @define-color surface_container_high {{colors.surface_container_high.light.hex}};
 
     /* Material state layers */
     @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.08);
     @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.light.red}}, {{colors.inverse_on_surface.light.green}}, {{colors.inverse_on_surface.light.blue}}, 0.18);
-    @define-color inverse_primary_hover rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.08);
-    @define-color inverse_primary_active rgba({{colors.inverse_primary.light.red}}, {{colors.inverse_primary.light.green}}, {{colors.inverse_primary.light.blue}}, 0.18);
+    @define-color inverse_on_primary_hover rgba({{colors.on_inverse_primary.light.red}}, {{colors.on_inverse_primary.light.green}}, {{colors.on_inverse_primary.light.blue}}, 0.08);
+    @define-color inverse_on_primary_active rgba({{colors.on_inverse_primary.light.red}}, {{colors.on_inverse_primary.light.green}}, {{colors.on_inverse_primary.light.blue}}, 0.18);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -102,6 +105,7 @@
     @define-color popover_bg_color {{colors.surface_container_highest.dark.hex}};
     @define-color popover_fg_color {{colors.on_surface.dark.hex}};
     @define-color popover_fg_hover_color rgba({{colors.on_surface.dark.red}}, {{colors.on_surface.dark.green}}, {{colors.on_surface.dark.blue}}, 0.08);
+    @define-color popover_fg_active_color rgba({{colors.on_surface.dark.red}}, {{colors.on_surface.dark.green}}, {{colors.on_surface.dark.blue}}, 0.18);
     @define-color dialog_bg_color {{colors.surface_container_high.dark.hex}};
     @define-color dialog_fg_color {{colors.on_surface.dark.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.dark.hex}};
@@ -112,13 +116,15 @@
     @define-color inverse_primary {{colors.inverse_primary.dark.hex}};
     @define-color inverse_surface {{colors.inverse_surface.dark.hex}};
 
+    @define-color on_surface {{colors.on_surface.dark.hex}};
     @define-color outline {{colors.outline.dark.hex}};
+    @define-color surface_container_high {{colors.surface_container_high.dark.hex}};
 
     /* Material state layers */
     @define-color inverse_on_surface_hover rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.08);
     @define-color inverse_on_surface_active rgba({{colors.inverse_on_surface.dark.red}}, {{colors.inverse_on_surface.dark.green}}, {{colors.inverse_on_surface.dark.blue}}, 0.18);
-    @define-color inverse_primary_hover rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.08);
-    @define-color inverse_primary_active rgba({{colors.inverse_primary.dark.red}}, {{colors.inverse_primary.dark.green}}, {{colors.inverse_primary.dark.blue}}, 0.18);
+    @define-color inverse_on_primary_hover rgba({{colors.on_inverse_primary.dark.red}}, {{colors.on_inverse_primary.dark.green}}, {{colors.on_inverse_primary.dark.blue}}, 0.08);
+    @define-color inverse_on_primary_active rgba({{colors.on_inverse_primary.dark.red}}, {{colors.on_inverse_primary.dark.green}}, {{colors.on_inverse_primary.dark.blue}}, 0.18);
 }
 
 * {
@@ -376,7 +382,7 @@ switch:checked slider {
 /* toast */
 
 toast {
-  border-radius: 4px;
+  border-radius: 999px;
   padding: 6px;
   background-color: @inverse_surface;
   color: @inverse_on_surface;
@@ -388,11 +394,11 @@ toast button {
 }
 
 toast button:hover {
-  background-color: @inverse_primary_hover;
+  background-color: @inverse_on_primary_hover;
 }
 
 toast button:active {
-  background-color: @inverse_primary_active;
+  background-color: @inverse_on_primary_active;
 }
 
 toast button:last-child {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -1,11 +1,13 @@
 /*
-* GTK colors generated with Matugen
-* The source template is here: ~/.config/matugen/templates/gtk-4.0/gtk.css
+* GTK Colors
+* Generated with Matugen
 */
 
 @media (prefers-color-scheme: light) {
     /* Accents */
     @define-color accent_color {{colors.primary.light.hex}};
+    @define-color accent_hover_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.08);
+    @define-color accent_active_color rgba({{colors.primary.light.red}}, {{colors.primary.light.green}}, {{colors.primary.light.blue}}, 0.1);
     @define-color accent_fg_color {{colors.on_primary.light.hex}};
     @define-color accent_bg_color {{colors.primary.light.hex}};
     @define-color destructive_bg_color {{colors.error_container.light.hex}};
@@ -22,11 +24,13 @@
     @define-color headerbar_fg_color {{colors.on_surface.light.hex}};
     @define-color card_bg_color {{colors.surface_container.light.hex}};
     @define-color card_fg_color {{colors.on_surface.light.hex}};
-    @define-color sidebar_bg_color {{colors.surface_container.light.hex}};
+    @define-color sidebar_bg_color {{colors.background.light.hex}};
     @define-color sidebar_fg_color {{colors.on_surface.light.hex}};
+    @define-color sidebar_row_active_bg_color {{colors.secondary_container.light.hex}};
+    @define-color sidebar_row_active_fg_color {{colors.on_secondary_container.light.hex}};
     @define-color secondary_sidebar_bg_color {{colors.surface_container_low.light.hex}};
     @define-color secondary_sidebar_backdrop_color {{colors.surface_container_low.light.hex}};
-    @define-color secondary_sidebar_fg_color {{colors.on_surface.light.hex}};
+    @define-color secondary_sidebar_fg_color {{colors.on_surface_variant.light.hex}};
     @define-color sidebar_border_color @sidebar_bg_color;
     @define-color sidebar_backdrop_color @sidebar_bg_color;
     @define-color view_bg_color {{colors.surface_container_lowest.light.hex}};
@@ -40,12 +44,15 @@
     @define-color dialog_fg_color {{colors.on_surface.light.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.light.hex}};
     @define-color thumbnail_fg_color {{colors.on_surface.light.hex}};
+    @define-color toast_bg_color {{colors.primary_container.light.hex}};
+    @define-color toast_gg_color {{colors.on_primary_container.light.hex}};
 }
 
 @media (prefers-color-scheme: dark) {
-
     /* Accents */
     @define-color accent_color {{colors.primary.dark.hex}};
+    @define-color accent_hover_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.08);
+    @define-color accent_active_color rgba({{colors.primary.dark.red}}, {{colors.primary.dark.green}}, {{colors.primary.dark.blue}}, 0.1);
     @define-color accent_fg_color {{colors.on_primary.dark.hex}};
     @define-color accent_bg_color {{colors.primary.dark.hex}};
     @define-color destructive_bg_color {{colors.error_container.dark.hex}};
@@ -62,11 +69,13 @@
     @define-color headerbar_fg_color {{colors.on_surface.dark.hex}};
     @define-color card_bg_color {{colors.surface_container.dark.hex}};
     @define-color card_fg_color {{colors.on_surface.dark.hex}};
-    @define-color sidebar_bg_color {{colors.surface_container.dark.hex}};
+    @define-color sidebar_bg_color {{colors.background.dark.hex}};
     @define-color sidebar_fg_color {{colors.on_surface.dark.hex}};
+    @define-color sidebar_row_active_bg_color {{colors.secondary_container.dark.hex}};
+    @define-color sidebar_row_active_fg_color {{colors.on_secondary_container.dark.hex}};
     @define-color secondary_sidebar_bg_color {{colors.surface_container_low.dark.hex}};
     @define-color secondary_sidebar_backdrop_color {{colors.surface_container_low.dark.hex}};
-    @define-color secondary_sidebar_fg_color {{colors.on_surface.dark.hex}};
+    @define-color secondary_sidebar_fg_color {{colors.on_surface_variant.dark.hex}};
     @define-color sidebar_border_color @sidebar_bg_color;
     @define-color sidebar_backdrop_color @sidebar_bg_color;
     @define-color view_bg_color {{colors.surface_container_lowest.dark.hex}};
@@ -80,4 +89,241 @@
     @define-color dialog_fg_color {{colors.on_surface.dark.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.dark.hex}};
     @define-color thumbnail_fg_color {{colors.on_surface.dark.hex}};
+    @define-color toast_bg_color {{colors.primary_container.dark.hex}};
+    @define-color toast_gg_color {{colors.on_primary_container.dark.hex}};
+}
+
+window {
+  background: @window_bg_color;
+}
+
+viewswitcher button {
+  padding: 6px 0;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 999px;
+}
+
+viewswitcher button:hover {
+  background-color: @accent_hover_color;
+}
+
+.text-button {
+	border-radius: 999px;
+}
+
+.text-button, .text-button * {
+	font-weight: 500;
+}
+
+.popup-menu-item {
+  background-color: transparent;
+  border-radius: 999px;
+}
+
+#NautilusPathBar #NautilusPathButton * {
+	color: @accent_color;
+	font-weight: 400;
+}
+
+#NautilusPathBar #NautilusPathButton {
+	background: @secondary_sidebar_bg_color;
+	border-radius: 4px;
+	margin: 0;
+	margin-right: 2px;
+}
+
+#NautilusPathBar #NautilusPathButton:hover {
+	background: @accent_hover_color;
+}
+
+#NautilusPathBar #NautilusPathButton:active {
+	background: @accent_active_color;
+}
+
+#NautilusPathBar {
+	background: transparent;
+}
+
+#NautilusPathBar box box:first-child #NautilusPathButton {
+	border-radius: 24px 4px 4px 24px;
+}
+
+#NautilusPathBar box box:last-child #NautilusPathButton {
+	border-radius: 4px 24px 24px 4px;
+}
+
+#NautilusPathBar #NautilusPathButton.current-dir.current-dir {
+	background: @accent_bg_color;
+	color: @accent_fg_color;
+	border-radius: 999px;
+}
+
+#NautilusPathBar #NautilusPathButton.current-dir.current-dir * {
+	color: @accent_fg_color;
+	opacity: 1;
+}
+
+#NautilusPathBar .dim-label {
+	font-size: 0;
+}
+
+#NautilusPathBar button .dim-label {
+	font-size: 14px;
+	opacity: 100%;
+}
+
+.nautilus-list-view, .nautilus-grid-view {
+    background: @secondary_sidebar_bg_color;
+    border-radius: 16px;
+}
+
+.navigation-sidebar row * {
+  color: @sidebar_fg_color;
+	font-weight: 500;
+	font-size: 13px;
+}
+
+.navigation-sidebar row {
+	border-radius: 999px;
+}
+
+.navigation-sidebar row:hover {
+	background: @accent_hover_color;
+}
+
+.navigation-sidebar row:active {
+	background: @accent_active_color;
+}
+
+.navigation-sidebar row:selected {
+	background: @sidebar_row_active_bg_color;
+}
+
+.navigation-sidebar row:selected * {
+	color: @sidebar_row_active_fg_color;
+}
+
+banner widget {
+	border-radius: 16px 0 0 16px;
+	margin-bottom: 8px;
+	background-color: @secondary_sidebar_bg_color;
+}
+
+.boxed-list {
+  background-color: @window_bg_color;
+}
+
+.boxed-list row {
+	background: @card_bg_color;
+	border-radius: 4px;
+	border: none;
+	margin-bottom: 2px;
+}
+
+.boxed-list row.activatable:hover {
+	background-color: @accent_hover_color;
+}
+
+.boxed-list row.activatable:active {
+	background-color: @accent_active_color;
+}
+
+.boxed-list row:insensitive {
+	background-color: @card_bg_color; 
+}
+
+.text-button.toggle {
+	border-radius: 4px;
+}
+
+.text-button.toggle * {
+	font-weight: 500;
+}
+
+.boxed-list row:first-child {
+	border-radius: 16px 16px 4px 4px;
+}
+
+.boxed-list row:last-child {
+	border-radius: 4px 4px 16px 16px;
+	margin-bottom: 0;
+}
+
+.text-button.toggle:first-child {
+	border-radius: 16px 4px 4px 16px;
+}
+
+.text-button.toggle:last-child {
+	border-radius: 4px 16px 16px 4px;
+}
+
+.boxed-list row:first-child:last-child,
+.text-button.toggle:first-child:last-child {
+	border-radius: 16px;
+}
+
+.text-button.toggle:checked {
+	background-color: @accent_bg_color;
+	border-radius: 999px;
+	color: @accent_fg_color;
+}
+
+button.back {
+	border-radius: 999px;
+	background-color: @secondary_sidebar_bg_color;
+	padding-left: 4px;
+	padding-right: 6px;
+}
+
+button.back * {
+	font-size: 12px;
+}
+
+button.back:hover {
+	background-color: @accent_hover_color;
+}
+
+button.back:active {
+	background-color: @accent_active_color;
+}
+
+/* switch */
+
+switch {
+	background: @secondary_sidebar_bg_color;
+	border: #90878f 2px solid;
+	padding: 0;
+}
+
+switch:checked {
+	background: @accent_color;
+	border-color: @accent_color;
+}
+
+slider {
+	background: #90878f;
+	border: @secondary_sidebar_bg_color 2px solid;
+	min-width: 4px;
+	min-height: 4px;
+}
+
+switch:checked slider {
+	background: @accent_fg_color;
+	border: none;
+}
+
+/* toast */
+
+toast {
+	border-radius: 999px;
+	padding: 2px 6px;
+	margin: 8px;
+	background-color: @toast_bg_color;
+	color: @toast_fg_color;
+}
+
+toast * {
+	font-weight: 400;
+	font-size: 12px;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -127,7 +127,7 @@ viewswitcher button:hover {
 }
 
 #NautilusPathBar #NautilusPathButton {
-	background: @secondary_sidebar_bg_color;
+	background: @accent_active_color;
 	border-radius: 4px;
 	margin: 0;
 	margin-right: 2px;
@@ -135,10 +135,6 @@ viewswitcher button:hover {
 
 #NautilusPathBar #NautilusPathButton:hover {
 	background: @accent_hover_color;
-}
-
-#NautilusPathBar #NautilusPathButton:active {
-	background: @accent_active_color;
 }
 
 #NautilusPathBar {
@@ -154,13 +150,11 @@ viewswitcher button:hover {
 }
 
 #NautilusPathBar #NautilusPathButton.current-dir.current-dir {
-	background: @accent_active_color;
 	border-radius: 999px;
 }
 
-#NautilusPathBar #NautilusPathButton.current-dir.current-dir * {
+#NautilusPathBar #NautilusPathButton * {
 	color: @sidebar_row_active_fg_color;
-	opacity: 1;
 }
 
 #NautilusPathBar .dim-label {
@@ -331,21 +325,21 @@ toast * {
     padding-bottom: 0;
 }
 
-tabbox, tabboxchild {
+tabbox {
 	padding: 0;
 }
 
 tabbox tabboxchild tab, tabbox tabboxchild {
 	background: transparent;
-	padding: 0;
-	border-radius: 0px;
+	padding: 0 8px 3px;
+	border-radius: 999px;
 }
 
 tab:hover {
 	background: @accent_hover_color;
 }
 
-tab:active {
+tab:active, tab:selected {
 	background: @accent_active_color;
 }
 
@@ -358,12 +352,11 @@ tab:hover .tab-title {
 }
 
 tab .tab-title label {
-	border-bottom: transparent 3px solid;
+border: none;
 	font-weight: 500;
 }
 
 tab:selected .tab-title label {
-	padding: 10px 0;
-	border-bottom-color: @accent_color;
+	padding: 6px 0;
 	color: @accent_color;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -52,6 +52,10 @@
     @define-color inverse_on_surface {{colors.inverse_on_surface.light.hex}};
     @define-color inverse_primary {{colors.inverse_primary.light.hex}};
     @define-color inverse_surface {{colors.inverse_surface.light.hex}};
+    @define-color surface_container_highest {{colors.surface_container_highest.light.hex}};
+    @define-color surface_container_high {{colors.surface_container_high.light.hex}};
+    @define-color on_surface_variant {{colors.on_surface_variant.light.hex}};
+    @define-color surface_variant {{colors.surface_variant.light.hex}};
 
     @define-color outline {{colors.outline.light.hex}};
 
@@ -111,6 +115,10 @@
     @define-color inverse_on_surface {{colors.inverse_on_surface.dark.hex}};
     @define-color inverse_primary {{colors.inverse_primary.dark.hex}};
     @define-color inverse_surface {{colors.inverse_surface.dark.hex}};
+    @define-color surface_container_highest {{colors.surface_container_highest.dark.hex}};
+    @define-color surface_container_high {{colors.surface_container_high.dark.hex}};
+    @define-color on_surface_variant {{colors.on_surface_variant.dark.hex}};
+    @define-color surface_variant {{colors.surface_variant.dark.hex}};
 
     @define-color outline {{colors.outline.dark.hex}};
 
@@ -226,9 +234,6 @@ headerbar >windowhandle box stack > box:nth-child(2) {
 
 .nautilus-list-view,
 .nautilus-grid-view {
-  
-  /* search */
-  
   background: @secondary_sidebar_bg_color;
   border-radius: 16px;
 }
@@ -241,6 +246,7 @@ headerbar >windowhandle box stack > box:nth-child(2) {
 
 .navigation-sidebar row {
   border-radius: 999px;
+  padding: 2px;
 }
 
 .navigation-sidebar row:hover {
@@ -295,10 +301,21 @@ banner widget {
 
 .text-button.toggle {
   border-radius: 4px;
+  background-color: @surface_container_highest;
+  margin-left: 2px;
+}
+
+.text-button.toggle:hover {
+  background-color: @surface_variant;
+}
+
+.text-button.toggle:active {
+  background-color: @surface_container_highest;
 }
 
 .text-button.toggle * {
-  font-weight: 500;
+  color: @on_surface_variant;
+  font-weight: 400;
 }
 
 .boxed-list row:first-child {
@@ -326,7 +343,11 @@ banner widget {
 .text-button.toggle:checked {
   background-color: @accent_bg_color;
   border-radius: 999px;
+}
+
+.text-button.toggle:checked * {
   color: @accent_fg_color;
+  font-weight: 500;
 }
 
 button.back {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -155,22 +155,6 @@ window {
   margin-right: 2px;
 }
 
-.nautilus-window headerbar button:hover {
-  background: @accent_hover_color;
-}
-
-.nautilus-window headerbar button:active {
-  background: @accent_active_color;
-}
-
-#NautilusPathBar #NautilusPathButton:hover {
-  background: @accent_vibrant_hover_color;
-}
-
-#NautilusPathBar #NautilusPathButton:active {
-  background: @accent_vibrant_active_color;
-}
-
 #NautilusPathBar {
   background: transparent;
 }
@@ -207,6 +191,10 @@ window {
 
 #NautilusPathBar button:checked {
   background: @accent_vibrant_hover_color;
+}
+
+headerbar button {
+  border-radius: 999px;
 }
 
 headerbar >windowhandle box stack > box:nth-child(2) {

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -40,6 +40,7 @@
     /* Popups */
     @define-color popover_bg_color {{colors.surface_container_highest.light.hex}};
     @define-color popover_fg_color {{colors.on_surface.light.hex}};
+    @define-color popover_fg_hover_color rgba({{colors.on_surface.light.red}}, {{colors.on_surface.light.green}}, {{colors.on_surface.light.blue}}, 0.08);
     @define-color dialog_bg_color {{colors.surface_container_high.light.hex}};
     @define-color dialog_fg_color {{colors.on_surface.light.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.light.hex}};
@@ -85,6 +86,7 @@
     /* Popups */
     @define-color popover_bg_color {{colors.surface_container_highest.dark.hex}};
     @define-color popover_fg_color {{colors.on_surface.dark.hex}};
+    @define-color popover_fg_hover_color rgba({{colors.on_surface.dark.red}}, {{colors.on_surface.dark.green}}, {{colors.on_surface.dark.blue}}, 0.08);
     @define-color dialog_bg_color {{colors.surface_container_high.dark.hex}};
     @define-color dialog_fg_color {{colors.on_surface.dark.hex}};
     @define-color thumbnail_bg_color {{colors.surface_container_high.dark.hex}};
@@ -97,23 +99,13 @@ window {
   background: @window_bg_color;
 }
 
-viewswitcher button {
-  padding: 6px 0;
-  font-size: 14px;
-  font-weight: 500;
+.text-button {
   border-radius: 999px;
 }
 
-viewswitcher button:hover {
-  background-color: @accent_hover_color;
-}
-
-.text-button {
-	border-radius: 999px;
-}
-
-.text-button, .text-button * {
-	font-weight: 500;
+.text-button,
+.text-button * {
+  font-weight: 500;
 }
 
 .popup-menu-item {
@@ -122,85 +114,86 @@ viewswitcher button:hover {
 }
 
 #NautilusPathBar #NautilusPathButton * {
-	color: @accent_color;
-	font-weight: 400;
+  color: @accent_color;
+  font-weight: 400;
 }
 
 #NautilusPathBar #NautilusPathButton {
-	background: @accent_active_color;
-	border-radius: 4px;
-	margin: 0;
-	margin-right: 2px;
+  background: @accent_active_color;
+  border-radius: 4px;
+  margin: 0;
+  margin-right: 2px;
 }
 
 #NautilusPathBar #NautilusPathButton:hover {
-	background: @accent_hover_color;
+  background: @accent_vibrant_hover_color;
 }
 
 #NautilusPathBar {
-	background: transparent;
+  background: transparent;
 }
 
 #NautilusPathBar box box:first-child #NautilusPathButton {
-	border-radius: 24px 4px 4px 24px;
+  border-radius: 24px 4px 4px 24px;
 }
 
 #NautilusPathBar box box:last-child #NautilusPathButton {
-	border-radius: 4px 24px 24px 4px;
+  border-radius: 4px 24px 24px 4px;
 }
 
 #NautilusPathBar #NautilusPathButton.current-dir.current-dir {
-	border-radius: 999px;
+  border-radius: 999px;
 }
 
 #NautilusPathBar #NautilusPathButton * {
-	color: @sidebar_row_active_fg_color;
+  color: @sidebar_row_active_fg_color;
 }
 
 #NautilusPathBar .dim-label {
-	font-size: 0;
+  font-size: 0;
 }
 
 #NautilusPathBar button .dim-label {
-	font-size: 14px;
-	opacity: 100%;
+  font-size: 14px;
+  opacity: 100%;
 }
 
-.nautilus-list-view, .nautilus-grid-view {
-    background: @secondary_sidebar_bg_color;
-    border-radius: 16px;
+.nautilus-list-view,
+.nautilus-grid-view {
+  background: @secondary_sidebar_bg_color;
+  border-radius: 16px;
 }
 
 .navigation-sidebar row * {
   color: @sidebar_fg_color;
-	font-weight: 500;
-	font-size: 13px;
+  font-weight: 500;
+  font-size: 13px;
 }
 
 .navigation-sidebar row {
-	border-radius: 999px;
+  border-radius: 999px;
 }
 
 .navigation-sidebar row:hover {
-	background: @accent_hover_color;
+  background: @accent_hover_color;
 }
 
 .navigation-sidebar row:active {
-	background: @accent_active_color;
+  background: @accent_active_color;
 }
 
 .navigation-sidebar row:selected {
-	background: @sidebar_row_active_bg_color;
+  background: @sidebar_row_active_bg_color;
 }
 
 .navigation-sidebar row:selected * {
-	color: @sidebar_row_active_fg_color;
+  color: @sidebar_row_active_fg_color;
 }
 
 banner widget {
-	border-radius: 16px 0 0 16px;
-	margin-bottom: 8px;
-	background-color: @secondary_sidebar_bg_color;
+  border-radius: 16px 0 0 16px;
+  margin-bottom: 8px;
+  background-color: @secondary_sidebar_bg_color;
 }
 
 .boxed-list {
@@ -208,155 +201,189 @@ banner widget {
 }
 
 .boxed-list row {
-	background: @card_bg_color;
-	border-radius: 4px;
-	border: none;
-	margin-bottom: 2px;
+  background: @card_bg_color;
+  border-radius: 4px;
+  border: none;
+  margin-bottom: 2px;
 }
 
 .boxed-list row.activatable:hover {
-	background-color: @accent_hover_color;
+  background-color: @thumbnail_bg_color;
 }
 
 .boxed-list row.activatable:active {
-	background-color: @accent_active_color;
+  background-color: @popover_bg_color;
+}
+
+.horizontal>listview>row {
+  background-color: transparent;
 }
 
 .boxed-list row:insensitive {
-	background-color: @card_bg_color; 
+  background-color: @card_bg_color;
 }
 
 .text-button.toggle {
-	border-radius: 4px;
+  border-radius: 4px;
 }
 
 .text-button.toggle * {
-	font-weight: 500;
+  font-weight: 500;
 }
 
 .boxed-list row:first-child {
-	border-radius: 16px 16px 4px 4px;
+  border-radius: 16px 16px 4px 4px;
 }
 
 .boxed-list row:last-child {
-	border-radius: 4px 4px 16px 16px;
-	margin-bottom: 0;
+  border-radius: 4px 4px 16px 16px;
+  margin-bottom: 0;
 }
 
 .text-button.toggle:first-child {
-	border-radius: 16px 4px 4px 16px;
+  border-radius: 16px 4px 4px 16px;
 }
 
 .text-button.toggle:last-child {
-	border-radius: 4px 16px 16px 4px;
+  border-radius: 4px 16px 16px 4px;
 }
 
 .boxed-list row:first-child:last-child,
 .text-button.toggle:first-child:last-child {
-	border-radius: 16px;
+  border-radius: 16px;
 }
 
 .text-button.toggle:checked {
-	background-color: @accent_bg_color;
-	border-radius: 999px;
-	color: @accent_fg_color;
+  background-color: @accent_bg_color;
+  border-radius: 999px;
+  color: @accent_fg_color;
 }
 
 button.back {
-	border-radius: 999px;
-	background-color: @secondary_sidebar_bg_color;
-	padding-left: 4px;
-	padding-right: 6px;
+  border-radius: 999px;
+  background-color: @accent_hover_color;
+  padding-left: 4px;
+  padding-right: 6px;
 }
 
 button.back * {
-	font-size: 12px;
+  font-size: 12px;
 }
 
 button.back:hover {
-	background-color: @accent_hover_color;
+  background-color: @accent_hover_color;
 }
 
 button.back:active {
-	background-color: @accent_active_color;
+  background-color: @accent_active_color;
 }
 
 /* switch */
 
 switch {
-	background: @secondary_sidebar_bg_color;
-	border: #90878f 2px solid;
-	padding: 0;
+  background: @secondary_sidebar_bg_color;
+  border: #90878f 2px solid;
+  padding: 0;
 }
 
 switch:checked {
-	background: @accent_color;
-	border-color: @accent_color;
+  background: @accent_color;
+  border-color: @accent_color;
 }
 
-slider {
-	background: #90878f;
-	border: @secondary_sidebar_bg_color 2px solid;
-	min-width: 4px;
-	min-height: 4px;
+switch slider {
+  background: #90878f;
+  outline: @secondary_sidebar_bg_color 2px solid;
+  margin: 2px;
+  min-width: 0;
+  min-height: 0;
 }
 
 switch:checked slider {
-	background: @accent_fg_color;
-	border: none;
+  background: @accent_fg_color;
+  outline: none;
+  margin: 0;
 }
 
 /* toast */
 
 toast {
-	border-radius: 999px;
-	padding: 2px 6px;
-	margin: 8px;
-	background-color: @toast_bg_color;
-	color: @toast_fg_color;
+  border-radius: 999px;
+  padding: 2px 6px;
+  margin: 8px;
+  background-color: @toast_bg_color;
+  color: @toast_fg_color;
 }
 
 toast * {
-	font-weight: 400;
-	font-size: 12px;
+  font-weight: 400;
+  font-size: 12px;
 }
 
 .collapse-spacing.vertical {
-    padding-bottom: 0;
+  padding-bottom: 0;
 }
 
 tabbox {
-	padding: 0;
+  padding: 0;
 }
 
-tabbox tabboxchild tab, tabbox tabboxchild {
-	background: transparent;
-	padding: 0 8px 3px;
-	border-radius: 999px;
+tabbox tabboxchild tab,
+tabbox tabboxchild {
+  background: transparent;
+  padding: 0 8px 3px;
+  border-radius: 999px;
+}
+
+tabbox tabboxchild tab {
+  padding: 3px 8px;
 }
 
 tab:hover {
-	background: @accent_hover_color;
+  background: @accent_hover_color;
 }
 
-tab:active, tab:selected {
-	background: @accent_active_color;
+tab:active,
+tab:selected {
+  background: @accent_active_color;
 }
 
 tab .tab-title {
-	padding: 0 12px;
-	color: @secondary_sidebar_fg_color;
-}
-
-tab:hover .tab-title {
+  padding: 0 12px;
+  color: @secondary_sidebar_fg_color;
 }
 
 tab .tab-title label {
-border: none;
-	font-weight: 500;
+  border: none;
+  font-weight: 500;
 }
 
 tab:selected .tab-title label {
-	padding: 6px 0;
-	color: @accent_color;
+  padding: 6px 0;
+  color: @accent_color;
+}
+
+/* popup menu */
+
+popover contents {
+  background: @secondary_sidebar_bg_color;
+}
+
+modelbutton {
+  padding: 2px 10px;
+}
+
+modelbutton * {
+  color: @popover_fg_color;
+}
+
+modelbutton:hover {
+  background-color: @popover_fg_hover_color;
+}
+
+tooltip {
+  background-color: #e3e1e9;
+  font-size: 11px;
+  padding: 5px 9px;
+  color: #393a40;
 }

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -105,6 +105,10 @@
     @define-color scrollbar_hover_color {{colors.outline_variant.dark.hex}};
 }
 
+* {
+  caret-color: @accent_color;
+}
+
 window {
   background: @window_bg_color;
 }
@@ -352,7 +356,6 @@ switch:checked {
 
 switch slider {
   background: #90878f;
-  outline: @secondary_sidebar_bg_color 2px solid;
   margin: 2px;
   min-width: 0;
   min-height: 0;
@@ -360,8 +363,8 @@ switch slider {
 
 switch:checked slider {
   background: @accent_fg_color;
-  outline: none;
-  margin: 0;
+  outline: transparent 2px solid;
+  margin: 0px;
 }
 
 /* toast */

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -326,3 +326,44 @@ toast * {
 	font-weight: 400;
 	font-size: 12px;
 }
+
+.collapse-spacing.vertical {
+    padding-bottom: 0;
+}
+
+tabbox, tabboxchild {
+	padding: 0;
+}
+
+tabbox tabboxchild tab, tabbox tabboxchild {
+	background: transparent;
+	padding: 0;
+	border-radius: 0px;
+}
+
+tab:hover {
+	background: @accent_hover_color;
+}
+
+tab:active {
+	background: @accent_active_color;
+}
+
+tab .tab-title {
+	padding: 0 12px;
+	color: @secondary_sidebar_fg_color;
+}
+
+tab:hover .tab-title {
+}
+
+tab .tab-title label {
+	border-bottom: transparent 3px solid;
+	font-weight: 500;
+}
+
+tab:selected .tab-title label {
+	padding: 10px 0;
+	border-bottom-color: @accent_color;
+	color: @accent_color;
+}

--- a/dots/.config/matugen/templates/gtk-4.0/gtk.css
+++ b/dots/.config/matugen/templates/gtk-4.0/gtk.css
@@ -119,26 +119,6 @@ window {
   background: @window_bg_color;
 }
 
-scrollbar * {
-  border: none;
-  margin: 0;
-  padding: 0;
-}
- 
-
-scrollbar slider {
-  background: @scrollbar_color;
-  border-radius: 999px;
-  min-width: 4px;
-}
-
-scrollbar trough {
-  background: transparent;
-  padding: 1px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
 .text-button {
   border-radius: 999px;
 }

--- a/sdata/subcmd-install/2.setups.sh
+++ b/sdata/subcmd-install/2.setups.sh
@@ -68,6 +68,5 @@ if [[ "$OS_GROUP_ID" == "gentoo" ]]; then
 fi
 
 v gsettings set org.gnome.desktop.interface font-name 'Google Sans Flex Medium 11 @opsz=11,wght=500'
-v gsettings set org.gnome.desktop.wm.preferences button-layout ":"
 v gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
 v kwriteconfig6 --file kdeglobals --group KDE --key widgetStyle Darkly

--- a/sdata/subcmd-install/2.setups.sh
+++ b/sdata/subcmd-install/2.setups.sh
@@ -68,5 +68,6 @@ if [[ "$OS_GROUP_ID" == "gentoo" ]]; then
 fi
 
 v gsettings set org.gnome.desktop.interface font-name 'Google Sans Flex Medium 11 @opsz=11,wght=500'
+v gsettings set org.gnome.desktop.wm.preferences button-layout ":"
 v gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
 v kwriteconfig6 --file kdeglobals --group KDE --key widgetStyle Darkly


### PR DESCRIPTION
Currently some GTK4 components (like shapes/spacing) differ from the rest of the theme, which makes them visually stand out compared to the overall Material design.

This PR improves that consistency without changing the project's focus or design direction. I’ve included a few screenshots for demonstration, though they may differ slightly

<img width="2048" height="727" alt="nautilus" src="https://github.com/user-attachments/assets/cd120ea8-4e9e-4f88-8e50-5e318372383f" />
<img width="2022" height="803" alt="old vs new" src="https://github.com/user-attachments/assets/a2afead1-8899-4123-98a4-24d6ea0f0ae0" />
<img width="1557" height="743" alt="additional windows" src="https://github.com/user-attachments/assets/70f74b6b-ffa3-476a-b0ae-1a65277d8a78" />


