### PR TITLE
Make brightness quickslider follow gamma lower limit

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/QuickSliders.qml
@@ -43,7 +43,7 @@ Rectangle {
                 materialSymbol: "light_mode"
                 secondaryMaterialSymbol: "wb_twilight"
                 stopIndicatorValues: Hyprsunset.gamma !== 100 && root.brightnessMonitor?.brightness !== 0 ? [0.3 + root.brightnessMonitor?.brightness * 0.7] : []
-                value: Hyprsunset.gamma === 100? 0.3 + root.brightnessMonitor?.brightness * 0.7 : Hyprsunset.gamma / 100 * 0.3
+                value: Hyprsunset.gamma === 100? 0.3 + root.brightnessMonitor?.brightness * 0.7 : (Hyprsunset.gamma - Hyprsunset.gammaLowerLimit) / (100 - Hyprsunset.gammaLowerLimit) * 0.3
                 tooltipContent: Hyprsunset.gamma === 100 ? `${Math.round(root.brightnessMonitor?.brightness * 100)}%` : `${Translation.tr("Gamma")} ${Hyprsunset.gamma}%`
                 onMoved: {
                     if (value >= 0.3) {
@@ -57,7 +57,7 @@ Rectangle {
                         if (root.brightnessMonitor.brightness !== 0) {
                             root.brightnessMonitor.setBrightness(0);
                         }
-                        Hyprsunset.setGamma(value * 100 / 0.3);
+                        Hyprsunset.setGamma((value / 0.3 * (100 - Hyprsunset.gammaLowerLimit) + Hyprsunset.gammaLowerLimit));
                     }
                 }
             }


### PR DESCRIPTION
## Describe your changes

- Make brightness quickslider correspond to gammaLowerLimit at the bottom end
  - Currently, in the bottom quarter of the gamma portion of the slider, gamma is always 0.25

<img width="647" height="159" alt="image" src="https://github.com/user-attachments/assets/b5a4162e-1d80-4f3a-a27b-cb2fc3bb86f2" />

## Is it ready? Questions/feedback needed?
Seems good, just a small bug fix
