### PR TITLE
fix: set min height for Notification Group to fix visual bug on  low-res screens

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -97,6 +97,7 @@ Item {
             }
 
             CenterWidgetGroup {
+                Layout.minimumHeight: 250
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 Layout.fillWidth: true


### PR DESCRIPTION
I have a 14" screen, 1920x1080, scale x1.2, when i edited quick toggles, the notification group was like in the attached screenshot. I guess the height seems equal to 0. 

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/11aa1cbe-d584-429b-92d0-fc8d5298a8cd" />


