### PR TITLE
Fix Gemini API thought_signature error in function calling

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -848,6 +848,7 @@ Singleton {
                 "annotationSources": message.annotationSources,
                 "functionName": message.functionName,
                 "functionCall": message.functionCall,
+                "thoughtSignature": message.thoughtSignature,
                 "functionResponse": message.functionResponse,
                 "visibleToUser": message.visibleToUser,
             })
@@ -904,6 +905,7 @@ Singleton {
                     "annotationSources": message.annotationSources,
                     "functionName": message.functionName,
                     "functionCall": message.functionCall,
+                    "thoughtSignature": message.thoughtSignature,
                     "functionResponse": message.functionResponse,
                     "visibleToUser": message.visibleToUser,
                 });

--- a/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
+++ b/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
@@ -18,6 +18,7 @@ QtObject {
     property list<string> searchQueries: []
     property string functionName
     property var functionCall
+    property string thoughtSignature
     property string functionResponse
     property bool functionPending: false
     property bool visibleToUser: true

--- a/dots/.config/quickshell/ii/services/ai/GeminiApiStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/GeminiApiStrategy.qml
@@ -21,13 +21,13 @@ ApiStrategy {
             const geminiApiRoleName = (message.role === "assistant") ? "model" : message.role;
             const usingSearch = tools[0]?.google_search !== undefined
             if (!usingSearch && message.functionCall != undefined && message.functionName.length > 0) {
+                const part = { functionCall: message.functionCall };
+                if (message.thoughtSignature && message.thoughtSignature.length > 0) {
+                    part.thoughtSignature = message.thoughtSignature;
+                }
                 return {
                     "role": geminiApiRoleName,
-                    "parts": [{
-                        functionCall: {
-                            "name": message.functionName,
-                        }
-                    }]
+                    "parts": [part]
                 }
             }
             if (!usingSearch && message.functionResponse != undefined && message.functionName.length > 0) {
@@ -129,13 +129,17 @@ ApiStrategy {
             
             // Function call handling
             if (dataJson.candidates[0]?.content?.parts[0]?.functionCall) {
-                const functionCall = dataJson.candidates[0]?.content?.parts[0]?.functionCall;
+                const part = dataJson.candidates[0].content.parts[0];
+                const functionCall = part.functionCall;
                 message.functionName = functionCall.name;
-                message.functionCall = functionCall.name;
+                message.functionCall = functionCall;
+                if (part.thoughtSignature) {
+                    message.thoughtSignature = part.thoughtSignature;
+                }
                 const newContent = `\n\n[[ Function: ${functionCall.name}(${JSON.stringify(functionCall.args, null, 2)}) ]]\n`
                 message.rawContent += newContent;
                 message.content += newContent;
-                return { functionCall: { name: functionCall.name, args: functionCall.args }, finished: finished };
+                return { functionCall: functionCall, finished: finished };
             }
 
             // Normal text response


### PR DESCRIPTION
Thinking models (Gemini 2.5/3) require thoughtSignature to be sent back
as a sibling of functionCall in each part object. Three bugs fixed:

- Preserve full functionCall object from API response instead of just name
- Extract and send thoughtSignature from response parts
- Persist thoughtSignature in chat save/load serialization