### PR TITLE
feat(ai): auto-resize input with scroll

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -497,10 +497,10 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
             RowLayout { // Input field and send button
                 id: inputFieldRowLayout
                 anchors {
-                    top: attachedFileIndicator.bottom
+                    bottom: commandButtonsRow.top
                     left: parent.left
                     right: parent.right
-                    topMargin: 5
+                    bottomMargin: 5
                 }
                 spacing: 0
 


### PR DESCRIPTION
Add the sidebar ai's input box to the scrolling view to avoid overflowing underneath and making it unreadable when there's too much text.

<img width="448" height="1024" alt="image" src="https://github.com/user-attachments/assets/8cd30b32-c428-4de4-a244-f7c883f719fd" />
