### PR TITLE
audio: prefer to show node description

### DIFF
--- a/dots/.config/quickshell/ii/services/Audio.qml
+++ b/dots/.config/quickshell/ii/services/Audio.qml
@@ -18,9 +18,9 @@ Singleton {
     readonly property real hardMaxValue: 2.00 // People keep joking about setting volume to 5172% so...
     property string audioTheme: Config.options.sounds.theme
     property real value: sink?.audio.volume ?? 0
-    
+
     function friendlyDeviceName(node) {
-        return (node.nickname || node.description || Translation.tr("Unknown"));
+        return (node.description || node.nickname || Translation.tr("Unknown"));
     }
     function appNodeDisplayName(node) {
         return (node.properties["application.name"] || node.description || node.name)
@@ -62,7 +62,7 @@ Singleton {
         const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
         Audio.sink.audio.volume = Math.min(1, Audio.sink.audio.volume + step);
     }
-    
+
     function decrementVolume() {
         const currentVolume = Audio.value;
         const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
@@ -100,7 +100,7 @@ Singleton {
                 lastReady = true;
                 return;
             }
-            const maxAllowedIncrease = Config.options.audio.protection.maxAllowedIncrease / 100; 
+            const maxAllowedIncrease = Config.options.audio.protection.maxAllowedIncrease / 100;
             const maxAllowed = Config.options.audio.protection.maxAllowed / 100;
 
             if (newVolume - lastVolume > maxAllowedIncrease) {


### PR DESCRIPTION
## Describe your changes

nickname looks like `USB Audio #1`, `USB Audio #2` when a device has multiple ports, which is not distinguishable.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

ready
