### PR TITLE
Add quick fix for max int workspace bug coming back from a shutdown, logout, or sleep

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
@@ -48,6 +48,9 @@ LockScreen {
                 for (var i = 0; i < Quickshell.screens.length; ++i) {
                     var mon = Quickshell.screens[i].name
                     var mData = HyprlandData.monitors.find(m => m.name === mon)
+                    if (mData?.activeWorkspace == undefined) {
+                        return;
+                    }
                     var ws = (mData?.activeWorkspace?.id ?? 1)
                     next[mon] = ws
                     batch += "dispatch focusmonitor " + mon + "; dispatch workspace " + (2147483647 - ws) + "; "


### PR DESCRIPTION
After adding this quick patch, I have not had any max int workspace bugs on two monitors or one monitor in general.

Defaulting to a single number would introduce unintended bugs due to dispatch workspace essentially becoming a focus if a monitor has already claimed that workspace, thus introducing weird bugs.

The proposed change just prevents the change to the max int/saving in general if undefined. 
This does not effect the intended result of the existing code as it can only be undefined if a user has lock on startup enabled and boots up their PC, logouts and logs back in, and rarely coming back from the PC sleeping.

Finally, one user has experienced the bug with just one monitor, I cannot recreate that with or without my proposed fix, but hopefully this fixes that issue as well as it just prevents it from happening entirely.

