### PR TITLE
fix: use --color=always for diff in exp-update (fixes no colored output)

### DIFF
--- a/sdata/subcmd-exp-update/0.run.sh
+++ b/sdata/subcmd-exp-update/0.run.sh
@@ -303,7 +303,7 @@ show_diff() {
   echo "----------------------------------------"
 
   if command -v diff &>/dev/null; then
-    diff -u "$file1" "$file2" || true
+    diff --color=always -u "$file1" "$file2" || true
   else
     echo "diff command not available"
   fi


### PR DESCRIPTION
For some reason, there is no colored output for the diff command in `exp-update` (even though I'm fairly certain that "diff" is aliased to "diff --color=auto" on my system).

Not entirely sure if there is an issue elsewhere in the script, but adding `--color=always` seems to have fixed it

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

### Is it ready? Questions/feedback needed?

Yes (unless more effort is needed - IMO this is probably sufficient for now until this AI-generated script gets fully rewritten)


