### PR TITLE
Adding alias to kitten ssh when using kitty

### DIFF
--- a/dots/.config/fish/config.fish
+++ b/dots/.config/fish/config.fish
@@ -27,5 +27,6 @@ if status is-interactive
     if test "$TERM" != "linux"
         alias ls 'eza --icons'
     end
-    
+    if test "$TERM" = "xterm-kitty"
+        alias ssh 'kitten ssh'
 end


### PR DESCRIPTION
## Describe your changes

Added one alias of the function kitten ssh to get kitty-terminfo when acessing to ssh from kitty terminal 

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Ready