### PR TITLE
Edit screen snip keybind to only take a screenshot of the focused monitor

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.conf
+++ b/dots/.config/hypr/hyprland/keybinds.conf
@@ -77,9 +77,9 @@ bindl = Super+Alt, R, exec, qs -c $qsConfig ipc call TEST_ALIVE || ~/.config/qui
 bindl = Ctrl+Alt, R, exec, ~/.config/quickshell/$qsConfig/scripts/videos/record.sh --fullscreen # [hidden] Record screen (no sound)
 bindl = Super+Shift+Alt, R, exec, ~/.config/quickshell/$qsConfig/scripts/videos/record.sh --fullscreen --sound # Record screen (with sound)
 # Fullscreen screenshot
-bindl = ,Print,exec,grim -g "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \(.width)x\(.height)"')" - | wl-copy # Screenshot >> clipboard
-bindln = Ctrl,Print,exec, mkdir -p $(xdg-user-dir PICTURES)/Screenshots && grim -g "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \(.width)x\(.height)"')" $(xdg-user-dir PICTURES)/Screenshots/Screenshot_"$(date '+%Y-%m-%d_%H.%M.%S')".png # Screenshot >> clipboard & file (file)
-bindln = Ctrl,Print,exec,grim -g "$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | "\(.x),\(.y) \(.width)x\(.height)"')" - | wl-copy # [hidden] Screenshot >> clipboard & file (clipboard)
+bindl = ,Print,exec,grim -o "$(hyprctl activeworkspace -j | jq -r '.monitor')" - | wl-copy # Screenshot >> clipboard
+bindln = Ctrl,Print, exec, mkdir -p $(xdg-user-dir PICTURES)/Screenshots && grim -o "$(hyprctl activeworkspace -j | jq -r '.monitor')" $(xdg-user-dir PICTURES)/Screenshots/Screenshot_"$(date '+%Y-%m-%d_%H.%M.%S')".png # Screenshot >> clipboard & file
+bindln = Ctrl,Print,exec,grim -o "$(hyprctl activeworkspace -j | jq -r '.monitor')" - | wl-copy # [hidden] Screenshot >> clipboard & file (clipboard)
 # AI
 bindd = Super+Shift+Alt, mouse:273, Generate AI summary for selected text, exec, ~/.config/hypr/hyprland/scripts/ai/primary-buffer-query.sh # [hidden] AI summary for selected text
 


### PR DESCRIPTION
I edited the command exec to parse the monitors and find the focused monitor to pass into grim. Before, any user with more than one monitor would have all their monitors included in the screen snip which isn't ideal.