### PR TITLE
Feat: Make gnome-keyring optional

### DIFF
--- a/dots-extra/fedora/hypr/hyprland/execs.conf
+++ b/dots-extra/fedora/hypr/hyprland/execs.conf
@@ -6,7 +6,7 @@ exec-once = qs -c $qsConfig &
 # exec-once = fcitx5
 
 # Core components (authentication, lock screen, notification daemon)
-exec-once = gnome-keyring-daemon --start --components=secrets
+exec-once = ~/.config/quickshell/ii/scripts/keyring/start_keyring_daemon.sh
 exec-once = hypridle
 exec-once = dbus-update-activation-environment --all
 exec-once = sleep 1 && dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP # Some fix idk

--- a/dots/.config/hypr/custom/env.conf
+++ b/dots/.config/hypr/custom/env.conf
@@ -20,3 +20,9 @@
 # for example: vi nano nvim ...
 
 #env = EDITOR, vim
+
+# ######## Keyring / Secrets #########
+# Override the default keyring daemon (gnome-keyring-daemon).
+# The script at scripts/keyring/start_keyring_daemon.sh will skip starting
+# any daemon if org.freedesktop.secrets is already on D-Bus (e.g. KeePassXC).
+#env = KEYRING_DAEMON_CMD, keepassxc --minimized

--- a/dots/.config/hypr/hyprland/execs.conf
+++ b/dots/.config/hypr/hyprland/execs.conf
@@ -4,7 +4,7 @@ exec-once = qs -c $qsConfig &
 exec-once = ~/.config/hypr/custom/scripts/__restore_video_wallpaper.sh
 
 # Core components (authentication, lock screen, notification daemon)
-exec-once = gnome-keyring-daemon --start --components=secrets
+exec-once = ~/.config/quickshell/ii/scripts/keyring/start_keyring_daemon.sh
 exec-once = hypridle
 exec-once = dbus-update-activation-environment --all
 exec-once = sleep 1 && dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP # Some fix idk

--- a/dots/.config/quickshell/ii/scripts/keyring/start_keyring_daemon.sh
+++ b/dots/.config/quickshell/ii/scripts/keyring/start_keyring_daemon.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Start a secrets service daemon if one isn't already available on D-Bus.
+# Supports gnome-keyring-daemon out of the box, but users can override
+# by setting KEYRING_DAEMON_CMD in their Hyprland env config, e.g.:
+#   env = KEYRING_DAEMON_CMD, keepassxc --minimized
+#
+# If the org.freedesktop.secrets D-Bus service is already registered
+# (e.g. KeePassXC is configured as a D-Bus service), this script exits
+# early and does nothing.
+
+# Check if a secrets service is already available on D-Bus
+if busctl --user list 2>/dev/null | grep -q 'org.freedesktop.secrets'; then
+    echo "Secrets service already available on D-Bus, skipping daemon start." >&2
+    exit 0
+fi
+
+if [[ -n "${KEYRING_DAEMON_CMD}" ]]; then
+    echo "Starting custom keyring daemon: ${KEYRING_DAEMON_CMD}" >&2
+    exec ${KEYRING_DAEMON_CMD}
+elif command -v gnome-keyring-daemon &>/dev/null; then
+    echo "Starting gnome-keyring-daemon" >&2
+    exec gnome-keyring-daemon --start --components=secrets
+else
+    echo "Warning: No secrets service found. Install gnome-keyring or set KEYRING_DAEMON_CMD." >&2
+    exit 1
+fi

--- a/dots/.config/quickshell/ii/scripts/keyring/unlock.sh
+++ b/dots/.config/quickshell/ii/scripts/keyring/unlock.sh
@@ -21,7 +21,7 @@ secrets_owner=$(busctl --user get-property org.freedesktop.secrets \
     /org/freedesktop/secrets org.freedesktop.DBus.Peer GetMachineId 2>/dev/null)
 
 # Only use the gnome-keyring-daemon unlock flow if it's the active provider
-if pgrep -u "$(whoami)" -x gnome-keyring-daemon &>/dev/null; then
+if pgrep -u "$(whoami)" -f gnome-keyring-daemon &>/dev/null; then
     killall -q -u "$(whoami)" gnome-keyring-daemon
     eval $(echo -n "${UNLOCK_PASSWORD}" \
                | gnome-keyring-daemon --daemonize --login \

--- a/dots/.config/quickshell/ii/scripts/keyring/unlock.sh
+++ b/dots/.config/quickshell/ii/scripts/keyring/unlock.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Based on https://unix.stackexchange.com/a/602935
+# Unlocks the keyring via the freedesktop secrets D-Bus API.
+# Only restarts gnome-keyring-daemon if it is the active secrets provider.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -14,10 +16,24 @@ if [[ -z "${UNLOCK_PASSWORD}" ]]; then
     read -s UNLOCK_PASSWORD || return
 fi
 
-# Unlock
-killall -q -u "$(whoami)" gnome-keyring-daemon
-eval $(echo -n "${UNLOCK_PASSWORD}" \
-           | gnome-keyring-daemon --daemonize --login \
-           | sed -e 's/^/export /')
+# Check which secrets provider is running
+secrets_owner=$(busctl --user get-property org.freedesktop.secrets \
+    /org/freedesktop/secrets org.freedesktop.DBus.Peer GetMachineId 2>/dev/null)
+
+# Only use the gnome-keyring-daemon unlock flow if it's the active provider
+if pgrep -u "$(whoami)" -x gnome-keyring-daemon &>/dev/null; then
+    killall -q -u "$(whoami)" gnome-keyring-daemon
+    eval $(echo -n "${UNLOCK_PASSWORD}" \
+               | gnome-keyring-daemon --daemonize --login \
+               | sed -e 's/^/export /')
+else
+    # For non-gnome-keyring providers (e.g. KeePassXC), attempt unlock via
+    # the freedesktop secrets D-Bus API
+    echo -n "${UNLOCK_PASSWORD}" | busctl --user call org.freedesktop.secrets \
+        /org/freedesktop/secrets/collection/login \
+        org.freedesktop.Secret.Collection Unlock 's' '' 2>/dev/null \
+        || echo "Note: Keyring unlock via D-Bus not supported by your provider. Unlock it manually." >&2
+fi
+
 unset UNLOCK_PASSWORD
 echo '' >&2

--- a/sdata/deps-info.md
+++ b/sdata/deps-info.md
@@ -107,8 +107,8 @@ Tips:
 ## illogical-impulse-kde
 - `bluedevil`
   - Provide command `kcmshell6 kcm_bluetooth` used by Quickshell bluetooth functionality.
-- `gnome-keyring`
-  - Provide executable `gnome-keyring-daemon`, used in Hyprland and Quickshell config.
+- `gnome-keyring` (optional, or any freedesktop secrets provider like KeePassXC)
+  - Provide executable `gnome-keyring-daemon`, used as default secrets provider. Set `KEYRING_DAEMON_CMD` env var to use an alternative, or pre-start your provider before Hyprland.
 - `networkmanager`
   - Basic component.
 - `plasma-nm`


### PR DESCRIPTION
Instead of running gnome-keyring-daemon directly, check if secrets service is present and attempt to unlock it.

Start gnome-keyring-daemon unless env KEYRING_DAEMON_CMD is set