### PR TITLE
(FIX TO "INVALID MODEL") Convert model names to lowercase in Ai.qml 

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -485,7 +485,7 @@ Singleton {
 
     function setModel(modelId, feedback = true, setPersistentState = true) {
         if (!modelId) modelId = ""
-        modelId = modelId.toLowerCase()
+        modelId = root.safeModelName(modelId)
         if (modelList.indexOf(modelId) !== -1) {
             const model = models[modelId]
             // See if policy prevents online models

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -63,7 +63,7 @@ Singleton {
     }
 
     function safeModelName(modelName) {
-        return modelName.replace(/:/g, "_").replace(/ /g, "-").replace(/\//g, "-")
+        return modelName.replace(/:/g, "_").replace(/ /g, "-").replace(/\//g, "-").toLowerCase()
     }
 
     property list<var> defaultPrompts: []
@@ -307,7 +307,7 @@ Singleton {
 
     function addUserModels() {
         (Config?.options.ai?.extraModels ?? []).forEach(model => {
-            const safeModelName = root.safeModelName(model["model"]).toLowerCase();
+            const safeModelName = root.safeModelName(model["model"]);
             root.addModel(safeModelName, model)
         });
     }
@@ -366,7 +366,7 @@ Singleton {
                     const dataJson = JSON.parse(data);
                     root.modelList = [...root.modelList, ...dataJson];
                     dataJson.forEach(model => {
-                        const safeModelName = root.safeModelName(model).toLowerCase();
+                        const safeModelName = root.safeModelName(model);
                         root.addModel(safeModelName, {
                             "name": guessModelName(model),
                             "icon": guessModelLogo(model),
@@ -485,7 +485,7 @@ Singleton {
 
     function setModel(modelId, feedback = true, setPersistentState = true) {
         if (!modelId) modelId = ""
-        modelId = root.safeModelName(modelId).toLowerCase()
+        modelId = modelId.toLowerCase()
         if (modelList.indexOf(modelId) !== -1) {
             const model = models[modelId]
             // See if policy prevents online models

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -307,7 +307,7 @@ Singleton {
 
     function addUserModels() {
         (Config?.options.ai?.extraModels ?? []).forEach(model => {
-            const safeModelName = root.safeModelName(model["model"]);
+            const safeModelName = root.safeModelName(model["model"]).toLowerCase();
             root.addModel(safeModelName, model)
         });
     }
@@ -366,7 +366,7 @@ Singleton {
                     const dataJson = JSON.parse(data);
                     root.modelList = [...root.modelList, ...dataJson];
                     dataJson.forEach(model => {
-                        const safeModelName = root.safeModelName(model);
+                        const safeModelName = root.safeModelName(model).toLowerCase();
                         root.addModel(safeModelName, {
                             "name": guessModelName(model),
                             "icon": guessModelLogo(model),
@@ -485,7 +485,7 @@ Singleton {
 
     function setModel(modelId, feedback = true, setPersistentState = true) {
         if (!modelId) modelId = ""
-        modelId = modelId.toLowerCase()
+        modelId = root.safeModelName(modelId).toLowerCase()
         if (modelList.indexOf(modelId) !== -1) {
             const model = models[modelId]
             // See if policy prevents online models


### PR DESCRIPTION
Fix Ollama model validation by applying safeModelName normalization and lowercasing consistently when both storing and looking up model keys, so that models with colons (e.g. phi4:latest) or mixed-case names (e.g. Qwen3-Coder-30B) are correctly recognized instead of throwing 'Invalid model'.


