### PR TITLE
FIX: Screenshot regions alpha value + improvements

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
@@ -51,7 +51,7 @@ PanelWindow {
     property color imageFillColor: ColorUtils.transparentize(imageBorderColor, 0.85)
     property color onBorderColor: "#ff000000"
     property real targetRegionOpacity: Config.options.regionSelector.targetRegions.opacity
-    property bool contentRegionOpacity: Config.options.regionSelector.targetRegions.contentRegionOpacity
+    property real contentRegionOpacity: Config.options.regionSelector.targetRegions.contentRegionOpacity
 
     // Vars for indicators
     readonly property var windows: [...HyprlandData.windowList].sort((a, b) => {
@@ -220,18 +220,27 @@ PanelWindow {
 
     Process {
         id: imageDetectionProcess
-        command: ["bash", "-c", `${Directories.scriptPath}/images/find-regions-venv.sh ` 
+        command: [
+            "bash", "-c", `${Directories.scriptPath}/images/find-regions-venv.sh ` 
             + `--hyprctl ` 
             + `--image '${StringUtils.shellSingleQuoteEscape(root.screenshotPath)}' ` 
             + `--max-width ${Math.round(root.screen.width * root.falsePositivePreventionRatio)} ` 
-            + `--max-height ${Math.round(root.screen.height * root.falsePositivePreventionRatio)} `]
+            + `--max-height ${Math.round(root.screen.height * root.falsePositivePreventionRatio)} ` 
+        ]
         stdout: StdioCollector {
             id: imageDimensionCollector
             onStreamFinished: {
                 imageRegions = RegionFunctions.filterImageRegions(
-                    JSON.parse(imageDimensionCollector.text),
-                    root.windowRegions
-                );
+                        JSON.parse(imageDimensionCollector.text).map(r => {
+                            return {
+                                x: Math.round(r.x / root.monitorScale),
+                                y: Math.round(r.y / root.monitorScale),
+                                width: Math.round(r.width / root.monitorScale),
+                                height: Math.round(r.height / root.monitorScale)
+                            }
+                        }),
+                        root.windowRegions
+                    );
             }
         }
     }
@@ -427,10 +436,10 @@ PanelWindow {
                     && root.targetedRegionWidth === modelData.size[0] //
                     && root.targetedRegionHeight === modelData.size[1])
 
-                opacity: root.draggedAway ? 0 : root.targetRegionOpacity
+                regionAlpha: root.draggedAway ? 0 : root.targetRegionOpacity
                 borderColor: root.windowBorderColor
                 fillColor: targeted ? root.windowFillColor : "transparent"
-                text: `${modelData.class}`
+                text: `${modelData.class} ${modelData.title}`
                 radius: Appearance.rounding.windowRounding
             }
         }
@@ -456,7 +465,7 @@ PanelWindow {
                     && root.targetedRegionWidth === modelData.size[0]
                     && root.targetedRegionHeight === modelData.size[1])
 
-                opacity: root.draggedAway ? 0 : root.targetRegionOpacity
+                regionAlpha: root.draggedAway ? 0 : root.targetRegionOpacity
                 borderColor: root.windowBorderColor
                 fillColor: targeted ? root.windowFillColor : "transparent"
                 text: `${modelData.namespace}`
@@ -485,7 +494,7 @@ PanelWindow {
                     && root.targetedRegionWidth === modelData.size[0]
                     && root.targetedRegionHeight === modelData.size[1])
 
-                opacity: root.draggedAway ? 0 : root.contentRegionOpacity
+                regionAlpha: root.draggedAway ? 0 : root.contentRegionOpacity
                 borderColor: root.imageBorderColor
                 fillColor: targeted ? root.imageFillColor : "transparent"
                 text: Translation.tr("Content region")

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/TargetRegion.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/TargetRegion.qml
@@ -12,16 +12,17 @@ Rectangle {
 
     property color colBackground: Qt.alpha("#88111111", 0.9)
     property color colForeground: "#ddffffff"
+    property real regionAlpha: 0.3
     property bool showLabel: Config.options.regionSelector.targetRegions.showLabel
     property bool showIcon: false
     property bool targeted: false
-    property color borderColor
+    property color borderColor: "#ddffffff"
     property color fillColor: "transparent"
     property string text: ""
     property real textPadding: 10
     z: 2
-    color: fillColor
-    border.color: borderColor
+    color: Qt.alpha(fillColor, regionAlpha)
+    border.color: Qt.alpha(borderColor, regionAlpha)
     border.width: targeted ? 4 : 2
     radius: 4
 
@@ -29,8 +30,8 @@ Rectangle {
         animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
     }
 
-    visible: opacity > 0
-    Behavior on opacity {
+    visible: regionAlpha > 0
+    Behavior on regionAlpha {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }
     x: clientDimensions.at[0]
@@ -51,31 +52,46 @@ Rectangle {
             property real verticalPadding: 5
             property real horizontalPadding: 10
             radius: 10
-            color: root.colBackground
+            color: Qt.alpha(root.colBackground, regionAlpha)
             border.width: 1
-            border.color: Appearance.m3colors.m3outlineVariant
-            implicitWidth: regionInfoRow.implicitWidth + horizontalPadding * 2
-            implicitHeight: regionInfoRow.implicitHeight + verticalPadding * 2
+            border.color: Qt.alpha(Appearance.m3colors.m3outlineVariant, regionAlpha)
+            implicitWidth: regionInfo.implicitWidth + horizontalPadding * 2
+            implicitHeight: regionInfo.implicitHeight + verticalPadding * 2
 
-            Row {
-                id: regionInfoRow
+            Column {
+                id: regionInfo
                 anchors.centerIn: parent
                 spacing: 4
 
-                Loader {
-                    id: regionIconLoader
-                    active: root.showIcon
-                    visible: active
-                    sourceComponent: IconImage {
-                        implicitSize: Appearance.font.pixelSize.larger
-                        source: Quickshell.iconPath(AppSearch.guessIcon(root.text), "image-missing")
+                Row {
+                    id: regionInfoRow
+                    spacing: 4
+
+                    Loader {
+                        id: regionIconLoader
+                        active: root.showIcon
+                        visible: active
+                        sourceComponent: IconImage {
+                            implicitSize: Appearance.font.pixelSize.larger
+                            source: Quickshell.iconPath(AppSearch.guessIcon(root.clientDimensions.class), "image-missing")
+                        }
+                    }
+
+                    StyledText {
+                        id: regionText
+                        text: root.text
+                        color: root.colForeground
                     }
                 }
 
-                StyledText {
-                    id: regionText
-                    text: root.text
-                    color: root.colForeground
+                Row {
+                    id: regionInfoPositionsRow
+                    spacing: 4
+
+                    StyledText {
+                        text: `${root.x},${root.y} ${root.width}x${root.height}`
+                        color: root.colForeground
+                    }
                 }
             }
         }


### PR DESCRIPTION
This commit fixes an issue with the alpha channel (transparency) not displaying correctly in the region selector when taking screenshots.

## Changes in RegionSelection.qml

### Data Type:
- Changed the contentRegionOpacity property type from Boolean to numeric (real), as described in the configuration
- This allows for the correct application of transparency values ​​in the range from 0 to 1

### Coordinate Handling:
- Added scaling of detected object coordinates based on the monitor scale
- Coordinates are divided by the monitor scale factor for correct positioning

### Region Display:
- Replaced the opacity property with regionAlpha for better control over target region transparency
- This provides more precise and consistent control over border and fill transparency regardless of region content

### Region Information:
- Added display of the window title in the region text label along with the application class name

## Changes in TargetRegion.qml

### Transparency Management:
- Added a new regionAlpha property to replace the opacity property for managing region transparency
- Reworked Transparency application logic — the alpha channel is now applied to the fill and borders, but not to the region content.

### Visual improvements:
- Transparency is now applied only to the region background, not to the title and icon, nor to the region coordinates.
- Icon display has been fixed — the application class icon is now displayed correctly, ignoring the background transparency, which made it unreadable at high transparency values ​​(which is typical).
- The structure of the region information panel has been changed.
- Region coordinates and dimensions (x,y width x height) are now displayed.