### PR TITLE
feat: add music/discord scratchpad with settings UI

### DIFF
--- a/dots/.config/hypr/custom/keybinds.conf
+++ b/dots/.config/hypr/custom/keybinds.conf
@@ -17,6 +17,10 @@ bind = Ctrl+Super+Alt, Slash, exec, xdg-open ~/.config/hypr/custom/keybinds.conf
 # bind = Super, I, exec, XDG_CURRENT_DESKTOP=gnome ~/.config/hypr/hyprland/scripts/launch_first_available.sh "qs -p ~/.config/quickshell/$qsConfig/settings.qml" "systemsettings" "gnome-control-center" "better-control" # Settings app
 # bind = Ctrl+Shift, Escape, exec, ~/.config/hypr/hyprland/scripts/launch_first_available.sh "gnome-system-monitor" "plasma-systemmonitor --page-name Processes" "command -v btop && kitty -1 fish -c btop" # Task manager
 
+##! Scratchpads
+# bind = Super, M, exec, ~/.config/hypr/hyprland/scripts/scratchpad.sh music # Music app (scratchpad)
+# bind = Super, D, exec, ~/.config/hypr/hyprland/scripts/scratchpad.sh discord # Discord (scratchpad)
+
 # Add stuff here
 # Use #! to add an extra column on the cheatsheet
 # Use ##! to add a section in that column

--- a/dots/.config/hypr/hyprland/scripts/scratchpad.sh
+++ b/dots/.config/hypr/hyprland/scripts/scratchpad.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scratchpad.sh <scratchpad_name>
+#
+# Launches or toggles a scratchpad (special workspace) for a given app.
+# Configuration is read from ~/.config/illogical-impulse/config.json:
+#
+#   scratchpads.music.enable       (bool)   - enable music scratchpad
+#   scratchpads.music.app          (string) - "youtube-music" or "spotify"
+#   scratchpads.music.alwaysInSpecial (bool) - skip searching other workspaces
+#
+#   scratchpads.discord.enable     (bool)   - enable discord scratchpad
+#   scratchpads.discord.alwaysInSpecial (bool)
+#
+# Behavior:
+#   - Special workspace visible  → hide it
+#   - App open on other workspace → move to special and show
+#   - App not open               → launch in special workspace
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+CONFIG_FILE="$XDG_CONFIG_HOME/illogical-impulse/config.json"
+
+SCRATCHPAD_NAME="$1"
+
+cfg() {
+    jq -r "$1 // empty" "$CONFIG_FILE" 2>/dev/null
+}
+
+case "$SCRATCHPAD_NAME" in
+    music)
+        ENABLE=$(cfg '.scratchpads.music.enable // true')
+        [ "$ENABLE" = "false" ] && exit 0
+
+        APP=$(cfg '.scratchpads.music.app // "youtube-music"')
+        ALWAYS_IN_SPECIAL=$(cfg '.scratchpads.music.alwaysInSpecial // false')
+
+        case "$APP" in
+            spotify)
+                WINDOW_CLASS="spotify"
+                APP_CMD="spotify"
+                ;;
+            *)
+                WINDOW_CLASS="com.github.th_ch.youtube_music"
+                APP_CMD="youtube-music"
+                ;;
+        esac
+        ;;
+    discord)
+        ENABLE=$(cfg '.scratchpads.discord.enable // true')
+        [ "$ENABLE" = "false" ] && exit 0
+
+        ALWAYS_IN_SPECIAL=$(cfg '.scratchpads.discord.alwaysInSpecial // false')
+        WINDOW_CLASS="discord"
+        APP_CMD="discord"
+        ;;
+    *)
+        echo "Usage: scratchpad.sh <music|discord>"
+        exit 1
+        ;;
+esac
+
+# Check if special workspace is visible on any monitor
+ACTIVE_SPECIAL=$(hyprctl monitors -j | jq -r '.[].specialWorkspace.name' | grep -Fx "special:$SCRATCHPAD_NAME")
+
+if [ -n "$ACTIVE_SPECIAL" ]; then
+    hyprctl dispatch togglespecialworkspace "$SCRATCHPAD_NAME"
+    exit 0
+fi
+
+# If alwaysInSpecial is true, skip searching other workspaces
+if [ "$ALWAYS_IN_SPECIAL" != "true" ]; then
+    WINDOW_ADDR=$(hyprctl clients -j | jq -r ".[] | select(.class == \"$WINDOW_CLASS\") | .address" | head -1)
+fi
+
+if [ -n "$WINDOW_ADDR" ]; then
+    hyprctl dispatch movetoworkspacesilent "special:$SCRATCHPAD_NAME,address:$WINDOW_ADDR"
+    hyprctl dispatch togglespecialworkspace "$SCRATCHPAD_NAME"
+else
+    hyprctl dispatch exec "[workspace special:$SCRATCHPAD_NAME] $APP_CMD"
+fi

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -161,6 +161,18 @@ Singleton {
                 property string volumeMixer: `~/.config/hypr/hyprland/scripts/launch_first_available.sh "pavucontrol-qt" "pavucontrol"`
             }
 
+            property JsonObject scratchpads: JsonObject {
+                property JsonObject music: JsonObject {
+                    property bool enable: true
+                    property string app: "youtube-music" // "youtube-music" or "spotify"
+                    property bool alwaysInSpecial: false // When true, skips searching other workspaces
+                }
+                property JsonObject discord: JsonObject {
+                    property bool enable: true
+                    property bool alwaysInSpecial: false
+                }
+            }
+
             property JsonObject background: JsonObject {
                 property JsonObject widgets: JsonObject {
                     property JsonObject clock: JsonObject {

--- a/dots/.config/quickshell/ii/modules/settings/ScratchpadConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/ScratchpadConfig.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+ContentPage {
+    forceWidth: true
+
+    ContentSection {
+        icon: "music_note"
+        title: Translation.tr("Music")
+
+        ConfigSwitch {
+            buttonIcon: "music_note"
+            text: Translation.tr("Enable music scratchpad")
+            checked: Config.options.scratchpads.music.enable
+            onCheckedChanged: {
+                Config.options.scratchpads.music.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Toggle music app in a floating special workspace with Super+M")
+            }
+        }
+
+        ContentSubsection {
+            enabled: Config.options.scratchpads.music.enable
+            title: Translation.tr("Music app")
+            tooltip: Translation.tr("The app that will be launched or toggled.\nMake sure the selected app is installed.")
+
+            ConfigSelectionArray {
+                currentValue: Config.options.scratchpads.music.app
+                onSelected: newValue => {
+                    Config.options.scratchpads.music.app = newValue;
+                }
+                options: [
+                    {
+                        displayName: "YouTube Music",
+                        icon: "smart_display",
+                        value: "youtube-music"
+                    },
+                    {
+                        displayName: "Spotify",
+                        icon: "queue_music",
+                        value: "spotify"
+                    }
+                ]
+            }
+        }
+
+        ConfigSwitch {
+            enabled: Config.options.scratchpads.music.enable
+            buttonIcon: "picture_in_picture"
+            text: Translation.tr("Always open in special area")
+            checked: Config.options.scratchpads.music.alwaysInSpecial
+            onCheckedChanged: {
+                Config.options.scratchpads.music.alwaysInSpecial = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("When disabled, pressing Super+M while the app is open on another workspace\nwill move it to the scratchpad instead of launching a new instance.")
+            }
+        }
+    }
+
+    ContentSection {
+        icon: "chat"
+        title: Translation.tr("Discord")
+
+        ConfigSwitch {
+            buttonIcon: "chat"
+            text: Translation.tr("Enable Discord scratchpad")
+            checked: Config.options.scratchpads.discord.enable
+            onCheckedChanged: {
+                Config.options.scratchpads.discord.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Toggle Discord in a floating special workspace with Super+D")
+            }
+        }
+
+        ConfigSwitch {
+            enabled: Config.options.scratchpads.discord.enable
+            buttonIcon: "picture_in_picture"
+            text: Translation.tr("Always open in special area")
+            checked: Config.options.scratchpads.discord.alwaysInSpecial
+            onCheckedChanged: {
+                Config.options.scratchpads.discord.alwaysInSpecial = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("When disabled, pressing Super+D while Discord is open on another workspace\nwill move it to the scratchpad instead of launching a new instance.")
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/settings.qml
+++ b/dots/.config/quickshell/ii/settings.qml
@@ -55,6 +55,11 @@ ApplicationWindow {
             component: "modules/settings/ServicesConfig.qml"
         },
         {
+            name: Translation.tr("Scratchpads"),
+            icon: "picture_in_picture",
+            component: "modules/settings/ScratchpadConfig.qml"
+        },
+        {
             name: Translation.tr("Advanced"),
             icon: "construction",
             component: "modules/settings/AdvancedConfig.qml"


### PR DESCRIPTION
## Summary

Adds a scratchpad feature (floating special workspace) for quick-toggling a music app and Discord, inspired by the behavior present in caelestia-dots.

- **`scratchpad.sh`** — toggles a named special workspace; reads config.json for app preference, enable/disable, and alwaysInSpecial mode
- **`Config.qml`** — adds `scratchpads.music` / `scratchpads.discord` with defaults
- **`ScratchpadConfig.qml`** — new settings page with enable toggles, music app selector (YouTube Music or Spotify), and alwaysInSpecial option per scratchpad
- **`settings.qml`** — registers the new Scratchpads page in the nav rail
- **`custom/keybinds.conf`** — adds commented-out example binds (`Super+M` / `Super+D`)

## Behavior

| Situation | Action |
|---|---|
| Special workspace is visible | Hide it |
| App is open on another workspace | Move to scratchpad and show |
| App is not running | Launch in scratchpad |

## Settings page

The new **Scratchpads** settings page exposes:
- Enable/disable each scratchpad independently
- Music app selector: **YouTube Music** or **Spotify**
- **Always open in special area** toggle: when disabled, pressing the keybind while the app is open on another workspace will pull it into the scratchpad instead of launching a new instance

## Test plan

- [ ] `Super+M` toggles YouTube Music scratchpad; pressing again hides it
- [ ] `Super+M` with YouTube Music open on ws 2 moves it to scratchpad
- [ ] Switching music app to Spotify in settings and re-triggering opens Spotify
- [ ] Disabling a scratchpad in settings makes the keybind a no-op
- [ ] `Super+D` same behavior for Discord
- [ ] Settings page renders correctly and changes persist across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)