### PR TITLE
fix(lock): guard against transient null screen data during monitor hotplug

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
@@ -69,9 +69,9 @@ LockScreen {
         delegate: Scope {
             required property ShellScreen modelData
             property bool shouldPush: GlobalStates.screenLocked
-            property string targetMonitorName: modelData.name
-            property int verticalMovementDistance: modelData.height
-            property int horizontalSqueeze: modelData.width * 0.2
+            property string targetMonitorName: modelData?.name ?? ""
+            property int verticalMovementDistance: modelData?.height ?? 0
+            property int horizontalSqueeze: (modelData?.width ?? 0) * 0.2
         }
     }
 }


### PR DESCRIPTION
This fixes a crash I was hitting locally when connecting a second monitor.

On my machine, Quickshell would sometimes die right after monitor hotplug because `modelData` in `modules/ii/lock/Lock.qml` briefly became null, and the lock variant was reading `name`, `height`, and `width` directly from it.

This change just adds null-safe fallbacks there:
- `modelData?.name ?? ""` 
- `modelData?.height ?? 0`
- `modelData?.width ?? 0`

Why:
during monitor add/remove there seems to be a short transition where the screen data is not fully available yet, and that was enough to trigger a QML `TypeError` and kill the shell here.

I only saw this on my machine when plugging in a second monitor. I didn't dig very deep into the underlying Quickshell / monitor lifecycle, so this is just a small defensive fix for the null case.