### PR TITLE
Added wallhaven support in wallpaper menu

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSearchGrid.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSearchGrid.qml
@@ -1,0 +1,573 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Quickshell.Io
+
+/**
+ * Wallhaven search grid with search input, results grid, pagination,
+ * and integrated settings popup. Drop-in replacement for the local
+ * wallpaper grid when Wallhaven mode is active.
+ */
+Item {
+    id: root
+
+    property int columns: 4
+    property real previewCellAspectRatio: 4 / 3
+    property bool useDarkMode: Appearance.m3colors.darkmode
+    property bool loading: WallhavenSearch.fetching
+    property bool downloading: false
+    property string downloadingId: ""
+
+    signal wallpaperApplied()
+
+    // Public API for parent key forwarding
+    function moveGridSelection(delta) { wallhavenGrid.moveSelection(delta) }
+    function activateGridCurrent() { wallhavenGrid.activateCurrent() }
+
+    // Download and apply a wallhaven wallpaper
+    function downloadAndApply(wallpaper) {
+        if (downloading) return
+        downloading = true
+        downloadingId = wallpaper.id || ""
+        WallhavenSearch.downloadWallpaper(wallpaper, function(success, localPath) {
+            downloading = false
+            downloadingId = ""
+            if (success && localPath) {
+                Wallpapers.apply(localPath, root.useDarkMode)
+                root.wallpaperApplied()
+            }
+        })
+    }
+
+    property bool showSettings: false
+
+    // Settings popup overlay
+    Loader {
+        id: settingsPopupLoader
+        anchors.fill: parent
+        z: 100
+        active: root.showSettings
+
+        onActiveChanged: {
+            if (active) {
+                item.show = true
+                item.forceActiveFocus()
+            }
+        }
+
+        Connections {
+            target: settingsPopupLoader.item
+            function onDismiss() {
+                if (settingsPopupLoader.item) {
+                    settingsPopupLoader.item.show = false
+                }
+                root.showSettings = false
+            }
+            function onVisibleChanged() {
+                if (settingsPopupLoader.item && !settingsPopupLoader.item.visible && !root.showSettings) {
+                    settingsPopupLoader.active = false
+                }
+            }
+        }
+
+        sourceComponent: WallhavenSettingsPopup {}
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Top bar: search + controls
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: searchBarLayout.implicitHeight + 16
+            color: Appearance.colors.colLayer1
+            radius: Appearance.rounding.normal
+
+            RowLayout {
+                id: searchBarLayout
+                anchors {
+                    fill: parent
+                    margins: 8
+                }
+                spacing: 8
+
+                MaterialSymbol {
+                    text: "search"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colSubtext
+                }
+
+                TextField {
+                    id: searchField
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    placeholderText: Translation.tr("Search Wallhaven...")
+                    placeholderTextColor: Appearance.colors.colSubtext
+                    color: Appearance.colors.colOnLayer1
+                    font {
+                        family: Appearance.font.family.main
+                        pixelSize: Appearance.font.pixelSize.small
+                        hintingPreference: Font.PreferFullHinting
+                        variableAxes: Appearance.font.variableAxes.main
+                    }
+                    renderType: Text.NativeRendering
+                    selectedTextColor: Appearance.colors.colOnSecondaryContainer
+                    selectionColor: Appearance.colors.colSecondaryContainer
+                    text: WallhavenSearch.currentQuery
+                    background: Rectangle {
+                        color: "transparent"
+                    }
+
+                    // Debounce search
+                    Timer {
+                        id: searchDebounce
+                        interval: 500
+                        onTriggered: {
+                            WallhavenSearch.search(searchField.text, 1)
+                        }
+                    }
+
+                    onTextChanged: {
+                        searchDebounce.restart()
+                    }
+                    onEditingFinished: {
+                        searchDebounce.stop()
+                        WallhavenSearch.search(text, 1)
+                    }
+
+                    Keys.onPressed: event => {
+                        if (event.key === Qt.Key_Escape) {
+                            event.accepted = true
+                        }
+                    }
+                }
+
+                // Inline Pagination
+                RowLayout {
+                    visible: WallhavenSearch.currentResults.length > 0
+                    spacing: 4
+
+                    IconToolbarButton {
+                        implicitWidth: height
+                        text: "navigate_before"
+                        enabled: !root.loading && WallhavenSearch.currentPage > 1
+                        onClicked: WallhavenSearch.previousPage()
+                    }
+
+                    TextField {
+                        id: pageInput
+                        implicitWidth: 40
+                        Layout.fillHeight: true
+                        horizontalAlignment: Text.AlignHCenter
+                        text: "" + WallhavenSearch.currentPage
+                        inputMethodHints: Qt.ImhDigitsOnly
+                        enabled: !root.loading
+                        color: Appearance.colors.colOnLayer1
+                        font {
+                            family: Appearance.font.family.main
+                            pixelSize: Appearance.font.pixelSize.small
+                            hintingPreference: Font.PreferFullHinting
+                        }
+                        renderType: Text.NativeRendering
+                        background: Rectangle {
+                            color: Appearance.colors.colLayer1
+                            radius: Appearance.rounding.small
+                            border.width: 1
+                            border.color: pageInput.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
+                        }
+                        onEditingFinished: {
+                            var page = parseInt(text)
+                            if (!isNaN(page) && page >= 1 && page <= WallhavenSearch.lastPage) {
+                                if (page !== WallhavenSearch.currentPage)
+                                    WallhavenSearch.search(WallhavenSearch.currentQuery, page)
+                            } else {
+                                text = "" + WallhavenSearch.currentPage
+                            }
+                        }
+
+                        Connections {
+                            target: WallhavenSearch
+                            function onCurrentPageChanged() {
+                                pageInput.text = "" + WallhavenSearch.currentPage
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        text: "/ " + WallhavenSearch.lastPage
+                        font.pixelSize: Appearance.font.pixelSize.small
+                        color: Appearance.colors.colOnLayer1
+                    }
+
+                    IconToolbarButton {
+                        implicitWidth: height
+                        text: "navigate_next"
+                        enabled: !root.loading && WallhavenSearch.currentPage < WallhavenSearch.lastPage
+                        onClicked: WallhavenSearch.nextPage()
+                    }
+                }
+
+                IconToolbarButton {
+                    implicitWidth: height
+                    text: "tune"
+                    onClicked: root.showSettings = true
+                    StyledToolTip {
+                        text: Translation.tr("Wallhaven search settings")
+                    }
+                }
+
+                IconToolbarButton {
+                    implicitWidth: height
+                    text: root.useDarkMode ? "dark_mode" : "light_mode"
+                    onClicked: root.useDarkMode = !root.useDarkMode
+                    StyledToolTip {
+                        text: Translation.tr("Toggle light/dark mode for applied wallpaper")
+                    }
+                }
+            }
+        }
+
+        // Results grid
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            // Loading indicator
+            ColumnLayout {
+                anchors.centerIn: parent
+                visible: root.loading && wallhavenGrid.count === 0
+                spacing: 12
+
+                MaterialLoadingIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    color: Appearance.colors.colPrimary
+                }
+                StyledText {
+                    text: Translation.tr("Searching Wallhaven...")
+                    color: Appearance.colors.colSubtext
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+
+            // Error state
+            ColumnLayout {
+                anchors.centerIn: parent
+                visible: WallhavenSearch.lastError.length > 0 && !root.loading
+                spacing: 12
+
+                MaterialSymbol {
+                    text: "error"
+                    iconSize: 48
+                    color: Appearance.m3colors.m3error
+                    Layout.alignment: Qt.AlignHCenter
+                }
+                StyledText {
+                    text: WallhavenSearch.lastError
+                    color: Appearance.colors.colOnLayer0
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.alignment: Qt.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    Layout.maximumWidth: root.width * 0.8
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            // Empty state
+            ColumnLayout {
+                anchors.centerIn: parent
+                visible: !root.loading && WallhavenSearch.lastError.length === 0 && WallhavenSearch.currentResults.length === 0 && searchField.text.length > 0
+                spacing: 12
+
+                MaterialSymbol {
+                    text: "image_not_supported"
+                    iconSize: 48
+                    color: Appearance.colors.colSubtext
+                    Layout.alignment: Qt.AlignHCenter
+                }
+                StyledText {
+                    text: Translation.tr("No results found")
+                    color: Appearance.colors.colOnLayer0
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+
+            // Initial empty state (no search yet)
+            ColumnLayout {
+                anchors.centerIn: parent
+                visible: !root.loading && WallhavenSearch.lastError.length === 0 && WallhavenSearch.currentResults.length === 0 && searchField.text.length === 0
+                spacing: 12
+
+                MaterialSymbol {
+                    text: "travel_explore"
+                    iconSize: 48
+                    color: Appearance.colors.colSubtext
+                    Layout.alignment: Qt.AlignHCenter
+                }
+                StyledText {
+                    text: Translation.tr("Search for wallpapers on Wallhaven")
+                    color: Appearance.colors.colOnLayer0
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            }
+
+            // Grid
+            GridView {
+                id: wallhavenGrid
+                anchors.fill: parent
+                visible: WallhavenSearch.currentResults.length > 0
+                focus: true
+
+                property int columns: root.columns
+                property int currentSelection: -1
+                // "first" = select first item, "last" = select last item, "" = none
+                property string pendingSelectionAfterPageChange: ""
+
+                cellWidth: width / root.columns
+                cellHeight: cellWidth / root.previewCellAspectRatio
+                interactive: true
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                bottomMargin: 64
+                ScrollBar.vertical: StyledScrollBar {}
+
+                function moveSelection(delta) {
+                    if (wallhavenGrid.count === 0) return
+                    var newIndex = currentSelection + delta
+
+                    // Auto-paginate: went past the last item → next page
+                    if (newIndex >= wallhavenGrid.count) {
+                        if (!root.loading && WallhavenSearch.currentPage < WallhavenSearch.lastPage) {
+                            pendingSelectionAfterPageChange = "first"
+                            WallhavenSearch.nextPage()
+                        }
+                        return
+                    }
+                    // Auto-paginate: went before the first item → previous page
+                    if (newIndex < 0) {
+                        if (!root.loading && WallhavenSearch.currentPage > 1) {
+                            pendingSelectionAfterPageChange = "last"
+                            WallhavenSearch.previousPage()
+                        }
+                        return
+                    }
+
+                    currentSelection = newIndex
+                    positionViewAtIndex(currentSelection, GridView.Contain)
+                }
+
+                function activateCurrent() {
+                    if (currentSelection >= 0 && currentSelection < wallhavenGrid.count) {
+                        var wallpaper = WallhavenSearch.currentResults[currentSelection]
+                        if (wallpaper) {
+                            root.downloadAndApply(wallpaper)
+                        }
+                    }
+                }
+
+                // After page change, select first or last item as appropriate
+                Connections {
+                    target: WallhavenSearch
+                    function onSearchCompleted() {
+                        if (wallhavenGrid.pendingSelectionAfterPageChange === "first") {
+                            wallhavenGrid.currentSelection = 0
+                            wallhavenGrid.positionViewAtBeginning()
+                        } else if (wallhavenGrid.pendingSelectionAfterPageChange === "last") {
+                            wallhavenGrid.currentSelection = wallhavenGrid.count - 1
+                            wallhavenGrid.positionViewAtEnd()
+                        }
+                        wallhavenGrid.pendingSelectionAfterPageChange = ""
+                    }
+                }
+
+                Keys.onPressed: event => {
+                    if (event.key === Qt.Key_Left) {
+                        moveSelection(-1)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Right) {
+                        moveSelection(1)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Up) {
+                        moveSelection(-columns)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Down) {
+                        moveSelection(columns)
+                        event.accepted = true
+                    } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                        activateCurrent()
+                        event.accepted = true
+                    }
+                }
+
+                model: WallhavenSearch.currentResults
+
+                delegate: MouseArea {
+                    id: wallhavenItemRoot
+                    required property var modelData
+                    required property int index
+
+                    width: wallhavenGrid.cellWidth
+                    height: wallhavenGrid.cellHeight
+                    hoverEnabled: true
+
+                    property string thumbnailUrl: modelData ? WallhavenSearch.getThumbnailUrl(modelData, "large") : ""
+                    property string wallpaperId: modelData?.id ?? ""
+                    property bool isDownloading: root.downloading && root.downloadingId === wallpaperId
+
+                    onClicked: {
+                        wallhavenGrid.currentSelection = index
+                        root.downloadAndApply(modelData)
+                    }
+
+                    Rectangle {
+                        id: itemBackground
+                        anchors {
+                            fill: parent
+                            margins: Appearance.sizes.wallpaperSelectorItemMargins
+                        }
+                        radius: Appearance.rounding.normal
+                        color: (index === wallhavenGrid.currentSelection || wallhavenItemRoot.containsMouse)
+                            ? Appearance.colors.colPrimary
+                            : Appearance.colors.colLayer1
+
+                        Behavior on color {
+                            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+                        }
+
+                        ColumnLayout {
+                            anchors {
+                                fill: parent
+                                margins: Appearance.sizes.wallpaperSelectorItemPadding
+                            }
+                            spacing: 4
+
+                            // Thumbnail
+                            Item {
+                                id: thumbnailContainer
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+
+                                Image {
+                                    id: thumbnailImage
+                                    anchors.fill: parent
+                                    source: wallhavenItemRoot.thumbnailUrl
+                                    fillMode: Image.PreserveAspectCrop
+                                    asynchronous: true
+                                    cache: true
+                                    sourceSize.width: wallhavenGrid.cellWidth
+                                    sourceSize.height: wallhavenGrid.cellHeight
+
+                                    layer.enabled: true
+                                    layer.effect: OpacityMask {
+                                        maskSource: Rectangle {
+                                            width: thumbnailContainer.width
+                                            height: thumbnailContainer.height
+                                            radius: Appearance.rounding.small
+                                        }
+                                    }
+                                }
+
+                                // Loading state for individual thumbnails
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: Appearance.rounding.small
+                                    color: Appearance.colors.colLayer1
+                                    visible: thumbnailImage.status === Image.Loading || thumbnailImage.status === Image.Error
+
+                                    MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        text: thumbnailImage.status === Image.Error ? "broken_image" : "image"
+                                        iconSize: Appearance.font.pixelSize.hugeass
+                                        color: Appearance.colors.colSubtext
+                                    }
+                                }
+
+                                // Download overlay
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: Appearance.rounding.small
+                                    color: Appearance.colors.colScrim
+                                    visible: wallhavenItemRoot.isDownloading
+
+                                    MaterialLoadingIndicator {
+                                        anchors.centerIn: parent
+                                        color: Appearance.colors.colOnPrimary
+                                    }
+                                }
+
+                                // Resolution badge
+                                Rectangle {
+                                    anchors {
+                                        bottom: parent.bottom
+                                        right: parent.right
+                                        margins: 4
+                                    }
+                                    visible: modelData?.resolution ? true : false
+                                    color: Appearance.colors.colScrim
+                                    radius: Appearance.rounding.small
+                                    implicitWidth: resolutionText.implicitWidth + 8
+                                    implicitHeight: resolutionText.implicitHeight + 4
+
+                                    StyledText {
+                                        id: resolutionText
+                                        anchors.centerIn: parent
+                                        text: modelData?.resolution ?? ""
+                                        font.pixelSize: Appearance.font.pixelSize.smaller * 0.85
+                                        color: "white"
+                                    }
+                                }
+                            }
+
+                            // Wallpaper ID label
+                            StyledText {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 10
+                                Layout.rightMargin: 10
+                                horizontalAlignment: Text.AlignHCenter
+                                elide: Text.ElideRight
+                                font.pixelSize: Appearance.font.pixelSize.smaller
+                                color: (index === wallhavenGrid.currentSelection || wallhavenItemRoot.containsMouse)
+                                    ? Appearance.colors.colOnPrimary
+                                    : Appearance.colors.colOnLayer1
+                                Behavior on color {
+                                    animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+                                }
+                                text: wallpaperId
+                            }
+                        }
+                    }
+                }
+
+                layer.enabled: true
+                layer.effect: OpacityMask {
+                    maskSource: Rectangle {
+                        width: wallhavenGrid.width
+                        height: wallhavenGrid.height
+                        radius: Appearance.rounding.normal
+                    }
+                }
+            }
+
+            // Loading overlay when re-searching (has results but fetching new page)
+            Rectangle {
+                anchors.fill: parent
+                color: Appearance.colors.colScrim
+                visible: root.loading && wallhavenGrid.count > 0
+                radius: Appearance.rounding.normal
+
+                MaterialLoadingIndicator {
+                    anchors.centerIn: parent
+                    color: Appearance.colors.colPrimary
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSettingsPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSettingsPopup.qml
@@ -1,0 +1,320 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+/**
+ * Popup dialog for configuring Wallhaven search filters.
+ * Used within the wallpaper selector when Wallhaven mode is active.
+ */
+WindowDialog {
+    id: root
+    backgroundWidth: 460
+
+    // Force hide on startup
+    Component.onCompleted: {
+        show = false
+    }
+
+    function triggerSearch() {
+        WallhavenSearch.saveToConfig()
+        WallhavenSearch.search(WallhavenSearch.currentQuery, 1)
+    }
+
+    WindowDialogTitle {
+        text: Translation.tr("Wallhaven Settings")
+    }
+
+    WindowDialogSeparator {}
+
+    // API Key
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 4
+
+        StyledText {
+            text: Translation.tr("API Key")
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colSubtext
+        }
+
+        TextField {
+            id: apiKeyField
+            Layout.fillWidth: true
+            echoMode: TextInput.Password
+            placeholderText: Translation.tr("Optional — needed for NSFW")
+            placeholderTextColor: Appearance.colors.colSubtext
+            color: Appearance.colors.colOnLayer1
+            text: WallhavenSearch.apiKey
+            font {
+                family: Appearance.font.family.main
+                pixelSize: Appearance.font.pixelSize.small
+                hintingPreference: Font.PreferFullHinting
+            }
+            renderType: Text.NativeRendering
+            background: Rectangle {
+                color: Appearance.colors.colLayer1
+                radius: Appearance.rounding.small
+                border.width: 1
+                border.color: apiKeyField.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
+            }
+            onEditingFinished: {
+                WallhavenSearch.apiKey = text
+                WallhavenSearch.saveToConfig()
+            }
+        }
+    }
+
+    WindowDialogSeparator {}
+
+    // Sorting
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 10
+
+        StyledText {
+            text: Translation.tr("Sort by")
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.preferredWidth: 80
+        }
+
+        StyledComboBox {
+            id: sortingCombo
+            Layout.fillWidth: true
+            model: [
+                Translation.tr("Date Added"),
+                Translation.tr("Relevance"),
+                Translation.tr("Random"),
+                Translation.tr("Views"),
+                Translation.tr("Favorites"),
+                Translation.tr("Top List"),
+            ]
+            property var sortKeys: ["date_added", "relevance", "random", "views", "favorites", "toplist"]
+            currentIndex: sortKeys.indexOf(WallhavenSearch.sorting)
+            onCurrentIndexChanged: {
+                if (currentIndex >= 0) {
+                    WallhavenSearch.sorting = sortKeys[currentIndex]
+                    root.triggerSearch()
+                }
+            }
+        }
+    }
+
+    // Order
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 10
+        visible: sortingCombo.currentIndex !== 2 // Hide for "random"
+
+        StyledText {
+            text: Translation.tr("Order")
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.preferredWidth: 80
+        }
+
+        StyledComboBox {
+            Layout.fillWidth: true
+            model: [Translation.tr("Descending"), Translation.tr("Ascending")]
+            property var orderKeys: ["desc", "asc"]
+            currentIndex: orderKeys.indexOf(WallhavenSearch.order)
+            onCurrentIndexChanged: {
+                if (currentIndex >= 0) {
+                    WallhavenSearch.order = orderKeys[currentIndex]
+                    root.triggerSearch()
+                }
+            }
+        }
+    }
+
+    WindowDialogSeparator {}
+
+    // Categories
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 10
+
+        StyledText {
+            text: Translation.tr("Categories")
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.preferredWidth: 80
+        }
+
+        RowLayout {
+            spacing: 12
+
+            RippleButton {
+                implicitWidth: implicitHeight * 2.5
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.categories.charAt(0) === "1"
+                colBackgroundToggled: Appearance.colors.colPrimary
+                onClicked: {
+                    var cats = WallhavenSearch.categories
+                    WallhavenSearch.categories = (cats.charAt(0) === "1" ? "0" : "1") + cats.charAt(1) + cats.charAt(2)
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: Translation.tr("General")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            RippleButton {
+                implicitWidth: implicitHeight * 2.5
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.categories.charAt(1) === "1"
+                colBackgroundToggled: Appearance.colors.colPrimary
+                onClicked: {
+                    var cats = WallhavenSearch.categories
+                    WallhavenSearch.categories = cats.charAt(0) + (cats.charAt(1) === "1" ? "0" : "1") + cats.charAt(2)
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: Translation.tr("Anime")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            RippleButton {
+                implicitWidth: implicitHeight * 2.5
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.categories.charAt(2) === "1"
+                colBackgroundToggled: Appearance.colors.colPrimary
+                onClicked: {
+                    var cats = WallhavenSearch.categories
+                    WallhavenSearch.categories = cats.charAt(0) + cats.charAt(1) + (cats.charAt(2) === "1" ? "0" : "1")
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: Translation.tr("People")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+        }
+    }
+
+    // Purity
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 10
+
+        StyledText {
+            text: Translation.tr("Purity")
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.preferredWidth: 80
+        }
+
+        RowLayout {
+            spacing: 12
+
+            RippleButton {
+                implicitWidth: implicitHeight * 2
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.purity.charAt(0) === "1"
+                colBackgroundToggled: Appearance.colors.colPrimary
+                onClicked: {
+                    var p = WallhavenSearch.purity
+                    WallhavenSearch.purity = (p.charAt(0) === "1" ? "0" : "1") + p.charAt(1) + p.charAt(2)
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: "SFW"
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            RippleButton {
+                implicitWidth: implicitHeight * 2.5
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.purity.charAt(1) === "1"
+                colBackgroundToggled: Appearance.colors.colPrimary
+                onClicked: {
+                    var p = WallhavenSearch.purity
+                    WallhavenSearch.purity = p.charAt(0) + (p.charAt(1) === "1" ? "0" : "1") + p.charAt(2)
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: Translation.tr("Sketchy")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            RippleButton {
+                visible: WallhavenSearch.apiKey.length > 0
+                implicitWidth: implicitHeight * 2
+                implicitHeight: 32
+                buttonRadius: height / 2
+                toggled: WallhavenSearch.purity.charAt(2) === "1"
+                colBackgroundToggled: Appearance.m3colors.m3error
+                onClicked: {
+                    var p = WallhavenSearch.purity
+                    WallhavenSearch.purity = p.charAt(0) + p.charAt(1) + (p.charAt(2) === "1" ? "0" : "1")
+                    root.triggerSearch()
+                }
+                contentItem: StyledText {
+                    text: "NSFW"
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+        }
+    }
+
+    WindowDialogSeparator {}
+
+    // Aspect Ratio
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 10
+
+        StyledText {
+            text: Translation.tr("Ratio")
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.preferredWidth: 80
+        }
+
+        StyledComboBox {
+            Layout.fillWidth: true
+            model: [
+                Translation.tr("Any"),
+                "16x9", "16x10", "21x9", "32x9",
+                "9x16", "10x16",
+                "1x1", "3x2", "4x3", "5x4",
+            ]
+            property var ratioKeys: ["", "16x9", "16x10", "21x9", "32x9", "9x16", "10x16", "1x1", "3x2", "4x3", "5x4"]
+            currentIndex: Math.max(0, ratioKeys.indexOf(WallhavenSearch.ratios))
+            onCurrentIndexChanged: {
+                if (currentIndex >= 0) {
+                    WallhavenSearch.ratios = ratioKeys[currentIndex]
+                    root.triggerSearch()
+                }
+            }
+        }
+    }
+
+    // Close button
+    WindowDialogButtonRow {
+        DialogButton {
+            text: Translation.tr("Close")
+            onClicked: root.dismiss()
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -15,22 +15,23 @@ MouseArea {
     property int columns: 4
     property real previewCellAspectRatio: 4 / 3
     property bool useDarkMode: Appearance.m3colors.darkmode
+    property string wallpaperSource: "local" // "local" or "wallhaven"
 
     function updateThumbnails() {
-        const totalImageMargin = (Appearance.sizes.wallpaperSelectorItemMargins + Appearance.sizes.wallpaperSelectorItemPadding) * 2;
-        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions(grid.cellWidth - totalImageMargin, grid.cellHeight - totalImageMargin);
-        Wallpapers.generateThumbnail(thumbnailSizeName);
+        const totalImageMargin = (Appearance.sizes.wallpaperSelectorItemMargins + Appearance.sizes.wallpaperSelectorItemPadding) * 2
+        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions(grid.cellWidth - totalImageMargin, grid.cellHeight - totalImageMargin)
+        Wallpapers.generateThumbnail(thumbnailSizeName)
     }
 
     Connections {
         target: Wallpapers
         function onDirectoryChanged() {
-            root.updateThumbnails();
+            root.updateThumbnails()
         }
     }
 
     function handleFilePasting(event) {
-        const currentClipboardEntry = Cliphist.entries[0];
+        const currentClipboardEntry = Cliphist.entries[0]
         if (/^\d+\tfile:\/\/\S+/.test(currentClipboardEntry)) {
             const url = StringUtils.cleanCliphistEntry(currentClipboardEntry);
             Wallpapers.setDirectory(FileUtils.trimFileProtocol(decodeURIComponent(url)));
@@ -60,6 +61,24 @@ MouseArea {
         if (event.key === Qt.Key_Escape) {
             GlobalStates.wallpaperSelectorOpen = false;
             event.accepted = true;
+        } else if (root.wallpaperSource === "wallhaven") {
+            // Forward navigation keys to the Wallhaven grid
+            if (event.key === Qt.Key_Left) {
+                wallhavenSearchGrid.moveGridSelection(-1)
+                event.accepted = true
+            } else if (event.key === Qt.Key_Right) {
+                wallhavenSearchGrid.moveGridSelection(1)
+                event.accepted = true
+            } else if (event.key === Qt.Key_Up) {
+                wallhavenSearchGrid.moveGridSelection(-root.columns)
+                event.accepted = true
+            } else if (event.key === Qt.Key_Down) {
+                wallhavenSearchGrid.moveGridSelection(root.columns)
+                event.accepted = true
+            } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                wallhavenSearchGrid.activateGridCurrent()
+                event.accepted = true
+            }
         } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_V) { // Intercept Ctrl+V to handle "paste to go to" in pickers
             root.handleFilePasting(event);
         } else if (event.modifiers & Qt.AltModifier && event.key === Qt.Key_Up) {
@@ -137,6 +156,7 @@ MouseArea {
             spacing: -4
 
             Rectangle {
+                visible: root.wallpaperSource === "local"
                 Layout.fillHeight: true
                 Layout.margins: 4
                 implicitWidth: quickDirColumnLayout.implicitWidth
@@ -164,48 +184,15 @@ MouseArea {
                         implicitWidth: 140
                         clip: true
                         model: [
-                            {
-                                icon: "home",
-                                name: "Home",
-                                path: Directories.home
-                            },
-                            {
-                                icon: "docs",
-                                name: "Documents",
-                                path: Directories.documents
-                            },
-                            {
-                                icon: "download",
-                                name: "Downloads",
-                                path: Directories.downloads
-                            },
-                            {
-                                icon: "image",
-                                name: "Pictures",
-                                path: Directories.pictures
-                            },
-                            {
-                                icon: "movie",
-                                name: "Videos",
-                                path: Directories.videos
-                            },
-                            {
-                                icon: "",
-                                name: "---",
-                                path: "INTENTIONALLY_INVALID_DIR"
-                            },
-                            {
-                                icon: "wallpaper",
-                                name: "Wallpapers",
-                                path: `${Directories.pictures}/Wallpapers`
-                            },
-                            ...(Config.options.policies.weeb === 1 ? [
-                                    {
-                                        icon: "favorite",
-                                        name: "Homework",
-                                        path: `${Directories.pictures}/homework`
-                                    }
-                                ] : []),]
+                            { icon: "home", name: "Home", path: Directories.home }, 
+                            { icon: "docs", name: "Documents", path: Directories.documents }, 
+                            { icon: "download", name: "Downloads", path: Directories.downloads }, 
+                            { icon: "image", name: "Pictures", path: Directories.pictures }, 
+                            { icon: "movie", name: "Videos", path: Directories.videos }, 
+                            { icon: "", name: "---", path: "INTENTIONALLY_INVALID_DIR" }, 
+                            { icon: "wallpaper", name: "Wallpapers", path: `${Directories.pictures}/Wallpapers` }, 
+                            ...(Config.options.policies.weeb === 1 ? [{ icon: "favorite", name: "Homework", path: `${Directories.pictures}/homework` }] : []),
+                        ]
                         delegate: RippleButton {
                             id: quickDirButton
                             required property var modelData
@@ -243,6 +230,7 @@ MouseArea {
 
             ColumnLayout {
                 id: gridColumnLayout
+                visible: root.wallpaperSource === "local"
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
@@ -300,7 +288,7 @@ MouseArea {
                         ScrollBar.vertical: StyledScrollBar {}
 
                         Component.onCompleted: {
-                            root.updateThumbnails();
+                            root.updateThumbnails()
                         }
 
                         function moveSelection(delta) {
@@ -309,7 +297,7 @@ MouseArea {
                         }
 
                         function activateCurrent() {
-                            const filePath = grid.model.get(currentIndex, "filePath");
+                            const filePath = grid.model.get(currentIndex, "filePath")
                             root.selectWallpaperPath(filePath);
                         }
 
@@ -327,7 +315,7 @@ MouseArea {
                             onEntered: {
                                 grid.currentIndex = index;
                             }
-
+                            
                             onActivated: {
                                 root.selectWallpaperPath(fileModelData.filePath);
                             }
@@ -343,96 +331,129 @@ MouseArea {
                         }
                     }
 
-                    Row {
-                        id: extraOptions
-                        anchors {
-                            bottom: parent.bottom
-                            horizontalCenter: parent.horizontalCenter
-                            bottomMargin: 8
+                }
+            }
+
+            // Wallhaven search grid (replaces local view when active)
+            WallhavenSearchGrid {
+                id: wallhavenSearchGrid
+                visible: root.wallpaperSource === "wallhaven"
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.margins: 4
+                columns: root.columns
+                previewCellAspectRatio: root.previewCellAspectRatio
+                useDarkMode: root.useDarkMode
+                onWallpaperApplied: {
+                    GlobalStates.wallpaperSelectorOpen = false
+                }
+            }
+        }
+
+        // Floating toolbar — outside mainLayout so it shows in both local and wallhaven modes
+        Toolbar {
+            id: extraOptions
+            z: 50
+            anchors {
+                bottom: parent.bottom
+                horizontalCenter: parent.horizontalCenter
+                bottomMargin: 8
+            }
+
+            IconToolbarButton {
+                implicitWidth: height
+                visible: root.wallpaperSource === "local"
+                onClicked: {
+                    Wallpapers.openFallbackPicker(root.useDarkMode);
+                    GlobalStates.wallpaperSelectorOpen = false;
+                }
+                altAction: () => {
+                    Wallpapers.openFallbackPicker(root.useDarkMode);
+                    GlobalStates.wallpaperSelectorOpen = false;
+                    Config.options.wallpaperSelector.useSystemFileDialog = true
+                }
+                text: "open_in_new"
+                StyledToolTip {
+                    text: Translation.tr("Use the system file picker instead\nRight-click to make this the default behavior")
+                }
+            }
+
+            IconToolbarButton {
+                implicitWidth: height
+                visible: root.wallpaperSource === "local"
+                onClicked: {
+                    Wallpapers.randomFromCurrentFolder();
+                }
+                text: "ifl"
+                StyledToolTip {
+                    text: Translation.tr("Pick random from this folder")
+                }
+            }
+
+            IconToolbarButton {
+                implicitWidth: height
+                visible: root.wallpaperSource === "local"
+                onClicked: root.useDarkMode = !root.useDarkMode
+                text: root.useDarkMode ? "dark_mode" : "light_mode"
+                StyledToolTip {
+                    text: Translation.tr("Click to toggle light/dark mode\n(applied when wallpaper is chosen)")
+                }
+            }
+
+            IconToolbarButton {
+                implicitWidth: height
+                onClicked: {
+                    root.wallpaperSource = (root.wallpaperSource === "local") ? "wallhaven" : "local"
+                }
+                text: root.wallpaperSource === "wallhaven" ? "folder" : "travel_explore"
+                StyledToolTip {
+                    text: root.wallpaperSource === "wallhaven" ? Translation.tr("Switch to local wallpapers") : Translation.tr("Search Wallhaven for wallpapers")
+                }
+            }
+
+            ToolbarTextField {
+                id: filterField
+                visible: root.wallpaperSource === "local"
+                placeholderText: focus ? Translation.tr("Search wallpapers") : Translation.tr("Hit \"/\" to search")
+
+                // Style
+                clip: true
+                font.pixelSize: Appearance.font.pixelSize.small
+
+                // Search
+                onTextChanged: {
+                    Wallpapers.searchQuery = text;
+                }
+
+                Keys.onPressed: event => {
+                    if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_V) {
+                        root.handleFilePasting(event);
+                        return;
+                    }
+                    else if (text.length !== 0) {
+                        if (event.key === Qt.Key_Down) {
+                            grid.moveSelection(grid.columns);
+                            event.accepted = true;
+                            return;
                         }
-                        spacing: 6
-                        Toolbar {
-
-                            IconToolbarButton {
-                                implicitWidth: height
-                                onClicked: {
-                                    Wallpapers.openFallbackPicker(root.useDarkMode);
-                                    GlobalStates.wallpaperSelectorOpen = false;
-                                }
-                                altAction: () => {
-                                    Wallpapers.openFallbackPicker(root.useDarkMode);
-                                    GlobalStates.wallpaperSelectorOpen = false;
-                                    Config.options.wallpaperSelector.useSystemFileDialog = true;
-                                }
-                                text: "open_in_new"
-                                StyledToolTip {
-                                    text: Translation.tr("Use the system file picker instead\nRight-click to make this the default behavior")
-                                }
-                            }
-
-                            IconToolbarButton {
-                                implicitWidth: height
-                                onClicked: {
-                                    Wallpapers.randomFromCurrentFolder();
-                                }
-                                text: "ifl"
-                                StyledToolTip {
-                                    text: Translation.tr("Pick random from this folder")
-                                }
-                            }
-
-                            IconToolbarButton {
-                                implicitWidth: height
-                                onClicked: root.useDarkMode = !root.useDarkMode
-                                text: root.useDarkMode ? "dark_mode" : "light_mode"
-                                StyledToolTip {
-                                    text: Translation.tr("Click to toggle light/dark mode\n(applied when wallpaper is chosen)")
-                                }
-                            }
-
-                            ToolbarTextField {
-                                id: filterField
-                                placeholderText: focus ? Translation.tr("Search wallpapers") : Translation.tr("Hit \"/\" to search")
-
-                                // Style
-                                clip: true
-                                font.pixelSize: Appearance.font.pixelSize.small
-
-                                // Search
-                                onTextChanged: {
-                                    Wallpapers.searchQuery = text;
-                                }
-
-                                Keys.onPressed: event => {
-                                    if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_V) { // Intercept Ctrl+V to handle "paste to go to" in pickers
-                                        root.handleFilePasting(event);
-                                        return;
-                                    } else if (text.length !== 0) {
-                                        // No filtering, just navigate grid
-                                        if (event.key === Qt.Key_Down) {
-                                            grid.moveSelection(grid.columns);
-                                            event.accepted = true;
-                                            return;
-                                        }
-                                        if (event.key === Qt.Key_Up) {
-                                            grid.moveSelection(-grid.columns);
-                                            event.accepted = true;
-                                            return;
-                                        }
-                                    }
-                                    event.accepted = false;
-                                }
-                            }
-                        }
-
-                        ToolbarPairedFab {
-                            iconText: "close"
-                            onClicked: GlobalStates.wallpaperSelectorOpen = false;
-                            StyledToolTip {
-                                text: Translation.tr("Cancel wallpaper selection")
-                            }
+                        if (event.key === Qt.Key_Up) {
+                            grid.moveSelection(-grid.columns);
+                            event.accepted = true;
+                            return;
                         }
                     }
+                    event.accepted = false;
+                }
+            }
+
+            IconToolbarButton {
+                implicitWidth: height
+                onClicked: {
+                    GlobalStates.wallpaperSelectorOpen = false;
+                }
+                text: "close"
+                StyledToolTip {
+                    text: Translation.tr("Cancel wallpaper selection")
                 }
             }
         }

--- a/dots/.config/quickshell/ii/services/WallhavenSearch.qml
+++ b/dots/.config/quickshell/ii/services/WallhavenSearch.qml
@@ -1,0 +1,256 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+/**
+ * Service for searching and downloading wallpapers from wallhaven.cc
+ */
+Singleton {
+    id: root
+
+    // State
+    property bool fetching: false
+    property var currentResults: []
+    property var currentMeta: ({})
+    property string lastError: ""
+    property string currentQuery: ""
+    property int currentPage: 1
+    property int lastPage: 1
+
+    // Search parameters
+    property string categories: "111" // general,anime,people (all enabled)
+    property string purity: "100" // sfw
+    property string sorting: "relevance"
+    property string order: "desc"
+    property string topRange: "1M"
+    property string seed: ""
+    property string minResolution: ""
+    property string ratios: ""
+    property string apiKey: ""
+
+    // Download directory
+    readonly property string downloadDirectory: `${FileUtils.trimFileProtocol(Directories.pictures)}/Wallpapers`
+
+    // Signals
+    signal searchCompleted(var results, var meta)
+    signal searchFailed(string error)
+    signal wallpaperDownloaded(string wallpaperId, string localPath)
+    readonly property string apiBaseUrl: "https://wallhaven.cc/api/v1"
+
+    Component.onCompleted: {
+        loadFromConfig()
+    }
+
+    function loadFromConfig() {
+        const cfg = Config.options?.wallpaperSelector
+        if (!cfg) return
+        apiKey = cfg.wallhavenApiKey || ""
+        categories = cfg.wallhavenCategories || "111"
+        purity = cfg.wallhavenPurity || "100"
+        sorting = cfg.wallhavenSorting || "relevance"
+        order = cfg.wallhavenOrder || "desc"
+        ratios = cfg.wallhavenRatios || ""
+        currentQuery = cfg.wallhavenQuery || ""
+    }
+
+    function saveToConfig() {
+        const cfg = Config.options?.wallpaperSelector
+        if (!cfg) return
+        cfg.wallhavenApiKey = apiKey
+        cfg.wallhavenCategories = categories
+        cfg.wallhavenPurity = purity
+        cfg.wallhavenSorting = sorting
+        cfg.wallhavenOrder = order
+        cfg.wallhavenRatios = ratios
+        cfg.wallhavenQuery = currentQuery
+    }
+
+    function search(query, page) {
+        if (fetching) return
+
+        fetching = true
+        lastError = ""
+        currentQuery = query || ""
+        currentPage = page || 1
+
+        var url = apiBaseUrl + "/search"
+        var params = []
+
+        if (currentQuery){
+            params.push("q=" + encodeURIComponent(currentQuery))
+        }
+
+        params.push("categories=" + categories)
+        var safePurity = (purity === "000") ? "100" : purity
+        params.push("purity=" + safePurity)
+        params.push("sorting=" + sorting)
+        params.push("order=" + order)
+
+        if (sorting === "toplist"){
+            params.push("topRange=" + topRange)
+        }
+
+        if (sorting === "random" && seed){
+            params.push("seed=" + seed)
+        }
+
+        if (minResolution){
+            params.push("atleast=" + minResolution)
+        }
+
+        if (ratios){
+            params.push("ratios=" + ratios)
+        }
+
+        if (apiKey){
+            params.push("apikey=" + apiKey)
+        }
+
+        params.push("page=" + currentPage)
+
+        url += "?" + params.join("&")
+
+        console.log("[WallhavenSearch] Searching:", url.replace(/apikey=[^&]+/, "apikey=***"))
+
+        var xhr = new XMLHttpRequest()
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                fetching = false
+                if (xhr.status === 200) {
+                    try {
+                        var response = JSON.parse(xhr.responseText)
+                        if (response.data && Array.isArray(response.data)) {
+                            currentResults = response.data
+                            currentMeta = response.meta || {}
+                            lastPage = currentMeta.last_page || 1
+                            if (currentMeta.seed){
+                                seed = currentMeta.seed
+                            }
+                            console.log("[WallhavenSearch] Search completed:", currentResults.length, "results, page", currentPage, "of", lastPage)
+                            searchCompleted(currentResults, currentMeta)
+                        } else {
+                            lastError = "Invalid API response"
+                            console.warn("[WallhavenSearch]", lastError)
+                            searchFailed(lastError)
+                        }
+                    } catch (e) {
+                        lastError = "Failed to parse API response: " + e.toString()
+                        console.warn("[WallhavenSearch]", lastError)
+                        searchFailed(lastError)
+                    }
+                } else if (xhr.status === 429) {
+                    lastError = Translation.tr("Rate limit exceeded (45 requests/minute)")
+                    console.warn("[WallhavenSearch]", lastError)
+                    searchFailed(lastError)
+                } else if (xhr.status === 401) {
+                    lastError = Translation.tr("Invalid API Key")
+                    console.warn("[WallhavenSearch]", lastError)
+                    searchFailed(lastError)
+                } else {
+                    lastError = "API error: " + xhr.status
+                    console.warn("[WallhavenSearch]", lastError)
+                    searchFailed(lastError)
+                }
+            }
+        }
+
+        xhr.open("GET", url)
+        xhr.send()
+    }
+
+    function getWallpaperUrl(wallpaper) {
+        if (wallpaper.path){ return wallpaper.path }
+        if (wallpaper.id) {
+            var idPrefix = wallpaper.id.substring(0, 2)
+            return "https://w.wallhaven.cc/full/" + idPrefix + "/wallhaven-" + wallpaper.id + ".jpg"
+        }
+        return ""
+    }
+
+    function getThumbnailUrl(wallpaper, size) {
+        // size: "small", "large", "original"
+        if (wallpaper.thumbs && wallpaper.thumbs[size]){
+            return wallpaper.thumbs[size]
+        }
+        if (wallpaper.id) {
+            var idPrefix = wallpaper.id.substring(0, 2)
+            var sizeMap = { "small": "small", "large": "lg", "original": "orig" }
+            var sizePath = sizeMap[size] || "lg"
+            return "https://th.wallhaven.cc/" + sizePath + "/" + idPrefix + "/" + wallpaper.id + ".jpg"
+        }
+        return ""
+    }
+
+    // Download process
+    Process {
+        id: downloadProc
+        property string localPath: ""
+        property var callback: null
+        property string wallpaperId: ""
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0) {
+                console.log("[WallhavenSearch] Wallpaper downloaded:", downloadProc.localPath)
+                root.wallpaperDownloaded(downloadProc.wallpaperId, downloadProc.localPath)
+                if (downloadProc.callback){
+                    downloadProc.callback(true, downloadProc.localPath)
+                }
+            } else {
+                console.warn("[WallhavenSearch] Failed to download wallpaper, exit code:", exitCode)
+                if (downloadProc.callback){
+                    downloadProc.callback(false, "")
+                }
+            }
+        }
+    }
+
+    function downloadWallpaper(wallpaper, callback) {
+        var url = getWallpaperUrl(wallpaper)
+        if (!url) {
+            console.warn("[WallhavenSearch] No URL available for wallpaper", wallpaper.id)
+            if (callback) callback(false, "")
+            return
+        }
+
+        var wallpaperId = wallpaper.id || "unknown"
+        var extension = url.split('.').pop() || "jpg"
+        var localPath = downloadDirectory + "/wallhaven_" + wallpaperId + "." + extension
+
+        console.log("[WallhavenSearch] Downloading wallpaper", wallpaperId, "to", localPath)
+
+        downloadProc.localPath = localPath
+        downloadProc.callback = callback
+        downloadProc.wallpaperId = wallpaperId
+        downloadProc.command = [
+            "bash", "-c",
+            `mkdir -p '${downloadDirectory}' && curl -L -s -o '${localPath}' '${url}'`
+        ]
+        downloadProc.running = true
+    }
+
+    function reset() {
+        currentResults = []
+        currentMeta = {}
+        currentQuery = ""
+        currentPage = 1
+        lastPage = 1
+        seed = ""
+        lastError = ""
+    }
+
+    function nextPage() {
+        if (currentPage < lastPage && !fetching){
+            search(currentQuery, currentPage + 1)
+        }
+    }
+
+    function previousPage() {
+        if (currentPage > 1 && !fetching){
+            search(currentQuery, currentPage - 1)
+        }
+    }
+}


### PR DESCRIPTION
## Feature: Added Wallhaven support in wallpaper selector menu

### Description

This pull request adds support for searching and downloading wallpapers from Wallhaven.cc in the wallpaper selector menu. The user can now search for wallpapers by category, purity, sorting, order, and other parameters. The search results are displayed in a grid with live previews, and the user can select a wallpaper to download and apply it as their desktop background.

### Changes Made

- Added [dots/.config/quickshell/ii/services/WallhavenSearch.qml 
- file to handle the Wallhaven API calls and wallpaper downloads.
- Updated [dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSearchGrid.qml]
- file to display the search results and handle user interactions.
- Updated [dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallhavenSettingsPopup.qml]
-  file to include options for sorting and ordering the search results.
- 
### Testing

I have tested this feature on my local machine and it works as expected without any bug as far as i could test.


### Screenshots


### Example Usage

1. Open the wallpaper selector menu.
2. Click on the Wallhaven tab.
3. Enter a search query and select the desired search parameters.
4. Click the "Search" button to start the search.
5. Select a wallpaper from the search results.
6. Click the wallpaper to download and apply the wallpaper.
7. The wallpaper are saved in Pictures/Wallpapers folder
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/7287e4b4-ef1f-448b-a8f5-e8e8425e6aed" />
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/4780fa6a-30e8-45b6-9177-a6be609379a6" />

https://github.com/user-attachments/assets/aa8b8d97-35e9-48b2-bdca-35ebb8075aaf

