### PR TITLE
Easily configurable Pomodoro

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -568,6 +568,7 @@ Singleton {
                     property int cyclesBeforeLongBreak: 4
                     property int focus: 1500
                     property int longBreak: 900
+                    property int alarmVolume: 100 // 0–100, controls ffplay -volume for the pomodoro alarm
                 }
                 property bool secondPrecision: false
             }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/BottomWidgetGroup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/BottomWidgetGroup.qml
@@ -13,7 +13,14 @@ Rectangle {
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
     clip: true
-    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : 350
+    // Track whether the pomodoro timer's inline editor is open so we can grow to fit it
+    property bool pomodoroTimerEditMode: {
+        if (selectedTab !== 2) return false;
+        if (tabStack.status !== Loader.Ready || !tabStack.item) return false;
+        return tabStack.item.timerEditMode ?? false;
+    }
+
+    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : (pomodoroTimerEditMode ? 530 : 350)
     property int selectedTab: Persistent.states.sidebar.bottomGroup.tab
     property int previousIndex: -1
     property bool collapsed: Persistent.states.sidebar.bottomGroup.collapsed

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
@@ -10,6 +10,8 @@ import Quickshell
 Item {
     id: root
 
+    property bool editMode: false
+
     implicitHeight: contentColumn.implicitHeight
     implicitWidth: contentColumn.implicitWidth
 
@@ -23,12 +25,13 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             lineWidth: 8
             value: {
-                return TimerService.pomodoroSecondsLeft / TimerService.pomodoroLapDuration;
+                return TimerService.pomodoroLapDuration > 0 ? TimerService.pomodoroSecondsLeft / TimerService.pomodoroLapDuration : 0;
             }
             implicitSize: 200
             enableAnimation: true
 
             ColumnLayout {
+                id: timerCenterLayout
                 anchors.centerIn: parent
                 spacing: 0
 
@@ -41,6 +44,10 @@ Item {
                     }
                     font.pixelSize: 40
                     color: Appearance.m3colors.m3onSurface
+                    opacity: timerEditArea.containsMouse ? 0.65 : 1.0
+                    Behavior on opacity {
+                        NumberAnimation { duration: 150 }
+                    }
                 }
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
@@ -48,12 +55,71 @@ Item {
                     font.pixelSize: Appearance.font.pixelSize.normal
                     color: Appearance.colors.colSubtext
                 }
+                MaterialSymbol {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: editMode ? "expand_less" : "edit"
+                    iconSize: 14
+                    color: Appearance.colors.colSubtext
+                    opacity: timerEditArea.containsMouse ? 1.0 : 0.0
+                    Behavior on opacity {
+                        NumberAnimation { duration: 150 }
+                    }
+                }
             }
 
+            // Invisible hit area over the center text – toggles edit mode
+            MouseArea {
+                id: timerEditArea
+                anchors.centerIn: parent
+                width: timerCenterLayout.width + 24
+                height: timerCenterLayout.height + 16
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: editMode = !editMode
+            }
+
+            // Skip button – top-right, above the cycle badge
+            Rectangle {
+                radius: Appearance.rounding.full
+                color: skipMouseArea.containsMouse ? Appearance.colors.colLayer2Hover : Appearance.colors.colLayer2
+
+                anchors {
+                    right: parent.right
+                    top: parent.top
+                }
+                implicitWidth: 36
+                implicitHeight: 36
+
+                Behavior on color {
+                    ColorAnimation { duration: 150 }
+                }
+
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "skip_next"
+                    iconSize: 20
+                    color: Appearance.colors.colOnLayer2
+                }
+
+                MouseArea {
+                    id: skipMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: TimerService.skipPomodoro()
+                }
+
+                StyledToolTip {
+                    text: TimerService.pomodoroBreak ? Translation.tr("Skip to focus") : Translation.tr("Skip to break")
+                    extraVisibleCondition: skipMouseArea.containsMouse
+                }
+            }
+
+            // Cycle badge – bottom-right
             Rectangle {
                 radius: Appearance.rounding.full
                 color: Appearance.colors.colLayer2
-                
+
                 anchors {
                     right: parent.right
                     bottom: parent.bottom
@@ -107,6 +173,72 @@ Item {
                     horizontalAlignment: Text.AlignHCenter
                     text: Translation.tr("Reset")
                     color: Appearance.colors.colOnErrorContainer
+                }
+            }
+        }
+
+        // Inline duration editor – toggled by clicking the time display
+        ColumnLayout {
+            visible: editMode
+            Layout.fillWidth: true
+            spacing: 4
+            Layout.topMargin: 12
+            Layout.leftMargin: 12
+            Layout.rightMargin: 12
+            Layout.bottomMargin: 4
+
+            GridLayout {
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 6
+                Layout.fillWidth: true
+
+                StyledText {
+                    text: Translation.tr("Focus (min)")
+                    color: Appearance.colors.colOnSecondaryContainer
+                    Layout.fillWidth: true
+                }
+                StyledSpinBox {
+                    value: Math.round(Config.options.time.pomodoro.focus / 60)
+                    from: 1
+                    to: 120
+                    onValueChanged: Config.options.time.pomodoro.focus = value * 60
+                }
+
+                StyledText {
+                    text: Translation.tr("Break (min)")
+                    color: Appearance.colors.colOnSecondaryContainer
+                    Layout.fillWidth: true
+                }
+                StyledSpinBox {
+                    value: Math.round(Config.options.time.pomodoro.breakTime / 60)
+                    from: 0
+                    to: 60
+                    onValueChanged: Config.options.time.pomodoro.breakTime = value * 60
+                }
+
+                StyledText {
+                    text: Translation.tr("Long break (min)")
+                    color: Appearance.colors.colOnSecondaryContainer
+                    Layout.fillWidth: true
+                }
+                StyledSpinBox {
+                    value: Math.round(Config.options.time.pomodoro.longBreak / 60)
+                    from: 0
+                    to: 60
+                    onValueChanged: Config.options.time.pomodoro.longBreak = value * 60
+                }
+
+                StyledText {
+                    text: Translation.tr("Cycles")
+                    color: Appearance.colors.colOnSecondaryContainer
+                    Layout.fillWidth: true
+                }
+                StyledSpinBox {
+                    value: Config.options.time.pomodoro.cyclesBeforeLongBreak
+                    from: 1
+                    to: 10
+                    onValueChanged: Config.options.time.pomodoro.cyclesBeforeLongBreak = value
                 }
             }
         }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
@@ -7,6 +7,7 @@ import QtQuick.Layouts
 
 Item {
     id: root
+    property alias timerEditMode: pomodoroTimerWidget.editMode
     property var tabButtonList: [
         {"name": Translation.tr("Pomodoro"), "icon": "search_activity"},
         {"name": Translation.tr("Stopwatch"), "icon": "timer"}
@@ -68,7 +69,7 @@ Item {
             currentIndex: tabBar.currentIndex
 
             // Tabs
-            PomodoroTimer {}
+            PomodoroTimer { id: pomodoroTimerWidget }
             Stopwatch {}
         }
     }

--- a/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
@@ -68,6 +68,56 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "timer"
+        title: Translation.tr("Pomodoro")
+
+        ConfigSpinBox {
+            icon: "avg_pace"
+            text: Translation.tr("Focus duration (min)")
+            value: Math.round(Config.options.time.pomodoro.focus / 60)
+            from: 1
+            to: 120
+            stepSize: 1
+            onValueChanged: {
+                Config.options.time.pomodoro.focus = value * 60;
+            }
+        }
+        ConfigSpinBox {
+            icon: "free_breakfast"
+            text: Translation.tr("Break duration (min)")
+            value: Math.round(Config.options.time.pomodoro.breakTime / 60)
+            from: 0
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.time.pomodoro.breakTime = value * 60;
+            }
+        }
+        ConfigSpinBox {
+            icon: "nature"
+            text: Translation.tr("Long break duration (min)")
+            value: Math.round(Config.options.time.pomodoro.longBreak / 60)
+            from: 0
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.time.pomodoro.longBreak = value * 60;
+            }
+        }
+        ConfigSpinBox {
+            icon: "repeat"
+            text: Translation.tr("Cycles before long break")
+            value: Config.options.time.pomodoro.cyclesBeforeLongBreak
+            from: 1
+            to: 10
+            stepSize: 1
+            onValueChanged: {
+                Config.options.time.pomodoro.cyclesBeforeLongBreak = value;
+            }
+        }
+    }
+
+    ContentSection {
         icon: "memory"
         title: Translation.tr("Resources")
 

--- a/dots/.config/quickshell/ii/services/TimerService.qml
+++ b/dots/.config/quickshell/ii/services/TimerService.qml
@@ -26,6 +26,11 @@ Singleton {
     property int pomodoroSecondsLeft: pomodoroLapDuration // Reasonable init value, to be changed
     property int pomodoroCycle: Persistent.states.timer.pomodoro.cycle
 
+    // When the configured duration changes while the timer is paused, show the new value immediately
+    onPomodoroLapDurationChanged: {
+        if (!pomodoroRunning) pomodoroSecondsLeft = pomodoroLapDuration;
+    }
+
     property bool stopwatchRunning: Persistent.states.timer.stopwatch.running
     property int stopwatchTime: 0
     property int stopwatchStart: Persistent.states.timer.stopwatch.start
@@ -49,11 +54,26 @@ Singleton {
     function refreshPomodoro() {
         // Work <-> break ?
         if (getCurrentTimeInSeconds() >= Persistent.states.timer.pomodoro.start + pomodoroLapDuration) {
-            // Reset counts
-            Persistent.states.timer.pomodoro.isBreak = !Persistent.states.timer.pomodoro.isBreak;
+            const wasBreak = pomodoroBreak;
+            Persistent.states.timer.pomodoro.isBreak = !wasBreak;
             Persistent.states.timer.pomodoro.start = getCurrentTimeInSeconds();
 
-            // Send notification
+            // Skip zero-duration break phases: go straight to the next focus session
+            if (!wasBreak) {
+                const enteringLongBreak = (pomodoroCycle + 1 == cyclesBeforeLongBreak);
+                const newBreakDuration = enteringLongBreak ? longBreakTime : breakTime;
+                if (newBreakDuration === 0) {
+                    Persistent.states.timer.pomodoro.isBreak = false;
+                    Persistent.states.timer.pomodoro.cycle = (Persistent.states.timer.pomodoro.cycle + 1) % root.cyclesBeforeLongBreak;
+                    Quickshell.execDetached(["notify-send", "Pomodoro",
+                        Translation.tr(`🔴 Focus: %1 minutes`).arg(Math.floor(focusTime / 60)), "-a", "Shell"]);
+                    playPomodoroAlarm();
+                    pomodoroSecondsLeft = pomodoroLapDuration;
+                    return;
+                }
+            }
+
+            // Send notification for the new phase
             let notificationMessage;
             if (Persistent.states.timer.pomodoro.isBreak && (pomodoroCycle + 1 == cyclesBeforeLongBreak)) {
                 notificationMessage = Translation.tr(`🌿 Long break: %1 minutes`).arg(Math.floor(longBreakTime / 60));
@@ -64,16 +84,16 @@ Singleton {
             }
 
             Quickshell.execDetached(["notify-send", "Pomodoro", notificationMessage, "-a", "Shell"]);
-            if (Config.options.sounds.pomodoro) {
-                Audio.playSystemSound("alarm-clock-elapsed")
-            }
+            playPomodoroAlarm();
 
             if (!pomodoroBreak) {
                 Persistent.states.timer.pomodoro.cycle = (Persistent.states.timer.pomodoro.cycle + 1) % root.cyclesBeforeLongBreak;
             }
         }
 
-        pomodoroSecondsLeft = pomodoroLapDuration - (getCurrentTimeInSeconds() - Persistent.states.timer.pomodoro.start);
+        pomodoroSecondsLeft = pomodoroLapDuration > 0
+            ? pomodoroLapDuration - (getCurrentTimeInSeconds() - Persistent.states.timer.pomodoro.start)
+            : 0;
     }
 
     Timer {
@@ -82,6 +102,38 @@ Singleton {
         running: root.pomodoroRunning
         repeat: true
         onTriggered: refreshPomodoro()
+    }
+
+    function playPomodoroAlarm() {
+        if (!Config.options.sounds.pomodoro) return;
+        const vol = String(Config.options.time.pomodoro.alarmVolume);
+        const base = `/usr/share/sounds/${Audio.audioTheme}/stereo/alarm-clock-elapsed`;
+        Quickshell.execDetached(["ffplay", "-nodisp", "-autoexit", "-volume", vol, base + ".oga"]);
+        Quickshell.execDetached(["ffplay", "-nodisp", "-autoexit", "-volume", vol, base + ".ogg"]);
+    }
+
+    function skipPomodoro() {
+        const wasBreak = pomodoroBreak;
+        Persistent.states.timer.pomodoro.isBreak = !wasBreak;
+        Persistent.states.timer.pomodoro.start = getCurrentTimeInSeconds();
+
+        // Skip zero-duration break phases (mirrors refreshPomodoro logic)
+        if (!wasBreak) {
+            const enteringLongBreak = (pomodoroCycle + 1 == cyclesBeforeLongBreak);
+            const newBreakDuration = enteringLongBreak ? longBreakTime : breakTime;
+            if (newBreakDuration === 0) {
+                Persistent.states.timer.pomodoro.isBreak = false;
+                Persistent.states.timer.pomodoro.cycle = (Persistent.states.timer.pomodoro.cycle + 1) % root.cyclesBeforeLongBreak;
+                pomodoroSecondsLeft = pomodoroLapDuration;
+                return;
+            }
+        }
+
+        if (wasBreak) {
+            Persistent.states.timer.pomodoro.cycle = (Persistent.states.timer.pomodoro.cycle + 1) % root.cyclesBeforeLongBreak;
+        }
+
+        pomodoroSecondsLeft = pomodoroLapDuration;
     }
 
     function togglePomodoro() {


### PR DESCRIPTION
I often like to use timers for different thing that require on-the-fly
adjustments, so I implemented some quick settings for the pomodoro widget.
Should be pretty intuitive and has minor impact.

## Describe your changes

- made timer duration and number of cycles configurable in the widget itself and config screen
- added button to skip to next cycle
- added alarm volume config in the json

## Is it ready? Questions/feedback needed?

It's ready. I've been using it without issue. It's my first contribution,
so I can't really guarantee that I've followed the standard practices.
If anything else is needed, be sure to let me know. I'll appreciate the feedback.
