### PR TITLE
fedora: Update matugen to 4.0.0 to avoid errors

### DIFF
--- a/sdata/dist-fedora/SPECS/matugen.spec
+++ b/sdata/dist-fedora/SPECS/matugen.spec
@@ -1,0 +1,41 @@
+# Original-Spec: https://copr-dist-git.fedorainfracloud.org/packages/errornointernet/quickshell/quickshell-git.git/plain/quickshell-git.spec?h=master
+
+%global commit      e65259d68edc034905da477b6c1a349e89e2aa8d
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commits     719
+%global snapdate    20260213
+%global tag         4.0.0
+
+Name:               matugen
+Version:            %{tag}^%{commits}.%{shortcommit}
+Release:            0%{?dist}
+Summary:            A cross-platform material you and base16 color generation tool
+
+License:            GPL-2.0
+URL:                https://github.com/InioX/matugen
+Source0:            %{url}/archive/%{commit}/matugen-%{shortcommit}.tar.gz
+
+BuildRequires:  rust-packaging
+BuildRequires:  cargo
+BuildRequires:  gcc
+
+%description
+Flexible toolkit for making desktop shells with QtQuick, targeting
+Wayland and X11.
+
+%prep
+%autosetup -n matugen-%{commit} -p1
+
+%build
+cargo build --release
+
+%install
+install -Dm0755 target/release/matugen %{buildroot}%{_bindir}/matugen
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/matugen
+
+%changelog
+%autochangelog

--- a/sdata/dist-fedora/SPECS/matugen.spec
+++ b/sdata/dist-fedora/SPECS/matugen.spec
@@ -1,5 +1,3 @@
-# Original-Spec: https://copr-dist-git.fedorainfracloud.org/packages/errornointernet/quickshell/quickshell-git.git/plain/quickshell-git.spec?h=master
-
 %global commit      e65259d68edc034905da477b6c1a349e89e2aa8d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commits     719
@@ -20,8 +18,7 @@ BuildRequires:  cargo
 BuildRequires:  gcc
 
 %description
-Flexible toolkit for making desktop shells with QtQuick, targeting
-Wayland and X11.
+A cross-platform material you and base16 color generation tool
 
 %prep
 %autosetup -n matugen-%{commit} -p1

--- a/sdata/dist-fedora/feddeps.toml
+++ b/sdata/dist-fedora/feddeps.toml
@@ -68,7 +68,6 @@ packages = [
   "fish",
   "fontconfig",
   "kitty",
-  "matugen",
   "florian-karsten-space-grotesk-fonts",
   "starship",
   "jetbrains-mono-nerd-fonts",

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -38,6 +38,7 @@ function install_RPMS() {
     "$rpm_specs/cpptrace.spec"
     "$rpm_specs/quickshell-git.spec"
     "$rpm_specs/hyprland-qt-support.spec"
+    "$rpm_specs/matugen.spec"
   )
   for spec_file in ${local_specs[@]}; do
     # Download sources


### PR DESCRIPTION
## Describe your changes

Fixes a bug where matugen on fedora would not work when changing the wallpaper because a newer version is needed

## Is it ready? Questions/feedback needed?

it works, so yes

fixes #3064 (for fedora users, though it's already fine in arch)