### PR TITLE
fix(ii): send configured User-Agent to Konachan requests 

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/utils/ImageDownloaderProcess.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/ImageDownloaderProcess.qml
@@ -16,9 +16,20 @@ Process {
         return StringUtils.shellSingleQuoteEscape(FileUtils.trimFileProtocol(filePath));
     }
 
+    function processSourceUrl() {
+        return StringUtils.shellSingleQuoteEscape(sourceUrl);
+    }
+
+    function curlUserAgentArg() {
+        if (!downloadUserAgent) {
+            return "";
+        }
+        return ` -H 'User-Agent: ${StringUtils.shellSingleQuoteEscape(downloadUserAgent)}'`;
+    }
+
     running: true
     command: ["bash", "-c", 
-        `mkdir -p $(dirname '${processFilePath()}'); [ -f '${processFilePath()}' ] || curl -sSL '${sourceUrl}' -o '${processFilePath()}' && file '${processFilePath()}'`
+        `mkdir -p $(dirname '${processFilePath()}'); [ -f '${processFilePath()}' ] || curl -sSL '${processSourceUrl()}'${curlUserAgentArg()} -o '${processFilePath()}' && file '${processFilePath()}'`
     ]
     stdout: StdioCollector {
         id: imageSizeOutputCollector

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/anime/BooruImage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/anime/BooruImage.qml
@@ -174,8 +174,10 @@ Button {
                             onClicked: {
                                 root.showActions = false;
                                 const targetPath = root.imageData.is_nsfw ? root.nsfwPath : root.downloadPath;
+                                const userAgent = Config.options?.networking?.userAgent ?? ""
+                                const userAgentHeader = userAgent ? ` -H 'User-Agent: ${StringUtils.shellSingleQuoteEscape(userAgent)}'` : ""
                                 Quickshell.execDetached(["bash", "-c", 
-                                    `mkdir -p '${targetPath}' && curl '${root.imageData.file_url}' -o '${targetPath}/${root.fileName}' && notify-send '${Translation.tr("Download complete")}' '${root.downloadPath}/${root.fileName}' -a 'Shell'`
+                                    `mkdir -p '${targetPath}' && curl '${StringUtils.shellSingleQuoteEscape(root.imageData.file_url)}'${userAgentHeader} -o '${targetPath}/${root.fileName}' && notify-send '${Translation.tr("Download complete")}' '${root.downloadPath}/${root.fileName}' -a 'Shell'`
                                 ])
                             }
                         }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/anime/BooruResponse.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/anime/BooruResponse.qml
@@ -230,7 +230,7 @@ Rectangle {
                         rowHeight: imageRow.rowHeight
                         imageRadius: imageRow.modelData.images.length == 1 ? 50 : Appearance.rounding.normal
                         // Download manually to reduce redundant requests or make sure downloading works
-                        manualDownload: ["danbooru", "waifu.im", "t.alcy.cc"].includes(root.responseData.provider)
+                        manualDownload: ["danbooru", "waifu.im", "t.alcy.cc", "konachan"].includes(root.responseData.provider)
                         previewDownloadPath: root.previewDownloadPath
                         downloadPath: root.downloadPath
                         nsfwPath: root.nsfwPath

--- a/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
@@ -29,14 +29,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p "$PICTURES_DIR/Wallpapers"
 page=$((1 + RANDOM % 1000));
-response=$(curl "https://konachan.net/post.json?tags=rating%3Asafe&limit=1&page=$page")
+illogicalImpulseConfigPath="$HOME/.config/illogical-impulse/config.json"
+userAgent=$(jq -r '.networking.userAgent // empty' "$illogicalImpulseConfigPath" 2>/dev/null)
+if [ -z "$userAgent" ]; then
+    userAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+fi
+response=$(curl -A "$userAgent" "https://konachan.net/post.json?tags=rating%3Asafe&limit=1&page=$page")
 link=$(echo "$response" | jq '.[0].file_url' -r);
 ext=$(echo "$link" | awk -F. '{print $NF}')
 downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper.$ext"
-illogicalImpulseConfigPath="$HOME/.config/illogical-impulse/config.json"
-currentWallpaperPath=$(jq -r '.background.wallpaperPath' $illogicalImpulseConfigPath)
+currentWallpaperPath=$(jq -r '.background.wallpaperPath' "$illogicalImpulseConfigPath")
 if [ "$downloadPath" == "$currentWallpaperPath" ]; then
     downloadPath="$PICTURES_DIR/Wallpapers/random_wallpaper-1.$ext"
 fi
-curl "$link" -o "$downloadPath"
+curl -A "$userAgent" "$link" -o "$downloadPath"
 "$SCRIPT_DIR/../switchwall.sh" --image "$downloadPath"

--- a/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/random/random_konachan_wall.sh
@@ -31,9 +31,6 @@ mkdir -p "$PICTURES_DIR/Wallpapers"
 page=$((1 + RANDOM % 1000));
 illogicalImpulseConfigPath="$HOME/.config/illogical-impulse/config.json"
 userAgent=$(jq -r '.networking.userAgent // empty' "$illogicalImpulseConfigPath" 2>/dev/null)
-if [ -z "$userAgent" ]; then
-    userAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
-fi
 response=$(curl -A "$userAgent" "https://konachan.net/post.json?tags=rating%3Asafe&limit=1&page=$page")
 link=$(echo "$response" | jq '.[0].file_url' -r);
 ext=$(echo "$link" | awk -F. '{print $NF}')

--- a/dots/.config/quickshell/ii/services/Booru.qml
+++ b/dots/.config/quickshell/ii/services/Booru.qml
@@ -406,8 +406,8 @@ Singleton {
         }
 
         try {
-            // Required for danbooru
-            if (currentProvider == "danbooru") {
+            // Required for danbooru and konachan
+            if (["danbooru", "konachan"].includes(currentProvider)) {
                 xhr.setRequestHeader("User-Agent", defaultUserAgent)
             }
             else if (currentProvider == "zerochan") {
@@ -458,8 +458,8 @@ Singleton {
         }
 
         try {
-            // Required for danbooru
-            if (currentProvider == "danbooru") {
+            // Required for danbooru and konachan
+            if (["danbooru", "konachan"].includes(currentProvider)) {
                 xhr.setRequestHeader("User-Agent", defaultUserAgent)
             }
             xhr.send()


### PR DESCRIPTION
## Describe your changes

Fixes #3231                                                                                                                                                      
                                                                                                                                                                  
 Konachan was failing in two places:                                                                                                                              
                                                                                                                                                                  
 1. the random wallpaper generator                                                                                                                                
 2. the anime booru sidebar                                                                                                                                       
                                                                                                                                                                  
 This PR makes both use the configured networking.userAgent instead of relying on plain unauthenticated requests.                                                 
                                                                                                                                                                  
 ### What changed                                                                                                                                                 
                                                                                                                                                                  
 - Random Konachan wallpaper script                                                                                                                               
     - sends the configured User-Agent for the Konachan API request                                                                                               
     - sends the same User-Agent for the wallpaper image download request                                                                                         
     - removes the hardcoded fallback UA, so it relies on the config value                                                                                        
 - Sidebar / booru Konachan support                                                                                                                               
     - sends the configured User-Agent for Konachan API/tag requests                                                                                              
     - makes Konachan previews download through the existing downloader path                                                                                      
     - makes Konachan image downloads send the configured User-Agent                                                                                              
                                                                                                                                                                  
 ### Notes                                                                                                                                                        
                                                                                                                                                                  
 Konachan currently rejects plain requests with a 403 / Cloudflare challenge, so this change keeps the behavior aligned with the existing configured UA used      
 elsewhere in the shell.