### PR TITLE
Add configurable Bluetooth devices background widget for QuickShell

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -209,6 +209,16 @@ Singleton {
                         property real x: 400
                         property real y: 100
                     }
+                    property JsonObject bluetooth: JsonObject {
+                        property bool enable: false
+                        property string placementStrategy: "free" // "free", "leastBusy", "mostBusy"
+                        property real x: 650
+                        property real y: 100
+                        property real opacity: 0.92
+                        property string listOrientation: "horizontal" // "horizontal", "vertical"
+                        property int refreshIntervalMinutes: 1
+                        property int maxVisibleDevices: 8
+                    }
                 }
                 property string wallpaperPath: ""
                 property string thumbnailPath: ""

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -17,6 +17,7 @@ import Quickshell.Hyprland
 import qs.modules.ii.background.widgets
 import qs.modules.ii.background.widgets.clock
 import qs.modules.ii.background.widgets.weather
+import qs.modules.ii.background.widgets.bluetooth
 
 Variants {
     id: root
@@ -261,6 +262,17 @@ Variants {
                 FadeLoader {
                     shown: Config.options.background.widgets.weather.enable
                     sourceComponent: WeatherWidget {
+                        screenWidth: bgRoot.screen.width
+                        screenHeight: bgRoot.screen.height
+                        scaledScreenWidth: bgRoot.screen.width
+                        scaledScreenHeight: bgRoot.screen.height
+                        wallpaperScale: 1
+                    }
+                }
+
+                FadeLoader {
+                    shown: Config.options.background.widgets.bluetooth.enable
+                    sourceComponent: BluetoothDevicesWidget {
                         screenWidth: bgRoot.screen.width
                         screenHeight: bgRoot.screen.height
                         scaledScreenWidth: bgRoot.screen.width

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/bluetooth/BluetoothDevicesWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/bluetooth/BluetoothDevicesWidget.qml
@@ -113,10 +113,6 @@ AbstractBackgroundWidget {
                 Layout.fillWidth: true
                 spacing: 8
 
-                Item {
-                    Layout.fillWidth: true
-                }
-
                 Rectangle {
                     width: 36
                     height: 36
@@ -138,6 +134,10 @@ AbstractBackgroundWidget {
                     color: root.textPrimaryColor
                     font.pixelSize: Appearance.font.pixelSize.large
                     font.weight: Font.DemiBold
+                }
+
+                Item {
+                    Layout.fillWidth: true
                 }
 
                 StyledText {
@@ -315,7 +315,7 @@ AbstractBackgroundWidget {
 
             StyledText {
                 Layout.fillWidth: true
-                horizontalAlignment: Text.AlignHCenter
+                horizontalAlignment: Text.AlignLeft
                 elide: Text.ElideRight
                 text: chip.device?.name || Translation.tr("Unknown")
                 textFormat: Text.PlainText
@@ -351,7 +351,7 @@ AbstractBackgroundWidget {
             StyledText {
                 Layout.fillWidth: true
                 elide: Text.ElideRight
-                horizontalAlignment: Text.AlignRight
+                horizontalAlignment: Text.AlignLeft
                 text: rowCard.device?.name || Translation.tr("Unknown")
                 textFormat: Text.PlainText
                 color: root.textPrimaryColor

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/bluetooth/BluetoothDevicesWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/bluetooth/BluetoothDevicesWidget.qml
@@ -1,0 +1,373 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Shapes
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import qs.modules.ii.background.widgets
+
+AbstractBackgroundWidget {
+    id: root
+
+    configEntryName: "bluetooth"
+
+    readonly property real widgetOpacity: Math.max(0.2, Math.min(1, Number(configEntry?.opacity ?? 0.92)))
+    readonly property string listOrientation: configEntry?.listOrientation === "vertical" ? "vertical" : "horizontal"
+    readonly property bool verticalList: listOrientation === "vertical"
+    readonly property int refreshIntervalMinutes: Math.max(1, Number(configEntry?.refreshIntervalMinutes ?? 1))
+    readonly property int refreshIntervalMs: refreshIntervalMinutes * 60 * 1000
+    readonly property int maxVisibleDevices: Math.max(1, Number(configEntry?.maxVisibleDevices ?? 8))
+
+    property var deviceSnapshot: []
+    property string lastRefresh: "--:--"
+
+    readonly property int chipWidth: 108
+    readonly property int chipSpacing: 12
+    readonly property int cardPadding: 18
+    readonly property int listPadding: 8
+    readonly property int shownCount: Math.max(1, deviceSnapshot.length)
+    readonly property int horizontalListWidth: (deviceSnapshot.length === 0) ? 220 : (shownCount * chipWidth + Math.max(0, shownCount - 1) * chipSpacing + listPadding * 2)
+    implicitWidth: verticalList ? 390 : Math.max(260, Math.min(980, horizontalListWidth + cardPadding * 2))
+    implicitHeight: verticalList ? Math.max(220, Math.min(760, 110 + shownCount * 102)) : 248
+
+    readonly property color cardBackgroundColor: ColorUtils.applyAlpha(Appearance.colors.colLayer1, widgetOpacity)
+    readonly property color cardBorderColor: ColorUtils.applyAlpha(Appearance.colors.colOutline, 0.55)
+    readonly property color tileBackgroundColor: ColorUtils.applyAlpha(Appearance.colors.colLayer2, Math.min(1, widgetOpacity + 0.06))
+    readonly property color tileBorderColor: ColorUtils.applyAlpha(Appearance.colors.colOutlineVariant, 0.8)
+    readonly property color textPrimaryColor: Appearance.colors.colOnLayer2
+    readonly property color textSecondaryColor: ColorUtils.applyAlpha(Appearance.colors.colOnLayer1, 0.78)
+    readonly property color ringHighColor: ColorUtils.mix(Appearance.colors.colPrimary, Appearance.colors.colOnPrimary, 0.86)
+    readonly property color ringMediumColor: ColorUtils.mix(Appearance.colors.colTertiary, Appearance.colors.colOnTertiary, 0.86)
+    readonly property color ringLowColor: ColorUtils.mix(Appearance.colors.colError, Appearance.colors.colOnError, 0.90)
+
+    function batteryKnown(device) {
+        return device?.batteryAvailable ?? false;
+    }
+
+    function batteryLevel(device) {
+        if (!batteryKnown(device))
+            return 0;
+        return Math.max(0, Math.min(1, Number(device?.battery ?? 0)));
+    }
+
+    function ringColor(device) {
+        const level = batteryLevel(device);
+        if (!batteryKnown(device))
+            return Appearance.colors.colOnLayer2;
+        if (level < 0.20)
+            return root.ringLowColor;
+        if (level < 0.40)
+            return root.ringMediumColor;
+        return root.ringHighColor;
+    }
+
+    function deviceIcon(device) {
+        return Icons.getBluetoothDeviceMaterialSymbol(device?.icon || "");
+    }
+
+    function refreshDevices() {
+        const devices = BluetoothStatus.connectedDevices || [];
+        root.deviceSnapshot = devices.slice(0, root.maxVisibleDevices);
+        root.lastRefresh = DateTime.time;
+    }
+
+    onMaxVisibleDevicesChanged: refreshDevices()
+
+    Connections {
+        target: BluetoothStatus
+
+        function onConnectedDevicesChanged() {
+            root.refreshDevices();
+        }
+    }
+
+    Timer {
+        id: refreshTimer
+        interval: root.refreshIntervalMs
+        running: true
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root.refreshDevices()
+    }
+
+    StyledDropShadow {
+        target: backgroundRect
+    }
+
+    Rectangle {
+        id: backgroundRect
+        anchors.fill: parent
+        radius: Appearance.rounding.large
+        color: root.cardBackgroundColor
+        border.width: 1
+        border.color: root.cardBorderColor
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 18
+            spacing: 12
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Rectangle {
+                    width: 36
+                    height: 36
+                    radius: 18
+                    color: ColorUtils.applyAlpha(Appearance.colors.colLayer2, 0.92)
+                    border.width: 1
+                    border.color: root.tileBorderColor
+
+                    MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "devices"
+                        iconSize: 19
+                        color: root.textPrimaryColor
+                    }
+                }
+
+                StyledText {
+                    text: Translation.tr("Devices")
+                    color: root.textPrimaryColor
+                    font.pixelSize: Appearance.font.pixelSize.large
+                    font.weight: Font.DemiBold
+                }
+
+                StyledText {
+                    text: root.lastRefresh
+                    color: root.textSecondaryColor
+                    font.pixelSize: Appearance.font.pixelSize.small
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                color: ColorUtils.applyAlpha(Appearance.colors.colLayer2, 0.34)
+                radius: Appearance.rounding.normal
+
+                StyledListView {
+                    id: devicesList
+                    anchors.fill: parent
+                    anchors.margins: root.listPadding
+                    clip: true
+                    spacing: root.verticalList ? 8 : root.chipSpacing
+                    animateAppearance: false
+                    orientation: root.verticalList ? ListView.Vertical : ListView.Horizontal
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    model: root.deviceSnapshot
+
+                    delegate: root.verticalList ? verticalDeviceDelegate : horizontalDeviceDelegate
+                }
+
+                StyledText {
+                    anchors.centerIn: parent
+                    visible: root.deviceSnapshot.length === 0
+                    text: Translation.tr("No connected Bluetooth devices")
+                    color: root.textSecondaryColor
+                    font.pixelSize: Appearance.font.pixelSize.smallie
+                }
+            }
+        }
+    }
+
+    component DeviceRing: Item {
+        id: ring
+        required property var device
+
+        readonly property bool hasBattery: root.batteryKnown(device)
+        readonly property real progressLevel: root.batteryLevel(device)
+        readonly property color thresholdColor: root.ringColor(device)
+        readonly property real arcStartAngle: 126
+        readonly property real arcSweep: 288
+
+        property real blinkOpacity: 1
+
+        function withAlpha(color, alphaValue) {
+            const c = Qt.color(color);
+            return Qt.rgba(c.r, c.g, c.b, Math.max(0, Math.min(1, alphaValue)));
+        }
+
+        onProgressLevelChanged: {
+            if (progressLevel >= 0.05)
+                blinkOpacity = 1;
+        }
+
+        width: 76
+        height: 98
+
+        SequentialAnimation on blinkOpacity {
+            running: ring.hasBattery && ring.progressLevel < 0.05
+            loops: Animation.Infinite
+            NumberAnimation {
+                from: 1
+                to: 0.25
+                duration: 360
+                easing.type: Easing.InOutQuad
+            }
+            NumberAnimation {
+                from: 0.25
+                to: 1
+                duration: 360
+                easing.type: Easing.InOutQuad
+            }
+        }
+
+        Item {
+            id: ringCanvas
+            width: 76
+            height: 76
+            anchors.top: parent.top
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Shape {
+                anchors.fill: parent
+                preferredRendererType: Shape.CurveRenderer
+
+                ShapePath {
+                    strokeColor: ColorUtils.applyAlpha(Appearance.colors.colOnLayer2, 0.22)
+                    strokeWidth: 6
+                    capStyle: ShapePath.RoundCap
+                    fillColor: "transparent"
+                    PathAngleArc {
+                        centerX: ringCanvas.width / 2
+                        centerY: ringCanvas.height / 2
+                        radiusX: ringCanvas.width / 2 - 5
+                        radiusY: ringCanvas.height / 2 - 5
+                        startAngle: ring.arcStartAngle
+                        sweepAngle: ring.arcSweep
+                    }
+                }
+
+                ShapePath {
+                    strokeColor: ring.withAlpha(ring.thresholdColor, ring.blinkOpacity)
+                    strokeWidth: 6
+                    capStyle: ShapePath.RoundCap
+                    fillColor: "transparent"
+                    PathAngleArc {
+                        centerX: ringCanvas.width / 2
+                        centerY: ringCanvas.height / 2
+                        radiusX: ringCanvas.width / 2 - 5
+                        radiusY: ringCanvas.height / 2 - 5
+                        startAngle: ring.arcStartAngle
+                        sweepAngle: ring.hasBattery ? ring.arcSweep * ring.progressLevel : 0
+                    }
+                }
+            }
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: 48
+                height: 48
+                radius: 24
+                color: ColorUtils.applyAlpha(Appearance.colors.colLayer0, 0.95)
+                border.width: 1
+                border.color: root.tileBorderColor
+
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: root.deviceIcon(ring.device)
+                    iconSize: 23
+                    color: root.textPrimaryColor
+                }
+            }
+        }
+
+        StyledText {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            text: ring.hasBattery ? Math.round(ring.progressLevel * 100) + "%" : "--"
+            color: ring.hasBattery ? ring.withAlpha(ring.thresholdColor, ring.blinkOpacity) : root.textSecondaryColor
+            font.pixelSize: Appearance.font.pixelSize.small
+            font.weight: Font.DemiBold
+        }
+    }
+
+    component HorizontalDeviceDelegate: Rectangle {
+        id: chip
+        required property var modelData
+        readonly property var device: modelData
+
+        width: root.chipWidth
+        height: 132
+        radius: Appearance.rounding.normal
+        color: root.tileBackgroundColor
+        border.width: 1
+        border.color: root.tileBorderColor
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 8
+            spacing: 4
+
+            DeviceRing {
+                Layout.alignment: Qt.AlignHCenter
+                device: chip.device
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+                text: chip.device?.name || Translation.tr("Unknown")
+                textFormat: Text.PlainText
+                color: root.textPrimaryColor
+                font.pixelSize: Appearance.font.pixelSize.smaller
+            }
+        }
+    }
+
+    component VerticalDeviceDelegate: Rectangle {
+        id: rowCard
+        required property var modelData
+        readonly property var device: modelData
+
+        width: ListView.view ? ListView.view.width : 320
+        height: 114
+        radius: Appearance.rounding.normal
+        color: root.tileBackgroundColor
+        border.width: 1
+        border.color: root.tileBorderColor
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 8
+            spacing: 10
+
+            DeviceRing {
+                Layout.preferredWidth: 76
+                Layout.preferredHeight: 98
+                device: rowCard.device
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignRight
+                text: rowCard.device?.name || Translation.tr("Unknown")
+                textFormat: Text.PlainText
+                color: root.textPrimaryColor
+                font.pixelSize: Appearance.font.pixelSize.normal
+                font.weight: Font.DemiBold
+            }
+        }
+    }
+
+    Component {
+        id: horizontalDeviceDelegate
+        HorizontalDeviceDelegate {}
+    }
+
+    Component {
+        id: verticalDeviceDelegate
+        VerticalDeviceDelegate {}
+    }
+}

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -701,7 +701,8 @@ ContentPage {
         }
 
         ConfigSlider {
-            text: Translation.tr("Background opacity")
+            text: Translation.tr("Opacity")
+            textWidth: 86
             value: Config.options.background.widgets.bluetooth.opacity * 100
             usePercentTooltip: false
             buttonIcon: "opacity"

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -614,4 +614,114 @@ ContentPage {
             }
         }
     }
+
+    ContentSection {
+        icon: "bluetooth"
+        title: Translation.tr("Widget: Bluetooth devices")
+
+        ConfigRow {
+            Layout.fillWidth: true
+
+            ConfigSwitch {
+                Layout.fillWidth: false
+                buttonIcon: "check"
+                text: Translation.tr("Enable")
+                checked: Config.options.background.widgets.bluetooth.enable
+                onCheckedChanged: {
+                    Config.options.background.widgets.bluetooth.enable = checked;
+                }
+            }
+            Item {
+                Layout.fillWidth: true
+            }
+            ConfigSelectionArray {
+                Layout.fillWidth: false
+                currentValue: Config.options.background.widgets.bluetooth.placementStrategy
+                onSelected: newValue => {
+                    Config.options.background.widgets.bluetooth.placementStrategy = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Draggable"),
+                        icon: "drag_pan",
+                        value: "free"
+                    },
+                    {
+                        displayName: Translation.tr("Least busy"),
+                        icon: "category",
+                        value: "leastBusy"
+                    },
+                    {
+                        displayName: Translation.tr("Most busy"),
+                        icon: "shapes",
+                        value: "mostBusy"
+                    },
+                ]
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "schedule"
+            text: Translation.tr("Refresh every (minutes)")
+            value: Config.options.background.widgets.bluetooth.refreshIntervalMinutes
+            from: 1
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.background.widgets.bluetooth.refreshIntervalMinutes = Math.round(value);
+            }
+        }
+
+        ConfigRow {
+            Layout.fillWidth: true
+
+            ConfigSelectionArray {
+                Layout.fillWidth: false
+                currentValue: Config.options.background.widgets.bluetooth.listOrientation
+                onSelected: newValue => {
+                    Config.options.background.widgets.bluetooth.listOrientation = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Horizontal list"),
+                        icon: "view_carousel",
+                        value: "horizontal"
+                    },
+                    {
+                        displayName: Translation.tr("Vertical list"),
+                        icon: "view_agenda",
+                        value: "vertical"
+                    }
+                ]
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+        }
+
+        ConfigSlider {
+            text: Translation.tr("Background opacity")
+            value: Config.options.background.widgets.bluetooth.opacity * 100
+            usePercentTooltip: false
+            buttonIcon: "opacity"
+            from: 20
+            to: 100
+            onValueChanged: {
+                Config.options.background.widgets.bluetooth.opacity = Math.max(0.2, Math.min(1, value / 100));
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "devices_wearables"
+            text: Translation.tr("Max shown devices")
+            value: Config.options.background.widgets.bluetooth.maxVisibleDevices
+            from: 1
+            to: 16
+            stepSize: 1
+            onValueChanged: {
+                Config.options.background.widgets.bluetooth.maxVisibleDevices = Math.round(value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a new QuickShell background widget for connected Bluetooth devices
- add settings and config entries for widget enable/placement/refresh interval/max devices
- add appearance controls for opacity and list orientation (horizontal/vertical)
- implement battery ring with threshold states and low-battery blink behavior
- simplify device rows to reduce duplicated information and prevent overflow

## Files
- dots/.config/quickshell/ii/modules/common/Config.qml
- dots/.config/quickshell/ii/modules/ii/background/Background.qml
- dots/.config/quickshell/ii/modules/ii/background/widgets/bluetooth/BluetoothDevicesWidget.qml
- dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml

## Validation
- launched QuickShell from repo path with:
  - `quickshell -p /home/oussama/Projects/dots-hyprland/dots/.config/quickshell/ii -v --log-times`
- confirmed successful startup with `Configuration Loaded`
- no QML diagnostics errors on changed files