### PR TITLE
translator: add languages history

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -352,6 +352,7 @@ Singleton {
                     property string engine: "auto" // Run `trans -list-engines` for available engines. auto should use google
                     property string targetLanguage: "auto" // Run `trans -list-all` for available languages
                     property string sourceLanguage: "auto"
+                    property list<string> history: []
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/Translator.qml
@@ -227,7 +227,10 @@ Item {
         sourceComponent: SelectionDialog {
             id: languageSelectorDialog
             titleText: Translation.tr("Select Language")
-            items: root.languages
+            items: [root.languages[0]] // keep "auto" the first
+                .concat(Config.options.language.translator.history)
+                .concat(root.languages.slice(1))
+            
             defaultChoice: root.languageSelectorTarget ? root.targetLanguage : root.sourceLanguage
             onCanceled: () => {
                 root.showLanguageSelector = false;
@@ -235,6 +238,20 @@ Item {
             onSelected: (result) => {
                 root.showLanguageSelector = false;
                 if (!result || result.length === 0) return; // No selection made
+
+                if (!Config.options.language.translator) {
+                    Config.options.language.translator = {}
+                }
+
+                let history =  Config.options.language.translator.history || []
+
+                history = history.filter(lang => lang !== result)
+
+                history.unshift(result)
+
+                history = history.slice(0, 5)
+
+                Config.options.language.translator.history = history
 
                 if (root.languageSelectorTarget) {
                     root.targetLanguage = result;


### PR DESCRIPTION
## Describe your changes

Languages list in translator now also contains up to 5 recently selected languages to make finding needed language easier

<img width="400" height="478" alt="image" src="https://github.com/user-attachments/assets/77051e51-79bd-48cb-815d-57a5d01c4091" />

## Is it ready? Questions/feedback needed?


