### PR TITLE
Fix os-release parsing.

### DIFF
--- a/diagnose
+++ b/diagnose
@@ -39,8 +39,8 @@ _exec() {
 _check_distro_id() {
   OS_RELEASE_FILE=/etc/os-release
   if [[ -f "$OS_RELEASE_FILE" ]]; then
-    OS_DISTRO_ID=$(awk -F'=' '/^ID=/ { gsub("\"","",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
-    OS_DISTRO_ID_LIKE=$(awk -F'=' '/^ID_LIKE=/ { gsub("\"","",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
+    OS_DISTRO_ID=$(awk -F'=' '/^ID=/ { gsub(/["'"'"']/,"",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
+    OS_DISTRO_ID_LIKE=$(awk -F'=' '/^ID_LIKE=/ { gsub(/["'"'"']/,"",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
     echo "distro ID: $OS_DISTRO_ID"
     echo "distro ID_LIKE: $OS_DISTRO_ID_LIKE"
   else
@@ -71,7 +71,7 @@ x git submodule status --recursive
 e "Checking distro"
 x _check_distro_id
 x cat os-release
-#x _check_distro 
+#x _check_distro
 
 e "Checking variables"
 x declare -p XDG_CACHE_HOME # ~/.cache

--- a/sdata/lib/dist-determine.sh
+++ b/sdata/lib/dist-determine.sh
@@ -78,8 +78,8 @@ elif test -f /etc/os-release; then
 else
   printf "${STY_RED}/etc/os-release does not exist, aborting...${STY_RST}\n" ; exit 1
 fi
-export OS_DISTRO_ID=$(awk -F'=' '/^ID=/ { gsub("\"","",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
-export OS_DISTRO_ID_LIKE=$(awk -F'=' '/^ID_LIKE=/ { gsub("\"","",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
+export OS_DISTRO_ID=$(awk -F'=' '/^ID=/ { gsub(/["'"'"']/,"",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
+export OS_DISTRO_ID_LIKE=$(awk -F'=' '/^ID_LIKE=/ {gsub(/["'"'"']/,"",$2); print tolower($2) }' ${OS_RELEASE_FILE} 2> /dev/null)
 
 
 ####################


### PR DESCRIPTION
Remove both single and double quotes from /etc/os-relase strings.
Fixes parsing issues on Gentoo when they changed the formatting of /etc/os-release.