### PR TITLE
fix(notifications): respect user timeout config for all notifications

### DIFF
--- a/dots/.config/quickshell/ii/services/Notifications.qml
+++ b/dots/.config/quickshell/ii/services/Notifications.qml
@@ -174,7 +174,7 @@ Singleton {
                 if (notification.expireTimeout != 0) {
                     newNotifObject.timer = notifTimerComponent.createObject(root, {
                         "notificationId": newNotifObject.notificationId,
-                        "interval": notification.expireTimeout < 0 ? (Config?.options.notifications.timeout ?? 7000) : notification.expireTimeout,
+                        "interval": Config?.options.notifications.timeout ?? 7000,
                     });
                 }
                 root.unread++;


### PR DESCRIPTION
## Problem

`Config.options.notifications.timeout` (configurable via Settings → Interface → Notifications → Timeout duration) is silently ignored when an app sends a notification with `expireTimeout > 0`.

Most real-world apps specify their own `expireTimeout` (commonly 3000–5000 ms), so the user-facing setting has no effect on them. Only apps that send `expireTimeout = -1` (use server default) are affected by the config — a minority in practice.

This makes the timeout setting in the UI effectively a no-op for the majority of notifications.

## Fix

Always use `Config.options.notifications.timeout`, regardless of what the app specifies.

```diff
- "interval": notification.expireTimeout < 0 ? (Config?.options.notifications.timeout ?? 7000) : notification.expireTimeout,
+ "interval": Config?.options.notifications.timeout ?? 7000,
```

The `expireTimeout == 0` case (never expire) is already handled by the outer `if` check on line 174 and is unaffected.