### PR TITLE
fix Hyprsunset default color temperature

### DIFF
--- a/dots/.config/quickshell/ii/services/Hyprsunset.qml
+++ b/dots/.config/quickshell/ii/services/Hyprsunset.qml
@@ -21,6 +21,7 @@ Singleton {
     property string to: Config.options?.light?.night?.to ?? "06:30"
     property bool automatic: Config.options?.light?.night?.automatic && (Config?.ready ?? true)
     property int colorTemperature: Config.options?.light?.night?.colorTemperature ?? 5000
+    property int defaultColorTemperature: 6000
     property int gamma: 100
     property bool shouldBeOn
     property bool firstEvaluation: true
@@ -112,7 +113,7 @@ Singleton {
     function disableTemperature() {
         root.temperatureActive = false;
         // console.log("[Hyprsunset] Disabling");
-        Quickshell.execDetached(["hyprctl", "hyprsunset", "identity"]);
+        Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset temperature ${root.defaultColorTemperature}`]);
     }
 
     function setGamma(gamma) {
@@ -139,7 +140,7 @@ Singleton {
                 if (output.length == 0 || output.startsWith("Couldn't"))
                     root.temperatureActive = false;
                 else
-                    root.temperatureActive = (output != "6500"); // 6500 is the default when off
+                    root.temperatureActive = (output != root.defaultColorTemperature); // 6000 is the default when off
                 // console.log("[Hyprsunset] Fetched state:", output, "->", root.temperatureActive);
             }
         }


### PR DESCRIPTION
## Problem
The "Night Light" button toggle in the sidebar was consistently appearing in the "On" state when restarting a Hyprland session. This occurred because hyprsunset now defaults to 6000K instead of 6500K ([See the docs](https://wiki.hypr.land/Hypr-Ecosystem/hyprsunset/#:~:text=00%3A00-,temperature,6000,-gamma)). In the `fetchState` logic, the system temperature was compared against `6500` and since `6000 != 6500`, the toggle button thought it was "Active".
## Fix
- Added a `defaultColorTemperature` variable to the Hyprsunset service with the new default color temp. 
- Updated the fetchState logic in `Hyprsunset.qml` to validate against this new default (6000K)

Hope it works. 
Any feedback would be appreciated. 