### PR TITLE
Allow One Active Region Selection Monitor (Recording)

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
@@ -34,6 +34,10 @@ PanelWindow {
     enum Phase { Select, Post }
     property var action: RegionSelection.SnipAction.Copy
     property var selectionMode: RegionSelection.SelectionMode.RectCorners
+    property var lockController: null
+    readonly property bool lockedOut: lockController !== null
+        && lockController.lockedScreenName !== ""
+        && lockController.lockedScreenName !== root.screen.name
     property var phase: RegionSelection.Phase.Select
     signal dismiss()
 
@@ -215,7 +219,15 @@ PanelWindow {
             root.dismiss();
             return;
         }
-        root.visible = true;
+        root.visible = !root.lockedOut;
+    }
+
+    onLockedOutChanged: {
+        if (root.lockedOut) {
+            root.visible = false;
+        } else if (root.preparationDone) {
+            root.visible = true;
+        }
     }
 
     Process {
@@ -300,7 +312,7 @@ PanelWindow {
     // Only clickable in Selection phase
     mask: Region {
         item: switch(root.phase) {
-            case RegionSelection.Phase.Select: return mouseArea;
+            case RegionSelection.Phase.Select: return root.lockedOut ? null : mouseArea;
             case RegionSelection.Phase.Post: return null;
         }
     }
@@ -328,6 +340,9 @@ PanelWindow {
 
         // Controls
         onPressed: (mouse) => {
+            if (root.lockController !== null && root.lockController.lockedScreenName === "") {
+                root.lockController.lockedScreenName = root.screen.name;
+            }
             root.dragStartX = mouse.x;
             root.dragStartY = mouse.y;
             root.draggingX = mouse.x;

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
@@ -10,9 +10,11 @@ Scope {
     id: root
 
     function dismiss() {
+        root.lockedScreenName = "";
         GlobalStates.regionSelectorOpen = false
     }
 
+    property string lockedScreenName: ""
     property var action: RegionSelection.SnipAction.Copy
     property var selectionMode: RegionSelection.SelectionMode.RectCorners
     
@@ -28,17 +30,20 @@ Scope {
                 onDismiss: root.dismiss()
                 action: root.action
                 selectionMode: root.selectionMode
+                lockController: root
             }
         }
     }
 
     function screenshot() {
+        root.lockedScreenName = "";
         root.action = RegionSelection.SnipAction.Copy
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
         GlobalStates.regionSelectorOpen = true
     }
 
     function search() {
+        root.lockedScreenName = "";
         root.action = RegionSelection.SnipAction.Search
         if (Config.options.search.imageSearch.useCircleSelection) {
             root.selectionMode = RegionSelection.SelectionMode.Circle
@@ -49,12 +54,14 @@ Scope {
     }
 
     function ocr() {
+        root.lockedScreenName = "";
         root.action = RegionSelection.SnipAction.CharRecognition
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
         GlobalStates.regionSelectorOpen = true
     }
 
     function record() {
+        root.lockedScreenName = "";
         root.action = RegionSelection.SnipAction.Record
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
         // If already open then re-trigger to stop recording
@@ -63,6 +70,7 @@ Scope {
     }
 
     function recordWithSound() {
+        root.lockedScreenName = "";
         root.action = RegionSelection.SnipAction.RecordWithSound
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
         // If already open then re-trigger to stop recording


### PR DESCRIPTION
When selecting a region on a monitor, disable the region select on other monitors. 

This fixes the issue where secondary monitors were blocked off during recordings.

https://github.com/user-attachments/assets/3db40d74-57bc-4af2-9536-53d23704be36

resolves #3260