### PR TITLE
fix(mediaControls): fall back to YouTube thumbnail when player exposes no mpris:artUrl

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -295,4 +295,27 @@ Singleton {
             }
         );
     }
+
+    /**
+     * Returns a URL the cover-art downloader can fetch as artwork for a
+     * YouTube link, or "" if the URL is not from YouTube. Used as a fallback
+     * when the player exposes no mpris:artUrl (Firefox MPRIS bridge,
+     * plasma-browser-integration on YouTube Music).
+     *
+     * - Watch URL (?v=, youtu.be/, /embed/, /shorts/) → deterministic
+     *   i.ytimg.com/vi/<id>/hqdefault.jpg.
+     * - Playlist / channel / other YouTube URL → public oEmbed endpoint;
+     *   the downloader resolves its `thumbnail_url` field at fetch time.
+     *
+     * @param { string } url
+     * @returns { string }
+     */
+    function getYoutubeArtUrl(url) {
+        if (!url || !/(?:^|\/\/|\.)(?:youtube\.com|youtu\.be)/.test(url))
+            return "";
+        const m = url.match(/(?:[?&]v=|youtu\.be\/|\/(?:embed|shorts)\/)([A-Za-z0-9_-]{11})/);
+        if (m)
+            return `https://i.ytimg.com/vi/${m[1]}/hqdefault.jpg`;
+        return `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+    }
 }

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -15,7 +15,11 @@ import Quickshell.Services.Mpris
 Item { // Player instance
     id: root
     required property MprisPlayer player
-    property var artUrl: player?.trackArtUrl
+    // Fall back to a YouTube cover URL when the player exposes no mpris:artUrl
+    // (Firefox MPRIS bridge and plasma-browser-integration both omit it on YT Music).
+    property var artUrl: (player?.trackArtUrl && player.trackArtUrl.length > 0)
+        ? player.trackArtUrl
+        : StringUtils.getYoutubeArtUrl(player?.metadata?.["xesam:url"] ?? "")
     property string artDownloadLocation: Directories.coverArt
     property string artFileName: Qt.md5(artUrl)
     property string artFilePath: `${artDownloadLocation}/${artFileName}`
@@ -77,7 +81,18 @@ Item { // Player instance
         id: coverArtDownloader
         property string targetFile: root.artUrl
         property string artFilePath: root.artFilePath
-        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'` ]
+        // For oEmbed URLs (returned by StringUtils.getYoutubeArtUrl for
+        // playlist / channel links), resolve the JSON `thumbnail_url` field
+        // first, then download the resulting image with the same curl call.
+        command: [ "bash", "-c", `
+            out='${artFilePath}'
+            url='${targetFile}'
+            if [ -z "$url" ] || [ -f "$out" ]; then exit 0; fi
+            case "$url" in *"/oembed?"*)
+                url=$(curl -4 -fsSL "$url" | sed -n 's/.*"thumbnail_url":"\\([^"]*\\)".*/\\1/p') ;;
+            esac
+            if [ -n "$url" ]; then curl -4 -fsSL "$url" -o "$out"; fi
+        ` ]
         onExited: (exitCode, exitStatus) => {
             root.downloaded = true
         }


### PR DESCRIPTION
## Symptom

When music is played in a browser tab (typical case: YouTube Music in Firefox or any Firefox-derived browser such as Zen, LibreWolf, Floorp), the media-controls popup shows correct title / artist / progress, but the cover-art slot stays empty and falls back to the placeholder square.

## Root cause

The empty slot is **not** an end-4 / Quickshell layout bug — it is missing upstream metadata. `PlayerControl.artUrl` binds straight to `MprisPlayer.trackArtUrl`, which is read from the standard `mpris:artUrl` MPRIS2 dict key. Two of the most common browser-side MPRIS sources never publish that key for YT Music:

1. **Firefox built-in MPRIS bridge** (`org.mpris.MediaPlayer2.firefox.instance_*`)
   only exposes a minimal set of fields (`xesam:title`, `xesam:url`, `mpris:length`, …). The MediaSession `artwork` array is not forwarded to D-Bus. This is a long-standing Firefox limitation, observable for every Firefox-family browser including Zen.

2. **plasma-browser-integration** (`org.mpris.MediaPlayer2.plasma-browser-integration`)
   does forward MediaSession metadata for many sites, but for YouTube Music in particular the `mpris:artUrl` key is simply absent from the metadata dict. The page sets cover artwork through internal player state rather than `MediaSession.setMetadata({artwork: [...]})`, so the integration host has nothing to relay.

D-Bus snapshot during playback (one tab, two MPRIS proxies, **neither** has `mpris:artUrl`):

```
$ qdbus6 org.mpris.MediaPlayer2.firefox.instance_1_42 \
        /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2.Player.Metadata
mpris:length: 124000000
xesam:title:  SXPRA DRIFT | YouTube Music
xesam:url:    https://music.youtube.com/watch?v=MJJcY7uGFvw&list=...

$ qdbus6 org.mpris.MediaPlayer2.plasma-browser-integration \
        /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2.Player.Metadata
xesam:album:  SXPRA DRIFT
xesam:artist: blueberry
xesam:title:  SXPRA DRIFT
xesam:url:    https://music.youtube.com/watch?v=MJJcY7uGFvw&list=...
```

With `trackArtUrl == ""`, `coverArtDownloader` is invoked with an empty `targetFile`, so nothing is fetched and `displayedArtFilePath` stays empty.

## Fix

A narrow, opt-in fallback inside `PlayerControl.artUrl`: if the player publishes a non-empty `trackArtUrl`, use it (current behaviour, untouched). Only when it is empty AND `metadata["xesam:url"]` points at a YouTube URL, synthesize a cover URL via a new `StringUtils.getYoutubeArtUrl(url)` helper, and let the existing `coverArtDownloader` pipeline handle caching.

Two cases:

1. **Watch URL** (`?v=`, `youtu.be/`, `/embed/`, `/shorts/`) → return the deterministic thumbnail URL `https://i.ytimg.com/vi/<videoId>/hqdefault.jpg`. No API key, no scraping, no extra dependency. `hqdefault.jpg` is chosen because it is guaranteed to exist for every public video (unlike `maxresdefault.jpg`, which 404s for many uploads).

2. **Playlist / channel / other YouTube URL without a video id** (e.g. YT Music album auto-playlists `OLAK5uy_*`) → return YouTube's public oEmbed endpoint `https://www.youtube.com/oembed?url=<encoded>&format=json`. The downloader detects `/oembed?` in the URL, extracts the JSON `thumbnail_url` field with `sed`, and downloads the image. No new dependencies — `curl` + `sed` are already available everywhere.

## Why it cannot regress other players

The fallback is gated by `direct.length > 0`. Every player that already exports `mpris:artUrl` — Spotify desktop (`file:///tmp/...`), Spotify Web via plasma-browser-integration, Tidal, Deezer, mpv, VLC, any site that calls `MediaSession.setMetadata({artwork:[...]})` — takes the original code path and is not touched.

When `trackArtUrl` is empty AND the URL is **not** YouTube, `getYoutubeArtUrl` returns `""`, so the resulting `artUrl` is `""` — identical to today's behaviour for SoundCloud / Bandcamp / etc. with no MediaSession artwork. Cases tested:

| URL                                          | Result          |
|----------------------------------------------|-----------------|
| `https://music.youtube.com/watch?v=MJJ…`     | `…/MJJ…/hqdefault.jpg` |
| `https://www.youtube.com/watch?v=dQw…`       | `…/dQw…/hqdefault.jpg` |
| `https://youtu.be/dQw…?t=42`                 | `…/dQw…/hqdefault.jpg` |
| `https://www.youtube.com/embed/dQw…`         | `…/dQw…/hqdefault.jpg` |
| `https://www.youtube.com/shorts/AbCdEfGhIjK` | `…/AbCdE…/hqdefault.jpg` |
| `https://music.youtube.com/playlist?list=OLAK5uy_*` | oEmbed → resolved thumb |
| `https://soundcloud.com/foo`                 | `""` (host check)       |
| `https://example.com/?v=dQw4w9WgXcQ`         | `""` (host check)       |

## Known limitation

Private playlists (Liked Music `list=LM`, Watch Later `list=WL`) cannot be resolved through public oEmbed — YouTube returns 404 because the artwork lives behind authenticated requests. Those keep the placeholder, same as today. Single tracks and public playlists are covered.

## Test plan

- [x] Smoke-tested in Quickshell 0.2.1 / Qt 6.11 with two real MPRIS sources (`firefox.instance_*` and `plasma-browser-integration`).
- [x] Cover-art file actually fetched — `~/.cache/quickshell/media/coverart/<md5>` materialized as a 480×360 JPEG, `<md5>` matching `md5("https://i.ytimg.com/vi/<id>/hqdefault.jpg")` for watch URLs and the resolved oEmbed thumbnail for playlists.
- [x] Other (non-YouTube) MPRIS sources keep their existing behaviour because the fallback short-circuits on a non-empty `trackArtUrl`.