### PR TITLE
fedora: Install packages right after building

### DIFF
--- a/sdata/dist-fedora/SPECS/cpptrace.spec
+++ b/sdata/dist-fedora/SPECS/cpptrace.spec
@@ -18,6 +18,7 @@ BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  make
 BuildRequires:  ninja-build
+BuildRequires:  libunwind-devel
 
 %description
 C++ lightweight logging library used by Quickshell.

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -45,7 +45,9 @@ function install_RPMS() {
     spec="$rpm_specs/$package.spec"
     installed_rpm_stamp=$(rpm -q --qf '%{NVRA}\n' "$package" 2>/dev/null || true)
     spec_stamp=$(rpmspec -q --qf '%{NVRA}\n' "$spec")
-    
+    arch=$(rpm --eval "%_arch") # if we somehow want aarch64??
+    built_rpm_path="$rpmbuildroot/RPMS/$arch/$spec_stamp.rpm"
+
     [[ -f "$spec" ]] || {
       echo "Missing spec: $spec"
       continue
@@ -69,13 +71,12 @@ function install_RPMS() {
       sudo dnf install -y $(basename "$spec" .spec)
       nolock_qs=true
     fi
-  done
 
-  mapfile -t -d '' local_rpms < <(find "$rpmbuildroot/RPMS" -maxdepth 2 -type f -name '*.rpm' -not -name '*debug*' -print0)
-  if [[ ${#local_rpms[@]} -ge 1 ]]; then
-    echo -e "${STY_BLUE}Next command:${STY_RST} sudo dnf install ${local_rpms[@]} -y"
-    r x sudo dnf install "${local_rpms[@]}" -y
-  fi
+    if [[ -f "$rpmbuildroot/RPMS/x86_64/$spec_stamp.rpm" ]]; then
+	echo -e "${STY_BLUE}Next command:${STY_RST} sudo dnf install $rpmbuildroot/RPMS/x86_64/$spec_stamp.rpm -y"
+    	r x sudo dnf install "$rpmbuildroot/RPMS/x86_64/$spec_stamp.rpm" -y
+    fi
+  done
   x cd ${REPO_ROOT}
 }
 


### PR DESCRIPTION
## Describe your changes

I just noticed an error message while building [here](https://github.com/end-4/dots-hyprland/pull/3259#issuecomment-4336618541). The build fails because the script tries to build all packages and then installs them. So installation worked if executed it a few times, but failed for the first one—that's why I didn't notice any problems before. Now, the script installs every package right after it's built so we are able to install cpptrace before quickshell is built

## Is it ready? Questions/feedback needed?

it works fine on a clean Fedora Everything installation