### PR TITLE
Add File and Folder Search to the Search Bar.

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -489,6 +489,13 @@ Singleton {
                     property string imageSearchEngineBaseUrl: "https://lens.google.com/uploadbyurl?url="
                     property bool useCircleSelection: false
                 }
+                 property JsonObject fileSearch: JsonObject {
+                    property bool enable: false
+                    property list<string> paths: [Directories.home]
+                    property list<string> exclude: [".git", "node_modules", "target", "build"]
+                    property bool excludeHiddenDirs: true
+                    property int maxResults: 30
+                }
             }
 
             property JsonObject sidebar: JsonObject {

--- a/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
@@ -124,6 +124,17 @@ ContentPage {
                 text: Translation.tr("Could be better if you make a ton of typos,\nbut results can be weird and might not work with acronyms\n(e.g. \"GIMP\" might not give you the paint program)")
             }
         }
+         ConfigSwitch {
+            text: Translation.tr("Enable file search")
+            checked: Config.options.search.fileSearch.enable
+            onCheckedChanged: {
+                Config.options.search.fileSearch.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Enabling this will allow searching for files and folders on your system")
+            }
+
+        }
 
         ContentSubsection {
             title: Translation.tr("Prefixes")

--- a/dots/.config/quickshell/ii/services/FileSearch.qml
+++ b/dots/.config/quickshell/ii/services/FileSearch.qml
@@ -1,0 +1,158 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+import qs.modules.common.functions
+
+Singleton {
+	id: root
+
+	property var results: []
+	property string pendingQuery: ""
+	property string activeQuery: ""
+	property int searchId: 0
+	property bool running: false
+
+	function normalizePath(path) {
+		if (!path) return "";
+		let normalized = FileUtils.trimFileProtocol(String(path)).trim();
+		if (normalized.startsWith("~/")) {
+			normalized = FileUtils.trimFileProtocol(Directories.home) + normalized.slice(1);
+		}
+		if (normalized.endsWith("/")) {
+			normalized = normalized.slice(0, -1);
+		}
+		return normalized;
+	}
+
+	function isExcluded(path) {
+    if (Config.options.search.fileSearch.excludeHiddenDirs) {
+        // Match any hidden dir segment: "/.name/" or ending "/.name"
+        if (path.match(/\/\.[^/]+(\/|$)/)) {
+            return true;
+        }
+    }
+
+    const exclude = Config.options.search.fileSearch.exclude;
+    if (!exclude || exclude.length === 0) return false;
+    for (let i = 0; i < exclude.length; i++) {
+        const needle = String(exclude[i]).trim();
+        if (needle.length === 0) continue;
+        if (path.includes(`/${needle}/`) || path.endsWith(`/${needle}`)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+	function isAllowedByPath(path) {
+		const paths = Config.options.search.fileSearch.paths;
+		if (!paths || paths.length === 0) return true;
+		for (let i = 0; i < paths.length; i++) {
+			const base = normalizePath(paths[i]);
+			if (!base) continue;
+			if (path === base || path.startsWith(base + "/")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	function shouldSearch(query) {
+		if (!Config.options.search.fileSearch.enable) return false;
+		if (!query || query.trim().length < 2) return false;
+		return true;
+	}
+
+	function reset() {
+		results = [];
+		activeQuery = "";
+		if (plocateProc.running) {
+			plocateProc.running = false;
+		}
+	}
+
+	function search(query) {
+		pendingQuery = String(query || "").trim();
+		if (!shouldSearch(pendingQuery)) {
+			reset();
+			return;
+		}
+		debounceTimer.restart();
+	}
+
+	Timer {
+		id: debounceTimer
+		interval: 200
+		repeat: false
+		onTriggered: {
+			root.runSearch(pendingQuery);
+		}
+	}
+
+	function runSearch(query) {
+    const trimmed = String(query || "").trim();
+    if (!shouldSearch(trimmed)) { reset(); return; }
+    if (plocateProc.running) plocateProc.running = false;
+
+    searchId += 1;
+    activeQuery = trimmed;
+    results = [];
+
+    const maxResults = Config.options.search.fileSearch.maxResults;
+
+    // Tag each line with d: or f: prefix
+    const command = [
+        "bash", "-c",
+        `plocate -i --basename --limit ${maxResults} '${trimmed}' | while IFS= read -r p; do [ -d "$p" ] && printf 'd:%s\n' "$p" || printf 'f:%s\n' "$p"; done`
+    ];
+
+    plocateProc.runId = searchId;
+    plocateProc.accepted = 0;
+    plocateProc.command = command;
+    plocateProc.running = true;
+    root.running = true;
+}
+
+	Process {
+		id: plocateProc
+		property int runId: 0
+		property int accepted: 0
+
+		stdout: SplitParser {
+			onRead: line => {
+    if (plocateProc.runId !== root.searchId) return;
+    const raw = String(line || "").trim();
+    if (!raw || raw.length < 3) return;
+
+    const isDir = raw.startsWith("d:");
+    const rawPath = raw.slice(2);
+
+    const normalized = root.normalizePath(rawPath);
+    if (!normalized) return;
+    if (!root.isAllowedByPath(normalized)) return;
+    if (root.isExcluded(normalized)) return;
+    if (plocateProc.accepted >= Config.options.search.fileSearch.maxResults) {
+        plocateProc.running = false;
+        return;
+    }
+
+    plocateProc.accepted += 1;
+    root.results = root.results.concat([{ path: normalized, isDir: isDir }]);
+}
+		}
+
+		stderr: SplitParser {
+			onRead: line => {
+				if (plocateProc.runId !== root.searchId) return;
+			}
+		}
+
+		onExited: (exitCode, exitStatus) => {
+			if (plocateProc.runId !== root.searchId) return;
+			root.running = false;
+		}
+	}
+}

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -3,11 +3,12 @@ pragma Singleton
 import qs.modules.common
 import qs.modules.common.models
 import qs.modules.common.functions
+import qs.services
 import QtQuick
 import Qt.labs.folderlistmodel
 import Quickshell
 import Quickshell.Io
-import Quickshell.Hyprland
+
 
 Singleton {
     id: root
@@ -20,6 +21,27 @@ Singleton {
         } else {
             root.query = prefix + root.query;
         }
+    }
+
+    function getFileSearchQuery() {
+        if (!Config.options.search.fileSearch.enable) return "";
+        const prefixes = [
+            Config.options.search.prefix.action,
+            Config.options.search.prefix.app,
+            Config.options.search.prefix.clipboard,
+            Config.options.search.prefix.emojis,
+            Config.options.search.prefix.math,
+            Config.options.search.prefix.shellCommand,
+            Config.options.search.prefix.webSearch,
+        ];
+        for (let i = 0; i < prefixes.length; i++) {
+            if (root.query.startsWith(prefixes[i])) return "";
+        }
+        return root.query.trim();
+    }
+
+    onQueryChanged: {
+        FileSearch.search(getFileSearchQuery());
     }
 
     // https://specifications.freedesktop.org/menu/latest/category-registry.html
@@ -109,7 +131,7 @@ Singleton {
         {
             action: "wallpaper",
             execute: () => {
-                Hyprland.dispatch("global quickshell:wallpaperSelectorToggle")
+                GlobalStates.wallpaperSelectorOpen = true;
             }
         },
         {
@@ -162,6 +184,40 @@ Singleton {
                 root.mathResult = data;
             }
         }
+    }
+
+
+    property list<var> fileResults: {
+        if (!Config.options.search.fileSearch.enable) return [];
+        if (!FileSearch.results || FileSearch.results.length === 0) return [];
+
+        return FileSearch.results.map(path => {
+            const trimmed = FileUtils.trimFileProtocol(path.path);
+            const isDir = path.isDir;
+            const displayName = isDir ? FileUtils.folderNameForPath(trimmed) : FileUtils.fileNameForPath(trimmed);
+            const parentDir = FileUtils.parentDirectory(trimmed);
+            return resultComp.createObject(null, {
+                rawValue: trimmed,
+                name: displayName || trimmed,
+                verb: Translation.tr("Open"),
+                type: isDir ? Translation.tr("Folder") : Translation.tr("File"),
+                iconName: isDir ? "folder" : "description",
+                iconType: LauncherSearchResult.IconType.Material,
+                execute: () => {
+                    Qt.openUrlExternally(`file://${trimmed}`);
+                },
+                actions: [resultComp.createObject(null, {
+                        name: Translation.tr("Open Parent folder"),
+                        iconName: "folder_open",
+                        iconType: LauncherSearchResult.IconType.Material,
+                        execute: () => {
+                            if (parentDir) {
+                                Qt.openUrlExternally(`file://${parentDir}`);
+                            }
+                        }
+                    })]
+            });
+        });
     }
 
     property list<var> results: {
@@ -339,6 +395,7 @@ Singleton {
 
         //////////////// Apps //////////////////
         result = result.concat(appResultObjects);
+        result = result.concat(fileResults);
 
         ////////// Launcher actions ////////////
         result = result.concat(launcherActionObjects);

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -3,12 +3,11 @@ pragma Singleton
 import qs.modules.common
 import qs.modules.common.models
 import qs.modules.common.functions
-import qs.services
 import QtQuick
 import Qt.labs.folderlistmodel
 import Quickshell
 import Quickshell.Io
-
+import Quickshell.Hyprland
 
 Singleton {
     id: root
@@ -22,26 +21,8 @@ Singleton {
             root.query = prefix + root.query;
         }
     }
-
-    function getFileSearchQuery() {
-        if (!Config.options.search.fileSearch.enable) return "";
-        const prefixes = [
-            Config.options.search.prefix.action,
-            Config.options.search.prefix.app,
-            Config.options.search.prefix.clipboard,
-            Config.options.search.prefix.emojis,
-            Config.options.search.prefix.math,
-            Config.options.search.prefix.shellCommand,
-            Config.options.search.prefix.webSearch,
-        ];
-        for (let i = 0; i < prefixes.length; i++) {
-            if (root.query.startsWith(prefixes[i])) return "";
-        }
-        return root.query.trim();
-    }
-
     onQueryChanged: {
-        FileSearch.search(getFileSearchQuery());
+        FileSearch.search(StringUtils.cleanPrefix(root.query, Config.options.search.prefix.app));
     }
 
     // https://specifications.freedesktop.org/menu/latest/category-registry.html
@@ -131,7 +112,7 @@ Singleton {
         {
             action: "wallpaper",
             execute: () => {
-                GlobalStates.wallpaperSelectorOpen = true;
+                Hyprland.dispatch("global quickshell:wallpaperSelectorToggle")
             }
         },
         {
@@ -185,9 +166,7 @@ Singleton {
             }
         }
     }
-
-
-    property list<var> fileResults: {
+       property list<var> fileResults: {
         if (!Config.options.search.fileSearch.enable) return [];
         if (!FileSearch.results || FileSearch.results.length === 0) return [];
 
@@ -331,6 +310,7 @@ Singleton {
                 })
             });
         });
+
         const commandResultObject = resultComp.createObject(null, {
             name: StringUtils.cleanPrefix(root.query, Config.options.search.prefix.shellCommand).replace("file://", ""),
             verb: Translation.tr("Run"),
@@ -396,6 +376,7 @@ Singleton {
         //////////////// Apps //////////////////
         result = result.concat(appResultObjects);
         result = result.concat(fileResults);
+
 
         ////////// Launcher actions ////////////
         result = result.concat(launcherActionObjects);

--- a/sdata/dist-arch/illogical-impulse-basic/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-basic/PKGBUILD
@@ -12,6 +12,7 @@ depends=(
   cmake
   curl
   wget
+  plocate
   ripgrep
   jq
   xdg-user-dirs

--- a/sdata/subcmd-install/2.setups.sh
+++ b/sdata/subcmd-install/2.setups.sh
@@ -28,6 +28,10 @@ showfun setup_user_group
 v setup_user_group
 
 if [[ ! -z $(systemctl --version) ]]; then
+# For Arch Linux, plocate-updatedb.timer can be enabled to keep the plocate database up-to-date.
+if [[ "$OS_GROUP_ID" == "arch" ]] && command -v plocate >/dev/null 2>&1; then
+  v sudo systemctl enable plocate-updatedb.timer --now
+fi
   # For Fedora, uinput is required for the virtual keyboard to function, and udev rules enable input group users to utilize it.
   if [[ "$OS_GROUP_ID" == "fedora" ]]; then
     v bash -c "echo uinput | sudo tee /etc/modules-load.d/uinput.conf"


### PR DESCRIPTION
## Describe your changes

Implemented index based File and Folder search to the searchBar, You can look for for files or folders, open them or open their parent folder directly from the Search Bar.
Uses plocate for search functionality that uses index based file search, so its pretty quick.
Closes #3104. 

https://github.com/user-attachments/assets/3a782be8-28de-48f2-8e02-95e90b6d0a91



## Is it ready? Questions/feedback needed?
Ready for Arch Linux but not for other OS.  I have not used the other OS so a bit of guidance is needed on how to add the dependency and updatedb timer.
