### PR TITLE
Avoid spawning qs ipc clients from Quickshell UI actions

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/models/quickToggles/ScreenSnipToggle.qml
+++ b/dots/.config/quickshell/ii/modules/common/models/quickToggles/ScreenSnipToggle.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Hyprland
 import qs
 import qs.services
 import qs.modules.common
@@ -21,7 +22,7 @@ QuickToggleModel {
         interval: 300
         repeat: false
         onTriggered: {
-            Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"]);
+            Hyprland.dispatch("global quickshell:regionScreenshot")
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/bar/UtilButtons.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/UtilButtons.qml
@@ -25,7 +25,7 @@ Item {
             visible: Config.options.bar.utilButtons.showScreenSnip
             sourceComponent: CircleUtilButton {
                 Layout.alignment: Qt.AlignVCenter
-                onClicked: Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"]);
+                onClicked: Hyprland.dispatch("global quickshell:regionScreenshot")
                 MaterialSymbol {
                     horizontalAlignment: Qt.AlignHCenter
                     fill: 1

--- a/dots/.config/quickshell/ii/modules/ii/overlay/recorder/Recorder.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overlay/recorder/Recorder.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Hyprland
 import qs
 import qs.services
 import qs.modules.common
@@ -31,7 +32,7 @@ StyledOverlayWidget {
                     name: "Screenshot region"
                     onClicked: {
                         GlobalStates.overlayOpen = false;
-                        Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"]);
+                        Hyprland.dispatch("global quickshell:regionScreenshot");
                     }
                 }
 
@@ -49,7 +50,7 @@ StyledOverlayWidget {
                     name: "Record region"
                     onClicked: {
                         GlobalStates.overlayOpen = false;
-                        Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "recordWithSound"]);
+                        Hyprland.dispatch("global quickshell:regionRecordWithSound");
                     }
                 }
                 

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Hyprland
 import qs
 import qs.services
 import qs.modules.common
@@ -106,7 +107,7 @@ RowLayout {
         Layout.bottomMargin: 4
         onClicked: {
             GlobalStates.overviewOpen = false;
-            Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "search"]);
+            Hyprland.dispatch("global quickshell:regionSearch")
         }
         text: "image_search"
         StyledToolTip {

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothControl.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothControl.qml
@@ -106,7 +106,7 @@ Item {
                 }
                 text: Translation.tr("More Bluetooth settings")
                 onClicked: {
-                    Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "sidebarLeft", "toggle"]);
+                    GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen;
                     Quickshell.execDetached(["bash", "-c", Config.options.apps.bluetooth]);
                 }
             }

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/volumeControl/VolumeControl.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/volumeControl/VolumeControl.qml
@@ -62,7 +62,7 @@ Item {
                 color: "transparent"
 
                 onClicked: {
-                    Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "sidebarLeft", "toggle"]);
+                    GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen;
                     Quickshell.execDetached(["bash", "-c", Config.options.apps.volumeMixer]);
                 }
 

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/wifi/WifiControl.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/wifi/WifiControl.qml
@@ -96,7 +96,7 @@ Item {
                 }
                 text: Translation.tr("More Internet settings")
                 onClicked: {
-                    Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "sidebarLeft", "toggle"]);
+                    GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen;
                     Quickshell.execDetached(["bash", "-c", Config.options.apps.network]);
                 }
             }

--- a/dots/.config/quickshell/ii/modules/waffle/bar/StartButton.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/bar/StartButton.qml
@@ -60,7 +60,7 @@ AppButton {
             {
                 text: Translation.tr("Search"),
                 action: () => {
-                    Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "overview", "toggle"]);
+                    GlobalStates.overviewOpen = !GlobalStates.overviewOpen;
                 }
             },
         ]

--- a/dots/.config/quickshell/ii/modules/waffle/notificationCenter/FocusFooter.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/notificationCenter/FocusFooter.qml
@@ -64,7 +64,7 @@ FooterRectangle {
                     TimerService.resetPomodoro();
                 } else {
                     TimerService.togglePomodoro();
-                    Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "sidebarRight", "toggle"]);
+                    GlobalStates.sidebarRightOpen = !GlobalStates.sidebarRightOpen;
                 }
             }
         }

--- a/dots/.config/quickshell/ii/welcome.qml
+++ b/dots/.config/quickshell/ii/welcome.qml
@@ -11,6 +11,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Io
 import qs.services
 import qs.modules.common
@@ -414,7 +415,7 @@ ApplicationWindow {
                         RippleButtonWithIcon {
                             materialIcon: "keyboard_alt"
                             onClicked: {
-                                Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "cheatsheet", "toggle"]);
+                                Hyprland.dispatch("global quickshell:cheatsheetToggle");
                             }
                             mainContentComponent: Component {
                                 RowLayout {


### PR DESCRIPTION
## Summary

Replace Quickshell UI click handlers that shell out to `qs ... ipc call ...` with in-process or global-shortcut actions.

This avoids starting an extra Quickshell instance/client when clicking region screenshot/search/record controls from inside the running shell.

## Problem

Several QML controls invoke actions like this from inside Quickshell:

```qml
Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"])
```

Because `-p` selects a QML path/config folder, this can create another Quickshell instance/client instead of only dispatching to the already-running shell. On my setup, clicking the top-bar screen snip button caused a duplicate bar to appear and left processes like:

```text
/usr/bin/qs -p /home/.../.config/quickshell/ii/ ipc call region screenshot
```

The region selector already exposes the relevant actions as Quickshell global shortcuts, so these buttons do not need to spawn `qs`.

## Changes

- Use existing global shortcuts for region actions:
  - `global quickshell:regionScreenshot`
  - `global quickshell:regionSearch`
  - `global quickshell:regionRecordWithSound`
- Replace local UI toggle IPC calls with direct `GlobalStates` updates where applicable.
- Remove in-shell `qs -p ... ipc call ...` usage from affected UI click handlers.

## Why This Approach

Hyprland keybinds already route through Quickshell global shortcuts for these actions. Using the same path from QML keeps behavior aligned with the existing architecture while avoiding a second Quickshell process.

For panel toggles that are already in the same QML runtime, updating `GlobalStates` directly preserves the existing target behavior without launching another `qs` process.

## Validation

- Confirmed the affected buttons no longer spawn `qs ... ipc call region ...` processes.
- Confirmed only one `ii` Quickshell instance remains after using the screen snip control.
- Confirmed the config loads without new QML errors in my local setup.
