### PR TITLE
feat: notification on specific monitor

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -399,6 +399,10 @@ Singleton {
 
             property JsonObject notifications: JsonObject {
                 property int timeout: 7000
+                property JsonObject monitor: JsonObject {
+                    property bool enable: false
+                    property string name: "" // Name of the monitor to show notifications on, like "eDP-1". Find out with 'hyprctl monitors' command
+                }
             }
 
             property JsonObject osd: JsonObject {

--- a/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
@@ -14,7 +14,7 @@ Scope {
     PanelWindow {
         id: root
         visible: (Notifications.popupList.length > 0) && !GlobalStates.screenLocked
-        screen: Quickshell.screens.find(s => Config.options.notifications.monitor.enable ? s.name === Config.options.notifications.monitor.name : s.name === Hyprland.focusedMonitor?.name) ?? null
+        screen: Quickshell.screens.find(s => Config.options.notifications.forceMonitor.enable ? s.name === Config.options.notifications.forceMonitor.name : s.name === Hyprland.focusedMonitor?.name) ?? null
 
         WlrLayershell.namespace: "quickshell:notificationPopup"
         WlrLayershell.layer: WlrLayer.Overlay

--- a/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
@@ -14,7 +14,7 @@ Scope {
     PanelWindow {
         id: root
         visible: (Notifications.popupList.length > 0) && !GlobalStates.screenLocked
-        screen: Quickshell.screens.find(s => s.name === Hyprland.focusedMonitor?.name) ?? null
+        screen: Quickshell.screens.find(s => Config.options.notifications.monitor.enable ? s.name === Config.options.notifications.monitor.name : s.name === Hyprland.focusedMonitor?.name) ?? null
 
         WlrLayershell.namespace: "quickshell:notificationPopup"
         WlrLayershell.layer: WlrLayer.Overlay

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -268,10 +268,10 @@ ContentPage {
 
         ConfigSwitch {
             buttonIcon: "monitor"
-            text: Translation.tr("Show on specific monitor")
-            checked: Config.options.notifications.monitor.enable
+            text: Translation.tr("Force specific monitor")
+            checked: Config.options.notifications.forceMonitor.enable
             onCheckedChanged: {
-                Config.options.notifications.monitor.enable = checked;
+                Config.options.notifications.forceMonitor.enable = checked;
             }
             StyledToolTip {
                 text: Translation.tr("If you have multiple monitors and want notifications to only show on one of them, enable this and enter the monitor name below (e.g., eDP-1)")
@@ -279,14 +279,14 @@ ContentPage {
         }
 
         ConfigRow {
-            enabled: Config.options.notifications.monitor.enable
+            enabled: Config.options.notifications.forceMonitor.enable
             MaterialTextArea {
                 Layout.fillWidth: true
                 placeholderText: Translation.tr("Monitor name to show notifications on (e.g., eDP-1)")
-                text: Config.options.notifications.monitor.name
+                text: Config.options.notifications.forceMonitor.name
                 wrapMode: TextEdit.Wrap
                 onTextChanged: {
-                    Config.options.notifications.monitor.name = text;
+                    Config.options.notifications.forceMonitor.name = text;
                 }
             }
         }

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -265,6 +265,31 @@ ContentPage {
                 Config.options.notifications.timeout = value;
             }
         }
+
+        ConfigSwitch {
+            buttonIcon: "monitor"
+            text: Translation.tr("Show on specific monitor")
+            checked: Config.options.notifications.monitor.enable
+            onCheckedChanged: {
+                Config.options.notifications.monitor.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("If you have multiple monitors and want notifications to only show on one of them, enable this and enter the monitor name below (e.g., eDP-1)")
+            }
+        }
+
+        ConfigRow {
+            enabled: Config.options.notifications.monitor.enable
+            MaterialTextArea {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("Monitor name to show notifications on (e.g., eDP-1)")
+                text: Config.options.notifications.monitor.name
+                wrapMode: TextEdit.Wrap
+                onTextChanged: {
+                    Config.options.notifications.monitor.name = text;
+                }
+            }
+        }
     }
 
     ContentSection {


### PR DESCRIPTION
## Describe your changes

Adds an option to show notifications on a specific monitor instead of the currently focused one. This may come in handy in multiple situations: such as when streaming/screen-sharing, and you still want to see your notifications, but don't want others to. Or just when you like it better this way.

## Is it ready? Questions/feedback needed?

IMO it is ready, attached a demo, but if you have feedback please provide it.

https://github.com/user-attachments/assets/06c6232d-948e-41a7-b452-77626b23fdf4