### PR TITLE
fix: show escaped text for selected entry in clipboard

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
@@ -226,7 +226,7 @@ RippleButton {
                     color: root.colForeground
                     horizontalAlignment: Text.AlignLeft
                     elide: Text.ElideRight
-                    text: root.selected ? root.itemName : root.displayContent
+                    text: root.selected ? StringUtils.escapeHtml(root.itemName) : root.displayContent
                 }
             }
             Loader { // Clipboard image preview


### PR DESCRIPTION
## Describe your changes

This would show escaped text for selected entry in the clipboard. Previously the text wasn't escaped which lead to bugs like "#include <stdio.h>" being shown as "#include " when selected. 

## Is it ready? Questions/feedback needed?

It should be ready, as far as I have tested.