### PR TITLE
fix: keybind.lua toggleable fullscreen spoof and working maximized

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -113,9 +113,9 @@ hl.bind("SUPER + Semicolon", hl.dsp.layout("splitratio -0.1"), {repeating = true
 hl.bind("SUPER + Apostrophe", hl.dsp.layout("splitratio +0.1"), {repeating = true} )
 --# Positioning mode
 hl.bind("SUPER + ALT + Space", hl.dsp.window.float({action = "toggle"}), {description = "Float/Tile"} )
-hl.bind("SUPER + D", hl.dsp.window.fullscreen({"maximized"}, {description = "Maximize"}) )
-hl.bind("SUPER + F", hl.dsp.window.fullscreen({"fullscreen"}, {description = "Fullscreen"}) )
-hl.bind("SUPER + ALT + F", hl.dsp.window.fullscreen_state({internal = 0, client = 3}, {description = "Fullscreen spoof"}) )
+hl.bind("SUPER + D", hl.dsp.window.fullscreen({mode = "maximized"}, {description = "Maximize"}) )
+hl.bind("SUPER + F", hl.dsp.window.fullscreen({mode = "fullscreen"}, {description = "Fullscreen"}) )
+hl.bind("SUPER + ALT + F", hl.dsp.window.fullscreen_state({internal = 0, client = 3, action = "toggle"}, {description = "Fullscreen spoof"}) )
 hl.bind("SUPER + P", hl.dsp.window.pin(), {description = "Pin"} )
 
 --#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
@@ -133,9 +133,9 @@ end
 --# #/# bind = SUPER+SHIFT, Scroll ↑/↓,, -- Send to workspace left/right
 for i = 1, 4 do
  local key = {"SUPER + SHIFT + mouse_", "SUPER + ALT + mouse_"}
- local keycombos = {key[1].."down", key[1].."up", key[2].."down", key[2].."up"}
- local prefix = {"r-","r+","-","+"}
- hl.bind(keycombos[i], hl.dsp.window.move({workspace = prefix[i].."1"}) )
+  local keycombos = {key[1].."down", key[1].."up", key[2].."down", key[2].."up"}
+  local prefix = {"r-","r+","-","+"}
+  hl.bind(keycombos[i], hl.dsp.window.move({workspace = prefix[i].."1"}) )
 end
 
 --#/# bind = SUPER+SHIFT, Page_↑/↓,, -- Send to workspace left/right


### PR DESCRIPTION
## Describe your changes
Minor fix for new lua configs. Where `maximized` was considered `fullscreen` and `fullscreen spoof` is untoggleable.

## Is it ready? Questions/feedback needed?
Ye

## Sample Demo (my bar is on bottom)

https://github.com/user-attachments/assets/d8483cfe-8a5a-44fc-9516-34626e1bd617

