### PR TITLE
Fix monitor scale type

### DIFF
--- a/dots/.config/hypr/hyprland/general.lua
+++ b/dots/.config/hypr/hyprland/general.lua
@@ -3,7 +3,7 @@ hl.monitor({
     output = "",
     mode = "preferred",
     position = "auto",
-    scale = "1"
+    scale = 1
 })
 
 hl.gesture({


### PR DESCRIPTION
Changes the default monitor scale value from `"1"` to `1`.

This fixes the typo in the default monitor configuration.

See the Hyprland wiki [here](https://wiki.hypr.land/Configuring/Basics/Monitors/) for confirmation of the formatting.
