### PR TITLE
Fix fullscreen keybindings

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -113,8 +113,8 @@ hl.bind("SUPER + Semicolon", hl.dsp.layout("splitratio -0.1"), {repeating = true
 hl.bind("SUPER + Apostrophe", hl.dsp.layout("splitratio +0.1"), {repeating = true} )
 --# Positioning mode
 hl.bind("SUPER + ALT + Space", hl.dsp.window.float({action = "toggle"}), {description = "Float/Tile"} )
-hl.bind("SUPER + D", hl.dsp.window.fullscreen({"maximized"}, {description = "Maximize"}) )
-hl.bind("SUPER + F", hl.dsp.window.fullscreen({"fullscreen"}, {description = "Fullscreen"}) )
+hl.bind("SUPER + D", hl.dsp.window.fullscreen({mode = "maximized"}, {description = "Maximize"}) )
+hl.bind("SUPER + F", hl.dsp.window.fullscreen({mode = "fullscreen"}, {description = "Fullscreen"}) )
 hl.bind("SUPER + ALT + F", hl.dsp.window.fullscreen_state({internal = 0, client = 3}, {description = "Fullscreen spoof"}) )
 hl.bind("SUPER + P", hl.dsp.window.pin(), {description = "Pin"} )
 


### PR DESCRIPTION
## Describe your changes

The new Lua configs have a bug with the `Super` + `D` shortcut, it just goes fullscreen instead of maximising. The problem was it just lacked the parameter name and the default behaviour is fullscreen.

## Is it ready? Questions/feedback needed?

Perfect, just tested it.

Docs for reference:
https://wiki.hypr.land/Configuring/Basics/Dispatchers/#window-1