### PR TITLE
Fix HOME env in lua

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -1,8 +1,10 @@
+local home_dir = os.getenv("HOME")
+
 -- Wayland
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 
 -- Applications
-hl.env("XDG_DATA_DIRS", "$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share")
+hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share")
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")
@@ -10,4 +12,4 @@ hl.env("QT_QPA_PLATFORMTHEME", "kde")
 hl.env("XDG_MENU_PREFIX", "plasma-")
 
 -- Virtual environment
-hl.env("ILLOGICAL_IMPULSE_VIRTUAL_ENV", "$HOME/.local/state/quickshell/.venv")
+hl.env("ILLOGICAL_IMPULSE_VIRTUAL_ENV", home_dir .. "/.local/state/quickshell/.venv")


### PR DESCRIPTION
## Describe your changes
Replace hardcoded $HOME with home_dir concatenation in env.lua for environment variables to ensure proper expansion.
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

It is ready and doesn't need any feedback.

## Reason
In env.lua, Lua strings are set as environment variables without shell expansion, so $HOME remains a literal string. Using os.getenv("HOME") guarantees the correct home path.

## Note
While exec.lua and keybinds.lua are unaffected because their strings are executed directly (e.g., via os.execute) where $HOME is expanded by the shell, I didn't modify them.