### PR TITLE
Do not override XDG_DATA_DIRS (fixes #2583)

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -2,7 +2,7 @@
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 
 -- Applications
-hl.env("XDG_DATA_DIRS", "$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share")
+hl.env("XDG_DATA_DIRS", "$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS")
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")


### PR DESCRIPTION
The title is self explanatory. By adding :$XDG_DATA_DIRS the variable is not replaced. There is another pull request that fixes this, but that was for the old .conf and not lua.