### PR TITLE
qs: wallpaper selector: fix missing thumbnails on hidpi monitors

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -18,7 +18,8 @@ MouseArea {
 
     function updateThumbnails() {
         const totalImageMargin = (Appearance.sizes.wallpaperSelectorItemMargins + Appearance.sizes.wallpaperSelectorItemPadding) * 2;
-        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions(grid.cellWidth - totalImageMargin, grid.cellHeight - totalImageMargin);
+        const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
+        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions((grid.cellWidth - totalImageMargin) * dpr, (grid.cellHeight - totalImageMargin) * dpr);
         Wallpapers.generateThumbnail(thumbnailSizeName);
     }
 


### PR DESCRIPTION
### Problem
  On a multi-monitor setup with mixed scale factors, opening the wallpaper
  selector on a hidpi monitor shows blank cells where thumbnails should be.
  On a 1.0-scale monitor it works fine.

  ### Cause
  Two pieces of code disagree on which thumbnail size bucket to use:

  - `WallpaperSelectorContent.qml:updateThumbnails()` calls
    `Images.thumbnailSizeNameForDimensions(grid.cellWidth - margins, ...)`
    using **logical** pixels.
  - `ThumbnailImage.qml` (a `StyledImage`) computes its `thumbnailSizeName`
    `width * devicePixelRatio`. So display lookup is in **physical** pixels.

  On a 2.0-scale monitor with ~280-logical-px cells:
  - Generator picks `large` (256) — the cell fits, in logical px.
  - Display picks `x-large` (512) — physical px is ~560.
  - `~/.cache/thumbnails/x-large/<hash>.png` doesn't exist → opacity stays 0.

  ### Fix
  Multiply by `devicePixelRatio` in `updateThumbnails()` so the generator
  asks for the same bucket the display will read from. Uses the same
  `(QsWindow.window as QsWindow)?.devicePixelRatio ?? 1` pattern that
  `StyledImage.qml` already uses, for consistency.
  
  ### Test
  - 1.0-scale monitor: still works (DPR=1, multiplication is a no-op).
  - 2.0-scale monitor: thumbnails now appear after first generation pass.