### PR TITLE
qs: wallpaper selector: fix missing thumbnails on hidpi monitors

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -18,7 +18,8 @@ MouseArea {
 
     function updateThumbnails() {
         const totalImageMargin = (Appearance.sizes.wallpaperSelectorItemMargins + Appearance.sizes.wallpaperSelectorItemPadding) * 2;
-        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions(grid.cellWidth - totalImageMargin, grid.cellHeight - totalImageMargin);
+        const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
+        const thumbnailSizeName = Images.thumbnailSizeNameForDimensions((grid.cellWidth - totalImageMargin) * dpr, (grid.cellHeight - totalImageMargin) * dpr);
         Wallpapers.generateThumbnail(thumbnailSizeName);
     }
 


### PR DESCRIPTION
## Describe your changes

On a multi-monitor setup with one 1.0-scale and one 2.0-scale display, the wallpaper selector shows blank cells on the hidpi monitor.

The cause is a DPR mismatch: `WallpaperSelectorContent.qml` calls `Images.thumbnailSizeNameForDimensions(grid.cellWidth - margins, ...)` in logical pixels, but `ThumbnailImage` (a `StyledImage`) computes its own `thumbnailSizeName` from `sourceSize`, which `StyledImage.qml` already multiplies by `devicePixelRatio`. So on a 2x screen with ~280 logical-px cells the generator writes to `large/` (256) while the display reads from `x-large/` (512), and the cache miss leaves the cells blank.

This patch multiplies `cellWidth`/`cellHeight` by the same DPR `StyledImage` uses, so generator and display agree. On 1x screens the multiplication is a no-op; on 2x screens the missing bucket gets generated on first open.

## Is it ready? Questions/feedback needed?

Ready.