### PR TITLE
fix hyprland XDG_DATA_DIRS env concatenation

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -4,7 +4,8 @@ local home_dir = os.getenv("HOME")
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 
 -- Applications
-hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS")
+local xdg_data_dirs = os.getenv("XDG_DATA_DIRS") or ""
+hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:" .. xdg_data_dirs)
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")


### PR DESCRIPTION
## Problem
Nvim suddenly had problems after updating Hyprland and ii. When I tried to open it, I got these errors:
```
E79: Cannot expand wildcards
E79: Cannot expand wildcards
E79: Cannot expand wildcards
...
```
I checked, and the problem was with the XDG_DATA_DIRS env that nvim uses. 
And traced that on `~/.config/hypr/hyprland/env.lua` It has a concatenation problem where the string was passed as `"/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS"` so it was literally setting an `$XDG_DATA_DIRS` instead of the actual var.

## Fix
Just added a simple `os.getenv`  and a string concatenation. This solved the issue completely with nvim and probably with anything else that uses that variable.

Note: After adding that line of code, the old XDG_DATA_DIRS with the bad "$" concatenated string will still be present even after resetting Hyprland. So the var must be cleaned up, or just do a reboot.

