### PR TITLE
Update keybinds.lua to allow hl.unbind()

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -3,9 +3,6 @@ require("hyprland.variables")
 if is_file_exists(HOME .. "/.config/hypr/custom/variables.lua") then
     require("custom.variables")
 end
-if is_file_exists(HOME .. "/.config/hypr/custom/keybinds.lua") then
-    require("custom.keybinds")
-end
 
 local qsScripts = "$HOME/.config/quickshell/$qsConfig/scripts"
 local hyprScripts = "$HOME/.config/hypr/hyprland/scripts"


### PR DESCRIPTION
## Describe your changes

`hyprland/keybinds.lua` has a duplicate `require("custom.keybinds")` , so the second `require("custom.keybinds")` in `hyprland.lua` (lines 31–32) literally does nothing.

Deleting this also helps using `hl.unbind` way easier.

For example:
```
local function bind(key, action, description)
	if description then
		hl.bind(key, action, { description = description })
	else
		hl.bind(key, action)
	end
end

local function rebind(key, action, description)
	hl.unbind(key)
	bind(key, action, description)
end

rebind(
	"SUPER + O",
	toggle_special_app({
		workspace = "special:1",
		command = "vesktop",
		class = "vesktop",
	}),
	"Vesktop"
)
```
SUPER + O ends up triggering both the Vesktop toggle and quickshell:sidebarLeftToggle simultaneously. (`hl.unbind` fails)

## Is it ready? Questions/feedback needed?

Yes, its a duplicating mess so yoink it

