### PR TITLE
fix: resolve $XDG_DATA_DIRS expansion issue causing neovim E79 error

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -4,7 +4,8 @@ local home_dir = os.getenv("HOME")
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 
 -- Applications
-hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS")
+local current = os.getenv("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:" .. current)
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")


### PR DESCRIPTION
## Summary
- Fix XDG_DATA_DIRS by properly expanding the environment variable instead of using literal `$XDG_DATA_DIRS`
- Resolves neovim runtime error: "E79: Cannot expand wildcards" caused by recursive/unresolved variable expansion