### PR TITLE
fix(hyprsunset): remove vestigial Hyprland.dispatch broken under .lua schema

### DIFF
--- a/dots/.config/quickshell/ii/services/Hyprsunset.qml
+++ b/dots/.config/quickshell/ii/services/Hyprsunset.qml
@@ -166,7 +166,6 @@ Singleton {
         target: Config.options.light.night
         function onColorTemperatureChanged() {
             if (!root.temperatureActive) return;
-            Hyprland.dispatch(`hyprctl hyprsunset temperature ${Config.options.light.night.colorTemperature}`);
             Quickshell.execDetached(["hyprctl", "hyprsunset", "temperature", `${Config.options.light.night.colorTemperature}`]);
         }
     }


### PR DESCRIPTION
## Problem

Under the `.lua` config schema, Hyprland evaluates `Hyprland.dispatch(<string>)` IPC calls as Lua expressions instead of parsing them as legacy dispatcher commands. Any `Hyprland.dispatch("foo bar")` written in raw conf-style syntax now fails with:

```
WARN quickshell.hyprland.ipc: Dispatch request "foo bar" failed with error
  "error: [string \"return hl.dispatch(foo bar)\"]:1: ')' expected near 'bar'
  → Note: dispatch in lua is a shorthand for hl.dispatch(...), your syntax might need to be updated."
```

You have already migrated essentially all of `quickshell/ii/` to `hl.dsp.*` Lua syntax — overview, taskView, workspaces, sidebar, etc. all dispatch correctly under the new schema. Nicely done.

**One vestigial call remains** in `services/Hyprsunset.qml:169`. It sits directly above a `Quickshell.execDetached(...)` line that already performs the same action correctly — it looks like a leftover from before the `execDetached` migration. Under `.conf` it silently no-ops (`hyprctl` is not a Hyprland dispatcher name); under `.lua` it produces a recurring IPC warning every time the night-mode color temperature changes.

## Solution

Delete the dead line. The `Quickshell.execDetached(["hyprctl", "hyprsunset", "temperature", ...])` immediately below already does the work in both schemas.

## Verification

After this patch:

```
$ grep -rn 'Hyprland.dispatch' dots/.config/quickshell/ii --include='*.qml' \
    | grep -vE 'hl\.dsp|hl\.config'
(no matches)
```

Every remaining `Hyprland.dispatch` in the tree uses proper `hl.dsp.*` / `hl.config(...)` Lua syntax.

Tested live on Hyprland 0.55.2 with `Hyprland --config ~/.config/hypr/hyprland.lua`: no more warnings on color-temperature change, night mode still applies correctly via the `execDetached` path.
