### PR TITLE
Fix: XDG_DATA_DIRS now expands correctly (fixes 3354)

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -4,7 +4,8 @@ local home_dir = os.getenv("HOME")
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 
 -- Applications
-hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS")
+local xdg_data_dirs_old = os.getenv("XDG_DATA_DIRS") or ""
+hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:" .. xdg_data_dirs_old)
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")


### PR DESCRIPTION
Previously the environmental variable would become literally  *:$XDG_DATA_DIRS
Now the variable is expanded correctly


