### PR TITLE
Polish Pomodoro controls

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -572,6 +572,7 @@ Singleton {
                     property int cyclesBeforeLongBreak: 4
                     property int focus: 1500
                     property int longBreak: 900
+                    property bool notifications: true
                 }
                 property bool secondPrecision: false
             }

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -317,6 +317,15 @@ Item { // Bar content region
                 }
             }
 
+            Revealer {
+                reveal: TimerService.pomodoroRunning
+                Layout.fillHeight: true
+
+                PomodoroBarIndicator {
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
             SysTray {
                 visible: root.useShortenedForm === 0
                 Layout.fillWidth: false

--- a/dots/.config/quickshell/ii/modules/ii/bar/PomodoroBarIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/PomodoroBarIndicator.qml
@@ -1,0 +1,113 @@
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+
+RippleButton {
+    id: root
+
+    property bool vertical: false
+    readonly property color stateColor: TimerService.pomodoroBreak ? Appearance.colors.colTertiaryContainer : Appearance.colors.colSecondaryContainer
+    readonly property color stateColorHover: TimerService.pomodoroBreak ? Appearance.colors.colTertiaryContainerHover : Appearance.colors.colSecondaryContainerHover
+    readonly property color stateColorActive: TimerService.pomodoroBreak ? Appearance.colors.colTertiaryContainerActive : Appearance.colors.colSecondaryContainerActive
+    readonly property color stateTextColor: TimerService.pomodoroBreak ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colOnSecondaryContainer
+
+    implicitWidth: vertical ? Appearance.sizes.verticalBarWidth - 10 : 104
+    implicitHeight: vertical ? 54 : Appearance.sizes.baseBarHeight - 8
+
+    buttonRadius: Appearance.rounding.full
+    toggled: TimerService.pomodoroRunning
+    colBackground: stateColor
+    colBackgroundHover: stateColorHover
+    colRipple: stateColorActive
+    colBackgroundToggled: stateColor
+    colBackgroundToggledHover: stateColorHover
+    colRippleToggled: stateColorActive
+
+    function pomodoroTimeText() {
+        const minutes = Math.floor(TimerService.pomodoroSecondsLeft / 60).toString().padStart(2, "0");
+        const seconds = Math.floor(TimerService.pomodoroSecondsLeft % 60).toString().padStart(2, "0");
+        return `${minutes}:${seconds}`;
+    }
+
+    function compactMinutesText() {
+        return Math.ceil(TimerService.pomodoroSecondsLeft / 60).toString().padStart(2, "0");
+    }
+
+    onClicked: {
+        Persistent.states.sidebar.bottomGroup.collapsed = false;
+        Persistent.states.sidebar.bottomGroup.tab = 2;
+        GlobalStates.sidebarRightOpen = true;
+    }
+
+    contentItem: Item {
+        anchors.fill: parent
+
+        RowLayout {
+            id: contentRow
+            anchors.centerIn: parent
+            visible: !root.vertical
+            spacing: 5
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignVCenter
+                text: TimerService.pomodoroBreak ? "coffee" : "search_activity"
+                iconSize: Appearance.font.pixelSize.larger
+                color: root.stateTextColor
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignVCenter
+                Layout.preferredWidth: 48
+                horizontalAlignment: Text.AlignHCenter
+                text: root.pomodoroTimeText()
+                font.family: Appearance.font.family.monospace
+                font.pixelSize: Appearance.font.pixelSize.normal
+                font.weight: Font.DemiBold
+                color: root.stateTextColor
+            }
+        }
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            visible: root.vertical
+            spacing: 1
+
+            ClippedFilledCircularProgress {
+                Layout.alignment: Qt.AlignHCenter
+                implicitSize: 28
+                lineWidth: 3
+                value: TimerService.pomodoroSecondsLeft / TimerService.pomodoroLapDuration
+                colPrimary: root.stateTextColor
+                colSecondary: root.stateColorHover
+                enableAnimation: true
+
+                textMask: Item {
+                    width: 28
+                    height: 28
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: root.compactMinutesText()
+                        font.family: Appearance.font.family.monospace
+                        font.pixelSize: 11
+                        font.weight: Font.DemiBold
+                    }
+                }
+            }
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignHCenter
+                text: TimerService.pomodoroBreak ? "coffee" : "search_activity"
+                iconSize: 14
+                color: root.stateTextColor
+            }
+        }
+    }
+
+    StyledToolTip {
+        text: TimerService.pomodoroLongBreak ? Translation.tr("Long break") : TimerService.pomodoroBreak ? Translation.tr("Break") : Translation.tr("Pomodoro")
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/BottomWidgetGroup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/BottomWidgetGroup.qml
@@ -13,7 +13,7 @@ Rectangle {
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
     clip: true
-    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : 350
+    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : 430
     property int selectedTab: Persistent.states.sidebar.bottomGroup.tab
     property int previousIndex: -1
     property bool collapsed: Persistent.states.sidebar.bottomGroup.collapsed
@@ -31,10 +31,16 @@ Rectangle {
             "widget": "todo/TodoWidget.qml"
         },
         {
-            "type": "timer",
-            "name": Translation.tr("Timer"),
-            "icon": "schedule",
+            "type": "pomodoro",
+            "name": Translation.tr("Pomodoro"),
+            "icon": "search_activity",
             "widget": "pomodoro/PomodoroWidget.qml"
+        },
+        {
+            "type": "stopwatch",
+            "name": Translation.tr("Stopwatch"),
+            "icon": "timer",
+            "widget": "pomodoro/StopwatchWidget.qml"
         },
     ]
 
@@ -54,6 +60,14 @@ Rectangle {
             collapsedBottomWidgetGroupRow.opacity = 0;
         }
         collapseCleanFadeTimer.start();
+    }
+
+    Connections {
+        target: Persistent.states.sidebar.bottomGroup
+
+        function onTabChanged() {
+            root.selectedTab = Persistent.states.sidebar.bottomGroup.tab;
+        }
     }
 
     Timer {

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroSettings.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroSettings.qml
@@ -1,0 +1,368 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+StyledFlickable {
+    id: root
+
+    clip: true
+    contentWidth: width
+    contentHeight: settingsColumn.implicitHeight
+
+    function setMinutes(optionName, minutes) {
+        Config.options.time.pomodoro[optionName] = Math.max(1, minutes) * 60;
+        if (!TimerService.pomodoroRunning) {
+            TimerService.resetPomodoro();
+        }
+    }
+
+    function minutes(optionName) {
+        return Math.round(Config.options.time.pomodoro[optionName] / 60);
+    }
+
+    function applyPreset(focus, shortBreak, longBreak, cycles) {
+        Config.options.time.pomodoro.focus = focus * 60;
+        Config.options.time.pomodoro.breakTime = shortBreak * 60;
+        Config.options.time.pomodoro.longBreak = longBreak * 60;
+        Config.options.time.pomodoro.cyclesBeforeLongBreak = cycles;
+        if (!TimerService.pomodoroRunning) {
+            TimerService.resetPomodoro();
+        }
+    }
+
+    function setCycles(cycles) {
+        Config.options.time.pomodoro.cyclesBeforeLongBreak = cycles;
+        if (!TimerService.pomodoroRunning) {
+            TimerService.resetPomodoro();
+        }
+    }
+
+    ColumnLayout {
+        id: settingsColumn
+        width: root.width
+        spacing: 10
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.leftMargin: 4
+            Layout.rightMargin: 12
+            implicitHeight: 108
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer2
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 8
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+
+                    Rectangle {
+                        Layout.alignment: Qt.AlignVCenter
+                        implicitWidth: 42
+                        implicitHeight: 42
+                        radius: Appearance.rounding.full
+                        color: Appearance.colors.colSecondaryContainer
+
+                        MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "search_activity"
+                            iconSize: Appearance.font.pixelSize.hugeass
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 1
+
+                        StyledText {
+                            text: Translation.tr("Focus profile")
+                            font.pixelSize: Appearance.font.pixelSize.normal
+                            font.weight: Font.Medium
+                            color: Appearance.colors.colOnLayer2
+                        }
+
+                        StyledText {
+                            text: `${root.minutes("focus")} / ${root.minutes("breakTime")} / ${root.minutes("longBreak")} min  •  ${Config.options.time.pomodoro.cyclesBeforeLongBreak} cycles`
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colSubtext
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    ProfileChip {
+                        iconName: "search_activity"
+                        label: `${root.minutes("focus")}m`
+                        color: Appearance.colors.colSecondaryContainer
+                        textColor: Appearance.colors.colOnSecondaryContainer
+                    }
+
+                    ProfileChip {
+                        iconName: "coffee"
+                        label: `${root.minutes("breakTime")}m`
+                        color: Appearance.colors.colTertiaryContainer
+                        textColor: Appearance.colors.colOnTertiaryContainer
+                    }
+
+                    ProfileChip {
+                        iconName: "spa"
+                        label: `${root.minutes("longBreak")}m`
+                        color: Appearance.colors.colLayer1
+                        textColor: Appearance.colors.colOnLayer1
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    RowLayout {
+                        spacing: 3
+
+                        Repeater {
+                            model: Config.options.time.pomodoro.cyclesBeforeLongBreak
+
+                            Rectangle {
+                                implicitWidth: 7
+                                implicitHeight: 7
+                                radius: Appearance.rounding.full
+                                color: Appearance.colors.colOnLayer2
+                                opacity: 0.45
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ContentSection {
+            icon: "timer"
+            title: Translation.tr("Pomodoro")
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 8
+                Layout.rightMargin: 8
+                spacing: 6
+                uniformCellSizes: true
+
+                PresetButton {
+                    label: "25/5"
+                    onClicked: root.applyPreset(25, 5, 15, 4)
+                }
+
+                PresetButton {
+                    label: "50/10"
+                    onClicked: root.applyPreset(50, 10, 25, 4)
+                }
+
+                PresetButton {
+                    label: "15/5"
+                    onClicked: root.applyPreset(15, 5, 15, 4)
+                }
+            }
+
+            PomodoroSpinRow {
+                iconName: "search_activity"
+                label: Translation.tr("Focus")
+                suffix: Translation.tr("min")
+                from: 1
+                to: 180
+                stepSize: 5
+                value: root.minutes("focus")
+                onValueModified: value => root.setMinutes("focus", value)
+            }
+
+            PomodoroSpinRow {
+                iconName: "coffee"
+                label: Translation.tr("Break")
+                suffix: Translation.tr("min")
+                from: 1
+                to: 60
+                stepSize: 1
+                value: root.minutes("breakTime")
+                onValueModified: value => root.setMinutes("breakTime", value)
+            }
+
+            PomodoroSpinRow {
+                iconName: "spa"
+                label: Translation.tr("Long break")
+                suffix: Translation.tr("min")
+                from: 1
+                to: 120
+                stepSize: 5
+                value: root.minutes("longBreak")
+                onValueModified: value => root.setMinutes("longBreak", value)
+            }
+
+            PomodoroSpinRow {
+                iconName: "repeat"
+                label: Translation.tr("Cycles")
+                suffix: ""
+                from: 1
+                to: 12
+                stepSize: 1
+                value: Config.options.time.pomodoro.cyclesBeforeLongBreak
+                onValueModified: value => root.setCycles(value)
+            }
+        }
+
+        ContentSection {
+            icon: "notifications"
+            title: Translation.tr("Alerts")
+
+            ConfigRow {
+                uniform: true
+
+                ConfigSwitch {
+                    buttonIcon: "notifications"
+                    text: Translation.tr("Notifications")
+                    checked: Config.options.time.pomodoro.notifications
+                    onCheckedChanged: Config.options.time.pomodoro.notifications = checked
+                }
+
+                ConfigSwitch {
+                    buttonIcon: "notification_sound"
+                    text: Translation.tr("Sound")
+                    checked: Config.options.sounds.pomodoro
+                    onCheckedChanged: Config.options.sounds.pomodoro = checked
+                }
+            }
+
+            RippleButton {
+                Layout.fillWidth: true
+                implicitHeight: 40
+                buttonRadius: Appearance.rounding.full
+                colBackground: Appearance.colors.colLayer2
+                colBackgroundHover: Appearance.colors.colLayer2Hover
+                colRipple: Appearance.colors.colLayer2Active
+
+                onClicked: Audio.playSystemSound("alarm-clock-elapsed")
+
+                contentItem: RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 12
+                    anchors.rightMargin: 12
+                    spacing: 8
+
+                    MaterialSymbol {
+                        text: "play_circle"
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: Appearance.colors.colOnLayer2
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: Translation.tr("Test sound")
+                        color: Appearance.colors.colOnLayer2
+                    }
+                }
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+            implicitHeight: 4
+        }
+    }
+
+    component PresetButton: RippleButton {
+        id: preset
+        property string label
+
+        Layout.fillWidth: true
+        implicitHeight: 34
+        buttonRadius: Appearance.rounding.full
+        colBackground: Appearance.colors.colLayer2
+        colBackgroundHover: Appearance.colors.colLayer2Hover
+        colRipple: Appearance.colors.colLayer2Active
+
+        contentItem: StyledText {
+            anchors.centerIn: parent
+            text: preset.label
+            horizontalAlignment: Text.AlignHCenter
+            font.family: Appearance.font.family.monospace
+            font.weight: Font.DemiBold
+            color: Appearance.colors.colOnLayer2
+        }
+    }
+
+    component ProfileChip: Rectangle {
+        property string iconName
+        property string label
+        property color textColor
+
+        Layout.fillWidth: true
+        implicitHeight: 28
+        radius: Appearance.rounding.full
+
+        RowLayout {
+            anchors.centerIn: parent
+            spacing: 4
+
+            MaterialSymbol {
+                text: parent.parent.iconName
+                iconSize: 14
+                color: parent.parent.textColor
+            }
+
+            StyledText {
+                text: parent.parent.label
+                font.family: Appearance.font.family.monospace
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                font.weight: Font.DemiBold
+                color: parent.parent.textColor
+            }
+        }
+    }
+
+    component PomodoroSpinRow: RowLayout {
+        id: row
+
+        property string iconName
+        property string label
+        property string suffix
+        property alias value: spinBox.value
+        property alias from: spinBox.from
+        property alias to: spinBox.to
+        property alias stepSize: spinBox.stepSize
+        signal valueModified(int value)
+
+        Layout.fillWidth: true
+        Layout.leftMargin: 8
+        Layout.rightMargin: 8
+        spacing: 10
+
+        MaterialSymbol {
+            text: row.iconName
+            iconSize: Appearance.font.pixelSize.larger
+            color: Appearance.colors.colOnSecondaryContainer
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            text: row.label
+            color: Appearance.colors.colOnSecondaryContainer
+        }
+
+        StyledSpinBox {
+            id: spinBox
+            Layout.preferredWidth: 96
+            stepSize: 1
+            onValueModified: row.valueModified(value)
+        }
+
+        StyledText {
+            Layout.preferredWidth: 24
+            text: row.suffix
+            color: Appearance.colors.colSubtext
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
@@ -12,39 +12,49 @@ Item {
 
     implicitHeight: contentColumn.implicitHeight
     implicitWidth: contentColumn.implicitWidth
+    readonly property color stateColor: TimerService.pomodoroBreak ? Appearance.colors.colTertiaryContainer : Appearance.colors.colSecondaryContainer
+    readonly property color stateTextColor: TimerService.pomodoroBreak ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colOnSecondaryContainer
+    readonly property string stateLabel: TimerService.pomodoroLongBreak ? Translation.tr("Long break") : TimerService.pomodoroBreak ? Translation.tr("Break") : Translation.tr("Focus")
+    readonly property int cyclePosition: TimerService.pomodoroCycle + 1
 
     ColumnLayout {
         id: contentColumn
         anchors.fill: parent
-        spacing: 0
+        spacing: 10
 
         // The Pomodoro timer circle
         CircularProgress {
             Layout.alignment: Qt.AlignHCenter
-            lineWidth: 8
+            lineWidth: 10
             value: {
                 return TimerService.pomodoroSecondsLeft / TimerService.pomodoroLapDuration;
             }
             implicitSize: 200
+            colPrimary: root.stateTextColor
+            colSecondary: root.stateColor
             enableAnimation: true
 
             ColumnLayout {
                 anchors.centerIn: parent
-                spacing: 0
+                spacing: 2
 
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: 150
+                    horizontalAlignment: Text.AlignHCenter
                     text: {
                         let minutes = Math.floor(TimerService.pomodoroSecondsLeft / 60).toString().padStart(2, '0');
                         let seconds = Math.floor(TimerService.pomodoroSecondsLeft % 60).toString().padStart(2, '0');
                         return `${minutes}:${seconds}`;
                     }
+                    font.family: Appearance.font.family.monospace
                     font.pixelSize: 40
+                    font.weight: Font.DemiBold
                     color: Appearance.m3colors.m3onSurface
                 }
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
-                    text: TimerService.pomodoroLongBreak ? Translation.tr("Long break") : TimerService.pomodoroBreak ? Translation.tr("Break") : Translation.tr("Focus")
+                    text: root.stateLabel
                     font.pixelSize: Appearance.font.pixelSize.normal
                     color: Appearance.colors.colSubtext
                 }
@@ -52,20 +62,81 @@ Item {
 
             Rectangle {
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer2
+                color: root.stateColor
                 
                 anchors {
                     right: parent.right
                     bottom: parent.bottom
                 }
-                implicitWidth: 36
-                implicitHeight: implicitWidth
+                implicitWidth: 58
+                implicitHeight: 36
+
+                RowLayout {
+                    anchors.centerIn: parent
+                    spacing: 3
+
+                    MaterialSymbol {
+                        text: "repeat"
+                        iconSize: 14
+                        color: root.stateTextColor
+                    }
+
+                    StyledText {
+                        id: cycleText
+                        font.family: Appearance.font.family.monospace
+                        font.weight: Font.DemiBold
+                        color: root.stateTextColor
+                        text: `${root.cyclePosition}/${TimerService.cyclesBeforeLongBreak}`
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: 210
+            Layout.preferredHeight: 30
+            radius: Appearance.rounding.full
+            color: Appearance.colors.colLayer2
+
+            RowLayout {
+                anchors.centerIn: parent
+                spacing: 6
+
+                MaterialSymbol {
+                    text: TimerService.pomodoroBreak ? "coffee" : "search_activity"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: root.stateTextColor
+                }
 
                 StyledText {
-                    id: cycleText
-                    anchors.centerIn: parent
+                    text: root.stateLabel
+                    font.pixelSize: Appearance.font.pixelSize.normal
                     color: Appearance.colors.colOnLayer2
-                    text: TimerService.pomodoroCycle + 1
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: 5
+
+            Repeater {
+                model: TimerService.cyclesBeforeLongBreak
+
+                Rectangle {
+                    required property int index
+                    implicitWidth: index === TimerService.pomodoroCycle ? 18 : 8
+                    implicitHeight: 8
+                    radius: Appearance.rounding.full
+                    color: index <= TimerService.pomodoroCycle ? root.stateTextColor : Appearance.colors.colLayer2
+
+                    Behavior on implicitWidth {
+                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                    }
+                    Behavior on color {
+                        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+                    }
                 }
             }
         }
@@ -76,14 +147,15 @@ Item {
             spacing: 10
 
             RippleButton {
+                buttonRadius: Appearance.rounding.full
                 contentItem: StyledText {
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     text: TimerService.pomodoroRunning ? Translation.tr("Pause") : (TimerService.pomodoroSecondsLeft === TimerService.focusTime) ? Translation.tr("Start") : Translation.tr("Resume")
                     color: TimerService.pomodoroRunning ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnPrimary
                 }
-                implicitHeight: 35
-                implicitWidth: 90
+                implicitHeight: 38
+                implicitWidth: 96
                 font.pixelSize: Appearance.font.pixelSize.larger
                 onClicked: TimerService.togglePomodoro()
                 colBackground: TimerService.pomodoroRunning ? Appearance.colors.colSecondaryContainer : Appearance.colors.colPrimary
@@ -91,8 +163,9 @@ Item {
             }
 
             RippleButton {
-                implicitHeight: 35
-                implicitWidth: 90
+                buttonRadius: Appearance.rounding.full
+                implicitHeight: 38
+                implicitWidth: 96
 
                 onClicked: TimerService.resetPomodoro()
                 enabled: (TimerService.pomodoroSecondsLeft < TimerService.pomodoroLapDuration) || TimerService.pomodoroCycle > 0 || TimerService.pomodoroBreak

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
@@ -8,11 +8,11 @@ import QtQuick.Layouts
 Item {
     id: root
     property var tabButtonList: [
-        {"name": Translation.tr("Pomodoro"), "icon": "search_activity"},
-        {"name": Translation.tr("Stopwatch"), "icon": "timer"}
+        {"name": Translation.tr("Timer"), "icon": "search_activity"},
+        {"name": Translation.tr("Customize"), "icon": "tune"}
     ]
 
-    // These are keybinds for stopwatch and pomodoro
+    // Pomodoro keybinds
     Keys.onPressed: (event) => {
         if ((event.key === Qt.Key_PageDown || event.key === Qt.Key_PageUp) && event.modifiers === Qt.NoModifier) { // Switch tabs
             if (event.key === Qt.Key_PageDown) {
@@ -24,19 +24,12 @@ Item {
         } else if (event.key === Qt.Key_Space || event.key === Qt.Key_S) { // Pause/resume with Space or S
             if (tabBar.currentIndex === 0) {
                 TimerService.togglePomodoro()
-            } else {
-                TimerService.toggleStopwatch()
             }
             event.accepted = true
         } else if (event.key === Qt.Key_R) { // Reset with R
             if (tabBar.currentIndex === 0) {
                 TimerService.resetPomodoro()
-            } else {
-                TimerService.stopwatchReset()
             }
-            event.accepted = true
-        } else if (event.key === Qt.Key_L) { // Record lap with L
-            TimerService.stopwatchRecordLap()
             event.accepted = true
         }
     }
@@ -69,7 +62,7 @@ Item {
 
             // Tabs
             PomodoroTimer {}
-            Stopwatch {}
+            PomodoroSettings {}
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/StopwatchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/pomodoro/StopwatchWidget.qml
@@ -1,0 +1,63 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    Keys.onPressed: (event) => {
+        if (event.key === Qt.Key_Space || event.key === Qt.Key_S) {
+            TimerService.toggleStopwatch();
+            event.accepted = true;
+        } else if (event.key === Qt.Key_R) {
+            TimerService.stopwatchReset();
+            event.accepted = true;
+        } else if (event.key === Qt.Key_L) {
+            TimerService.stopwatchRecordLap();
+            event.accepted = true;
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 8
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 4
+            Layout.rightMargin: 14
+            spacing: 8
+
+            MaterialSymbol {
+                text: "timer"
+                iconSize: Appearance.font.pixelSize.hugeass
+                color: Appearance.colors.colOnSecondaryContainer
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                StyledText {
+                    text: Translation.tr("Stopwatch")
+                    font.pixelSize: Appearance.font.pixelSize.larger
+                    font.weight: Font.Medium
+                    color: Appearance.colors.colOnLayer1
+                }
+
+                StyledText {
+                    text: TimerService.stopwatchRunning ? Translation.tr("Running") : Translation.tr("Ready")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                }
+            }
+        }
+
+        Stopwatch {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
@@ -190,6 +190,18 @@ Item { // Bar content region
                 invertSide: Config?.options.bar.bottom
             }
 
+            Revealer {
+                vertical: true
+                reveal: TimerService.pomodoroRunning
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+
+                Bar.PomodoroBarIndicator {
+                    vertical: true
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+            }
+
             RippleButton { // Right sidebar button
                 id: rightSidebarButton
 

--- a/dots/.config/quickshell/ii/services/TimerService.qml
+++ b/dots/.config/quickshell/ii/services/TimerService.qml
@@ -63,7 +63,9 @@ Singleton {
                 notificationMessage = Translation.tr(`🔴 Focus: %1 minutes`).arg(Math.floor(focusTime / 60));
             }
 
-            Quickshell.execDetached(["notify-send", "Pomodoro", notificationMessage, "-a", "Shell"]);
+            if (Config.options.time.pomodoro.notifications) {
+                Quickshell.execDetached(["notify-send", "Pomodoro", notificationMessage, "-a", "Shell"]);
+            }
             if (Config.options.sounds.pomodoro) {
                 Audio.playSystemSound("alarm-clock-elapsed")
             }


### PR DESCRIPTION
## Summary
- make Pomodoro a dedicated sidebar tab and move Stopwatch to its own tab
- add active Pomodoro indicators for horizontal and vertical bars
- add Pomodoro-specific settings for durations, cycles, notifications, and sound

## Notes
This is a targeted Pomodoro-focused polish for users who rely on the timer during work sessions.

## Testing
- Ran qmllint on the touched QML files
- Tested the changes in a local Quickshell session

<img width="362" height="430" alt="swappy-20260517_135847" src="https://github.com/user-attachments/assets/a517eb93-97fd-4dfa-a08c-44ad6f14f584" />
<img width="354" height="432" alt="swappy-20260517_135900" src="https://github.com/user-attachments/assets/239b1237-f5fc-4b60-b381-4a3913a38616" />


<img width="256" height="272" alt="image" src="https://github.com/user-attachments/assets/f289130b-bb03-4d5f-a107-d5593caf4140" />
<img width="372" height="137" alt="image" src="https://github.com/user-attachments/assets/f2a5de2d-43ef-4096-84ac-f166f1713ada" />
