### PR TITLE
fix: properly expand XDG_DATA_DIRS and deduplicate entries

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -1,10 +1,26 @@
 local home_dir = os.getenv("HOME")
 
+local function unique_paths(str)
+	local seen = {}
+	local result = {}
+
+	for path in string.gmatch(str or "", "([^:]+)") do
+		if not path:match("^%$[%w_]+$") and not seen[path] then
+			seen[path] = true
+			table.insert(result, path)
+		end
+	end
+
+	return table.concat(result, ":")
+end
+
+local base_xdg = home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share"
+local current_xdg = os.getenv("XDG_DATA_DIRS") or ""
+
+hl.env("XDG_DATA_DIRS", unique_paths(base_xdg .. ":" .. current_xdg))
+
 -- Wayland
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
-
--- Applications
-hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:$XDG_DATA_DIRS")
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")


### PR DESCRIPTION
Fixes #2583, #3329, #3354

The current env.lua uses string concatenation with a literal '$XDG_DATA_DIRS' which is not expanded in Lua. This causes Neovim to fail with 'E79: Cannot expand wildcards' when opening directories.

This fix:
1. Uses os.getenv() to properly expand the existing XDG_DATA_DIRS value
2. Adds deduplication to prevent entries accumulating after Hyprland reloads

See:
- #3329: $XDG_DATA_DIRS variable affecting Neovim
- #3354: XDG_DATA_DIRS may contain unresolved literal '$XDG_DATA_DIRS' and duplicate entries after reloads