### PR TITLE
change lock command in hypridle.conf to work with latest hyprland

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -1,4 +1,4 @@
-$lock_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lock")' & pidof qs quickshell hyprlock || hyprlock
+$lock_cmd = qs -c ii ipc call lock activate || hyprlock
 # $lock_cmd = pidof hyprlock || hyprlock
 $suspend_cmd = systemctl suspend || loginctl suspend
 


### PR DESCRIPTION
`loginctl lock-session` didnt work as of latest hyprland version and latest dots.

- Cause: when `loginctl lock-session` triggers hypridle, it executes a command containing `global quickshell:lock`. The new Lua parser hits the colon, gets confused, thinks it’s an invalid Lua function, and silently crashes.
- Fix: bypass the broken Hyprland global dispatcher and target Quickshell directly