### PR TITLE
Fix old syntax hyprctl dispatchers in hypridle.conf

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -16,7 +16,7 @@ listener {
 
 listener {
     timeout = 600 # 10mins
-    on-timeout = hypctl dispatch 'hl.dsp.dpms({ action = "disable" })'
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'
     on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
 }
 

--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -5,7 +5,7 @@ $suspend_cmd = systemctl suspend || loginctl suspend
 general {
     lock_cmd = $lock_cmd
     before_sleep_cmd = loginctl lock-session
-    after_sleep_cmd = hyprctl dispatch global quickshell:lockFocus
+    after_sleep_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lockFocus")'
     inhibit_sleep = 3
 }
 
@@ -16,8 +16,8 @@ listener {
 
 listener {
     timeout = 600 # 10mins
-    on-timeout = hyprctl dispatch dpms off
-    on-resume = hyprctl dispatch dpms on
+    on-timeout = hypctl dispatch 'hl.dsp.dpms({ action = "disable" })'
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
 }
 
 listener {


### PR DESCRIPTION
## Describe your changes

Fix some dispatchers in `hypridle.conf` that were not modified for Hyprland 0.55 (I think end4 simply just missed those ones).
This should fix `quickshell:lockFocus` and dpms on lockscreen after sleep.
https://wiki.hypr.land/Configuring/Basics/Dispatchers/#cursor

## Is it ready? Questions/feedback needed?

Yes, I should've noticed this long ago but here we are
