### PR TITLE
fix(StyledPopup): clamp popup position to prevent overflow on multi-monitor

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
@@ -35,10 +35,15 @@ LazyLoader {
         exclusiveZone: 0
         margins {
             left: {
-                if (!Config.options.bar.vertical) return root.QsWindow?.mapFromItem(
-                    root.hoverTarget, 
-                    (root.hoverTarget.width - popupBackground.implicitWidth) / 2, 0
-                ).x;
+                if (!Config.options.bar.vertical) {
+                    const rawX = root.QsWindow?.mapFromItem(
+                        root.hoverTarget,
+                        (root.hoverTarget.width - popupBackground.implicitWidth) / 2, 0
+                    ).x ?? 0;
+                    const screenWidth = root.QsWindow?.window?.screen?.width ?? 0;
+                    const maxX = screenWidth - popupBackground.implicitWidth - Appearance.sizes.elevationMargin * 2;
+                    return screenWidth > 0 ? Math.max(0, Math.min(rawX, maxX)) : rawX;
+                }
                 return Appearance.sizes.verticalBarWidth
             }
             top: {


### PR DESCRIPTION
## Problem

On multi-monitor setups, bar popups (e.g. clock, network, audio) can overflow onto the second monitor when the hovered bar item is near the right edge of the primary screen.

## Fix

Clamp the computed `left` margin so the popup never exceeds `screenWidth - popupWidth`. Falls back to unclamped behavior if `screenWidth` is unavailable.