### PR TITLE
qs: preload sidebar dialogs and bar popups (closes #3350)

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -241,6 +241,7 @@ Singleton {
                 property bool showBackground: true
                 property bool verbose: true
                 property bool vertical: false
+                property bool preloadPopups: true // Eagerly compile bar popups after a short idle so first hover is instant
                 property JsonObject resources: JsonObject {
                     property bool alwaysShowSwap: true
                     property bool alwaysShowCpu: true

--- a/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
@@ -9,8 +9,8 @@ Rectangle {
     id: root
 
     property bool show: false
-    default property alias contentData: contentColumn.data
-    property real backgroundHeight: dialogBackground.implicitHeight
+    default property alias data: contentColumn.data
+    property real backgroundHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
     property real backgroundWidth: 350
     property real backgroundAnimationMovementDistance: 60
     
@@ -30,7 +30,6 @@ Rectangle {
 
     onShowChanged: {
         dialogBackgroundHeightAnimation.easing.bezierCurve = (show ? Appearance.animationCurves.emphasizedDecel : Appearance.animationCurves.emphasizedAccel)
-        dialogBackground.implicitHeight = show ? backgroundHeight : 0
     }
 
     radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
@@ -51,7 +50,7 @@ Rectangle {
         property real targetY: root.height / 2 - root.backgroundHeight / 2
         y: root.show ? targetY : (targetY - root.backgroundAnimationMovementDistance)
         implicitWidth: root.backgroundWidth
-        implicitHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
+        implicitHeight: root.show ? root.backgroundHeight : 0
         Behavior on implicitHeight {
             NumberAnimation {
                 id: dialogBackgroundHeightAnimation

--- a/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
@@ -12,12 +12,21 @@ LazyLoader {
     property Item hoverTarget
     default property Item contentItem
     property real popupBackgroundMargin: 0
+    property bool preloaded: false
 
-    active: hoverTarget && hoverTarget.containsMouse
+    Timer {
+        interval: 2500
+        running: !root.preloaded && (Config?.options?.bar?.preloadPopups ?? true)
+        repeat: false
+        onTriggered: root.preloaded = true
+    }
+
+    active: (hoverTarget && hoverTarget.containsMouse) || root.preloaded
 
     component: PanelWindow {
         id: popupWindow
         color: "transparent"
+        visible: root.hoverTarget && root.hoverTarget.containsMouse
 
         anchors.left: !Config.options.bar.vertical || (Config.options.bar.vertical && !Config.options.bar.bottom)
         anchors.right: Config.options.bar.vertical && Config.options.bar.bottom

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -28,6 +28,15 @@ Item {
     property bool showNightLightDialog: false
     property bool showWifiDialog: false
     property bool editMode: false
+    property bool dialogsPreloaded: false
+
+    Timer {
+        id: dialogsPreloadTimer
+        interval: 2500
+        running: Config?.options?.sidebar?.keepRightSidebarLoaded ?? false
+        repeat: false
+        onTriggered: root.dialogsPreloaded = true
+    }
 
     Connections {
         target: GlobalStates
@@ -160,10 +169,16 @@ Item {
         readonly property bool shown: root[shownPropertyString]
         anchors.fill: parent
 
-        onShownChanged: if (shown) toggleDialogLoader.active = true;
-        active: shown
+        active: shown || root.dialogsPreloaded
+        asynchronous: !shown
+        onShownChanged: {
+            if (shown && item) {
+                item.show = true;
+                item.forceActiveFocus();
+            }
+        }
         onActiveChanged: {
-            if (active) {
+            if (active && shown && item) {
                 item.show = true;
                 item.forceActiveFocus();
             }
@@ -175,7 +190,11 @@ Item {
                 root[toggleDialogLoader.shownPropertyString] = false;
             }
             function onVisibleChanged() {
-                if (!toggleDialogLoader.item.visible && !root[toggleDialogLoader.shownPropertyString]) toggleDialogLoader.active = false;
+                if (!toggleDialogLoader.item.visible
+                    && !root[toggleDialogLoader.shownPropertyString]
+                    && !root.dialogsPreloaded) {
+                    toggleDialogLoader.active = false;
+                }
             }
         }
     }


### PR DESCRIPTION
Preloads sidebar inner dialogs (NightLight/Bluetooth/Wifi/Volume in+out) and bar popups (Resources/Battery/Clock/Weather/SysTray) so the first interaction with each is instant. Most visible improvement on NVIDIA + Wayland.

**Sidebar dialogs** — reuses existing `sidebar.keepRightSidebarLoaded`. A 2.5s idle Timer flips `dialogsPreloaded`; ToggleDialog becomes `active: shown || dialogsPreloaded` with `asynchronous: !shown`.

**Bar popups** — new `bar.preloadPopups` flag (default true). Same Timer pattern in StyledPopup; PanelWindow `visible` is bound to hover so preloaded instances compile without mapping a Wayland surface.

**WindowDialog hotfix (1st commit)** — needed for preload to be sound. The existing `visible: dialogBackground.implicitHeight > 0` paired with imperative `implicitHeight = show ? backgroundHeight : 0` from `onShowChanged` worked for direct-toggle but ghost-rendered under hidden-state instantiation (default `show: false` never emits `showChanged`, so implicitHeight stayed at content-derived value). Replaced with declarative `implicitHeight: root.show ? backgroundHeight : 0`. `backgroundHeight` default rebased to content directly to avoid self-referential binding.

Closes #3350 (the opacity-only patch I proposed there was unsound for exactly this reason).

Tested: NVIDIA RTX 4060, Hyprland on Wayland, 165Hz ext + 144Hz int. First open of each sidebar dialog and first hover of each bar popup are instant; no artifacts during the 2.5s preload window.

Opt-out: `sidebar.keepRightSidebarLoaded: false` / `bar.preloadPopups: false`.