### PR TITLE
fix(WindowDialog): bind implicitHeight declaratively to root.show

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
@@ -10,7 +10,7 @@ Rectangle {
 
     property bool show: false
     default property alias contentData: contentColumn.data
-    property real backgroundHeight: dialogBackground.implicitHeight
+    property real backgroundHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
     property real backgroundWidth: 350
     property real backgroundAnimationMovementDistance: 60
     
@@ -30,7 +30,6 @@ Rectangle {
 
     onShowChanged: {
         dialogBackgroundHeightAnimation.easing.bezierCurve = (show ? Appearance.animationCurves.emphasizedDecel : Appearance.animationCurves.emphasizedAccel)
-        dialogBackground.implicitHeight = show ? backgroundHeight : 0
     }
 
     radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
@@ -51,7 +50,7 @@ Rectangle {
         property real targetY: root.height / 2 - root.backgroundHeight / 2
         y: root.show ? targetY : (targetY - root.backgroundAnimationMovementDistance)
         implicitWidth: root.backgroundWidth
-        implicitHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
+        implicitHeight: root.show ? root.backgroundHeight : 0
         Behavior on implicitHeight {
             NumberAnimation {
                 id: dialogBackgroundHeightAnimation


### PR DESCRIPTION
## Problem

`WindowDialog` pairs the visibility guard

```qml
visible: dialogBackground.implicitHeight > 0
```

with an imperative size assignment inside `onShowChanged`:

```qml
onShowChanged: {
    ...
    dialogBackground.implicitHeight = show ? backgroundHeight : 0
}
```

That works for the direct-toggle path (a dialog goes from
`show: false` → `show: true`, the handler fires, `implicitHeight`
becomes `backgroundHeight`, `visible` becomes `true`).

It breaks for any path where the dialog is **instantiated** with the
default `show: false` and never goes through a `show` transition
before being expected to stay invisible — for example, when the
dialog is preloaded ahead of time, or constructed inside a `Loader`
that becomes active before its `show` is touched.

In that case `onShowChanged` never fires, `dialogBackground.implicitHeight`
keeps its content-derived value
(`contentColumn.implicitHeight + radius*2`), the `visible` guard
evaluates to `true`, and the dialog ghost-renders.

This is the same underlying issue that #3350 tried to paper over by
making the dialog `opacity: 0` instead of `visible: false` — but that
approach still kept the rectangle in the scene graph and still painted
the shadow under it. The right fix is to make the size binding
declarative, so it is always correct regardless of whether
`onShowChanged` ever fired.

## Change

- `dialogBackground.implicitHeight` is now bound declaratively to
  `root.show ? root.backgroundHeight : 0`.
- The imperative `dialogBackground.implicitHeight = ...` line is
  removed from `onShowChanged` (the easing-curve swap stays).
- `backgroundHeight` used to default to `dialogBackground.implicitHeight`,
  which would now be self-referential. It is rebased onto the content
  directly: `contentColumn.implicitHeight + dialogBackground.radius * 2`.
  This is the same value the old `implicitHeight` binding used, so
  open size is unchanged for all existing call sites.

The `Behavior on implicitHeight` animation continues to drive both
directions, so the open/close animation is unchanged in look and
duration.

## Diff

```diff
-    property real backgroundHeight: dialogBackground.implicitHeight
+    property real backgroundHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
...
     onShowChanged: {
         dialogBackgroundHeightAnimation.easing.bezierCurve = (show ? Appearance.animationCurves.emphasizedDecel : Appearance.animationCurves.emphasizedAccel)
-        dialogBackground.implicitHeight = show ? backgroundHeight : 0
     }
...
-        implicitHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
+        implicitHeight: root.show ? root.backgroundHeight : 0
```

## Closes / supersedes

Supersedes #3350. The opacity-only patch proposed there did not
address the root cause (`onShowChanged` never firing on default-false
instantiation); this PR does.

## Tested

NVIDIA RTX 4060, Hyprland on Wayland, 165 Hz + 144 Hz monitors.

- Direct open/close of every sidebar inner dialog
  (NightLight / Bluetooth / Wifi / Volume in / Volume out): animation
  identical to before, no size pop.
- A `WindowDialog` constructed with default `show: false` and never
  toggled now stays fully invisible (previously: ghost-rendered with
  content-derived height).