### PR TITLE
feat(bar, sidebarRight): preload bar popups and sidebar inner dialogs on idle

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -241,6 +241,7 @@ Singleton {
                 property bool showBackground: true
                 property bool verbose: true
                 property bool vertical: false
+                property bool preloadPopups: true // Idle-time eager load of bar popups so first hover is instant
                 property JsonObject resources: JsonObject {
                     property bool alwaysShowSwap: true
                     property bool alwaysShowCpu: true

--- a/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/WindowDialog.qml
@@ -10,7 +10,7 @@ Rectangle {
 
     property bool show: false
     default property alias contentData: contentColumn.data
-    property real backgroundHeight: dialogBackground.implicitHeight
+    property real backgroundHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
     property real backgroundWidth: 350
     property real backgroundAnimationMovementDistance: 60
     
@@ -30,7 +30,6 @@ Rectangle {
 
     onShowChanged: {
         dialogBackgroundHeightAnimation.easing.bezierCurve = (show ? Appearance.animationCurves.emphasizedDecel : Appearance.animationCurves.emphasizedAccel)
-        dialogBackground.implicitHeight = show ? backgroundHeight : 0
     }
 
     radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
@@ -51,7 +50,7 @@ Rectangle {
         property real targetY: root.height / 2 - root.backgroundHeight / 2
         y: root.show ? targetY : (targetY - root.backgroundAnimationMovementDistance)
         implicitWidth: root.backgroundWidth
-        implicitHeight: contentColumn.implicitHeight + dialogBackground.radius * 2
+        implicitHeight: root.show ? root.backgroundHeight : 0
         Behavior on implicitHeight {
             NumberAnimation {
                 id: dialogBackgroundHeightAnimation

--- a/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
@@ -12,12 +12,21 @@ LazyLoader {
     property Item hoverTarget
     default property Item contentItem
     property real popupBackgroundMargin: 0
+    property bool preloaded: false
 
-    active: hoverTarget && hoverTarget.containsMouse
+    Timer {
+        interval: 2500
+        running: !root.preloaded && (Config?.options?.bar?.preloadPopups ?? true)
+        repeat: false
+        onTriggered: root.preloaded = true
+    }
+
+    active: (hoverTarget && hoverTarget.containsMouse) || root.preloaded
 
     component: PanelWindow {
         id: popupWindow
         color: "transparent"
+        visible: root.hoverTarget && root.hoverTarget.containsMouse
 
         anchors.left: !Config.options.bar.vertical || (Config.options.bar.vertical && !Config.options.bar.bottom)
         anchors.right: Config.options.bar.vertical && Config.options.bar.bottom

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -28,6 +28,15 @@ Item {
     property bool showNightLightDialog: false
     property bool showWifiDialog: false
     property bool editMode: false
+    property bool dialogsPreloaded: false
+
+    Timer {
+        id: dialogsPreloadTimer
+        interval: 2500
+        running: Config?.options?.sidebar?.keepRightSidebarLoaded ?? false
+        repeat: false
+        onTriggered: root.dialogsPreloaded = true
+    }
 
     Connections {
         target: GlobalStates
@@ -160,10 +169,16 @@ Item {
         readonly property bool shown: root[shownPropertyString]
         anchors.fill: parent
 
-        onShownChanged: if (shown) toggleDialogLoader.active = true;
-        active: shown
+        active: shown || root.dialogsPreloaded
+        asynchronous: !shown
+        onShownChanged: {
+            if (shown && item) {
+                item.show = true;
+                item.forceActiveFocus();
+            }
+        }
         onActiveChanged: {
-            if (active) {
+            if (active && shown && item) {
                 item.show = true;
                 item.forceActiveFocus();
             }
@@ -175,7 +190,11 @@ Item {
                 root[toggleDialogLoader.shownPropertyString] = false;
             }
             function onVisibleChanged() {
-                if (!toggleDialogLoader.item.visible && !root[toggleDialogLoader.shownPropertyString]) toggleDialogLoader.active = false;
+                if (!toggleDialogLoader.item.visible
+                    && !root[toggleDialogLoader.shownPropertyString]
+                    && !root.dialogsPreloaded) {
+                    toggleDialogLoader.active = false;
+                }
             }
         }
     }


### PR DESCRIPTION
## Why

The first interaction with a bar popup (Resources / Battery / Clock /
Weather / SysTray) or a sidebar inner dialog (NightLight / Bluetooth /
Wifi / Volume in / Volume out) has a visible cost — the QML
component is inflated, the Wayland surface is mapped, and on NVIDIA
the scene graph pipeline is compiled on demand. The cost is paid
exactly when the user is waiting on a frame, which is the worst
possible time.

This PR makes both kinds of widget inflate themselves on an idle
timer after startup, so the first real interaction is instant.

> **Note**: builds on top of #3376. Without that fix, preloaded
> `WindowDialog` instances ghost-render (their `visible` guard
> `dialogBackground.implicitHeight > 0` evaluates to true on the
> content-derived implicit height when `onShowChanged` never fires).
> Please review #3376 first.

## Bar popups (`StyledPopup.qml`, `Config.qml`)

- New `bar.preloadPopups` config option, default `true` (so this is
  on by default but easy to turn off).
- New `preloaded` boolean on the `StyledPopup` `LazyLoader`.
- A non-repeating 2.5 s `Timer` flips `preloaded = true` once, gated
  on `Config?.options?.bar?.preloadPopups ?? true`.
- `LazyLoader.active` becomes
  `(hoverTarget && hoverTarget.containsMouse) || root.preloaded`, so
  the inner `PanelWindow` is realized in advance.
- `PanelWindow.visible` is bound to
  `root.hoverTarget && root.hoverTarget.containsMouse`. The window
  object and its scene graph exist during preload, but the Wayland
  surface is not mapped until the user hovers. Layout and input
  behavior are unchanged.

## Sidebar inner dialogs (`SidebarRightContent.qml`)

- New `dialogsPreloaded` boolean on the sidebar root.
- A non-repeating 2.5 s `Timer` flips it once, gated on the existing
  `sidebar.keepRightSidebarLoaded` option — no new flag, because the
  sidebar is already being kept around anyway when that option is on.
- The shared `ToggleDialog` `Loader` becomes
  `active: shown || root.dialogsPreloaded` with
  `asynchronous: !shown`. Background preload uses async loading so it
  does not block the UI thread; a real open path still loads
  synchronously so there is no animation hitch.
- The \"raise the dialog when it becomes shown\" call
  (`item.show = true; item.forceActiveFocus()`) is split between
  `onShownChanged` and `onActiveChanged` so it fires whether the
  dialog became active by being shown or was already active from
  preload and is being shown now.
- The visibility-teardown path in the inner `Connections` block
  additionally checks `!root.dialogsPreloaded`, so an idle preloaded
  dialog instance is not collapsed back to nothing.

## Cost

Memory cost is the inflated QML tree for those components on the
sidebar / bar instance. No additional Wayland surfaces are mapped
during preload (popups stay `visible: false`, dialogs stay
`show: false` and rely on #3376 to keep `implicitHeight` at 0).

## Why 2.5 s

The goal is \"after the shell is otherwise settled\". On the systems
I tested, 2.5 s comfortably clears the rest of the shell's
first-frame work without being long enough to lose the first
interaction race. Open to tuning if a maintainer has a preferred
value or wants this driven off an explicit idle signal instead of
wall-clock.

## Tested

NVIDIA RTX 4060, Hyprland on Wayland, 165 Hz + 144 Hz monitors.

- First open of each sidebar inner dialog after the 2.5 s window is
  instant. Subsequent opens unchanged.
- First hover of each bar popup after the 2.5 s window is instant.
  Subsequent hovers unchanged.
- During the 2.5 s preload window itself: no visible artifacts,
  sidebar / bar layout unchanged, no extra Wayland surfaces visible
  in `wayland-info` / compositor inspector.

## Limitations / open questions

- I only have NVIDIA hardware to test on. Intel and AMD users would
  pay the resident-RAM cost without as much of the latency benefit —
  the `bar.preloadPopups` flag and `sidebar.keepRightSidebarLoaded`
  gating let them opt out, but if the default should be flipped on
  non-NVIDIA, I'm open to that.
- 2.5 s is wall-clock. A `LazyLoader.activeAsync`-style idle signal
  would be cleaner; happy to switch if there is an obvious hook for
  it.