### PR TITLE
fix(mediaControls): YouTube cover fallback when player exposes no mpris:artUrl

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -295,4 +295,27 @@ Singleton {
             }
         );
     }
+
+    /**
+     * Returns a URL the cover-art downloader can fetch as artwork for a
+     * YouTube link, or "" if the URL is not from YouTube. Used as a fallback
+     * when the player exposes no mpris:artUrl (Firefox MPRIS bridge,
+     * plasma-browser-integration on YouTube Music).
+     *
+     * - Watch URL (?v=, youtu.be/, /embed/, /shorts/) → deterministic
+     *   i.ytimg.com/vi/<id>/hqdefault.jpg.
+     * - Playlist / channel / other YouTube URL → public oEmbed endpoint;
+     *   the downloader resolves its `thumbnail_url` field at fetch time.
+     *
+     * @param { string } url
+     * @returns { string }
+     */
+    function getYoutubeArtUrl(url) {
+        if (!url || !/(?:^|\/\/|\.)(?:youtube\.com|youtu\.be)/.test(url))
+            return "";
+        const m = url.match(/(?:[?&]v=|youtu\.be\/|\/(?:embed|shorts)\/)([A-Za-z0-9_-]{11})/);
+        if (m)
+            return `https://i.ytimg.com/vi/${m[1]}/hqdefault.jpg`;
+        return `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+    }
 }

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -15,39 +15,27 @@ import Quickshell.Services.Mpris
 Item { // Player instance
     id: root
     required property MprisPlayer player
-    // Some MPRIS players (Firefox via firefox-mpris, Spotify) emit empty
-    // trackArtUrl between/during tracks. MprisController persists the last
-    // non-empty value per player so we can fall back to it when the panel is
-    // (re)opened during an empty window.
-    property string artUrl: {
-        const cur = player?.trackArtUrl ?? "";
-        if (cur.length > 0) return cur;
-        const id = player?.uniqueId;
-        if (id === undefined) return "";
-        return MprisController.stableArtUrlByPlayer[id] ?? "";
-    }
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: artUrl.length > 0 ? `${artDownloadLocation}/${artFileName}` : ""
     property color artDominantColor: ColorUtils.mix((colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary), Appearance.colors.colPrimaryContainer, 0.8) || Appearance.m3colors.m3secondaryContainer
     property list<real> visualizerPoints: []
     property real maxVisualizerValue: 1000 // Max value in the data points
     property int visualizerSmoothing: 2 // Number of points to average for smoothing
     property real radius
 
-    // Only advances when a new file is confirmed on disk. Never clears, so the
-    // cover stays visible across track changes (transient empty trackArtUrl
-    // from Spotify/browsers) and panel close/reopen (cached file already on
-    // disk; previous design reset `downloaded` to false on every remount).
-    property string displayedArtFilePath: ""
-
-    // Track identity used to decide whether to reset best-quality tracking.
-    // Firefox emits multiple artUrls per song at different resolutions (e.g.,
-    // 544x544 followed by a 60x60 thumbnail); without this we'd swap to the
-    // smaller thumbnail and the cover would visibly degrade.
-    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}|${player?.trackAlbum ?? ""}`
-    property int _bestArtBytes: 0
-    on_TrackKeyChanged: { _bestArtBytes = 0; refreshArt(); }
+    // Cover art is downloaded centrally by MprisController (per-player Process
+    // that runs regardless of panel state), and tracked there as the
+    // highest-quality variant seen for each (player, track) pair. We just
+    // read that cache. This survives both:
+    //   - panel close/reopen (we weren't here to receive emissions; the
+    //     central downloader was)
+    //   - players that emit multiple sizes per track (Firefox: 544x544 then
+    //     60x60 thumbnail; Chromium: several near-identical tmp files) —
+    //     bestArtByPlayer keeps the largest.
+    // title|artist only; see MprisController._trackKeyOf for why album is omitted.
+    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`
+    readonly property string displayedArtFilePath: {
+        const entry = MprisController.getBestArt(player, _trackKey);
+        return entry ? Qt.resolvedUrl(entry.artFilePath) : "";
+    }
 
     component TrackChangeButton: RippleButton {
         implicitWidth: 24
@@ -77,68 +65,6 @@ Item { // Player instance
         repeat: true
         onTriggered: {
             root.player.positionChanged()
-        }
-    }
-
-    function refreshArt() {
-        if (root.artUrl.length === 0) return;
-        // Compute the path here rather than reading root.artFilePath: on
-        // onArtUrlChanged, QML may fire this handler before the chained
-        // artFilePath binding re-evaluates, giving us a stale (often empty)
-        // path. Deriving from artUrl directly avoids that race.
-        const path = `${root.artDownloadLocation}/${Qt.md5(root.artUrl)}`;
-        coverArtDownloader.targetFile = root.artUrl;
-        coverArtDownloader.artFilePath = path;
-        coverArtDownloader.running = true;
-    }
-
-    // Trigger on artUrl change AND on (re)mount, so a cached file on disk
-    // surfaces immediately when the panel is reopened. On mount we also
-    // consult MprisController's per-player best-art cache so reopening the
-    // panel doesn't downgrade to a thumbnail when the current trackArtUrl
-    // points at a low-res variant the player emitted later (Firefox).
-    Component.onCompleted: {
-        const best = MprisController.getBestArt(root.player, root._trackKey);
-        if (best) {
-            root._bestArtBytes = best.artBytes;
-            root.displayedArtFilePath = Qt.resolvedUrl(best.artFilePath);
-        }
-        refreshArt();
-    }
-    onArtUrlChanged: refreshArt()
-
-    Process { // Cover art downloader. Emits the file size on stdout so we can
-              // pick the highest-quality variant when a player advertises
-              // multiple sizes for one track (Firefox does this).
-        id: coverArtDownloader
-        property string targetFile
-        property string artFilePath
-        property int sizeBytes: 0
-        stdout: SplitParser {
-            onRead: data => {
-                const n = parseInt(data.trim());
-                if (!isNaN(n)) coverArtDownloader.sizeBytes = n;
-            }
-        }
-        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null` ]
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0 || artFilePath.length === 0 || sizeBytes <= 0) return;
-            // Never downgrade or rerun-flicker: only swap when the new file is
-            // strictly larger than the best we've seen for this track.
-            // _trackKey changes reset _bestArtBytes to 0 so a new track always
-            // accepts the first hit. Strict > also rejects same-size
-            // re-emissions (Chromium emits several near-identical tmp files
-            // per track) which would otherwise cause StyledImage opacity flicker.
-            if (sizeBytes <= root._bestArtBytes) return;
-            root._bestArtBytes = sizeBytes;
-            const url = Qt.resolvedUrl(artFilePath);
-            if (root.displayedArtFilePath.toString() !== url.toString()) {
-                root.displayedArtFilePath = url;
-            }
-            // Persist into MprisController so a panel close/reopen on the same
-            // track can restore this best variant directly, bypassing whatever
-            // (possibly lower-res) URL the player is currently advertising.
-            MprisController.rememberBestArt(root.player, root._trackKey, artFilePath, sizeBytes);
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -30,8 +30,30 @@ Item { // Player instance
     //   - players that emit multiple sizes per track (Firefox: 544x544 then
     //     60x60 thumbnail; Chromium: several near-identical tmp files) —
     //     bestArtByPlayer keeps the largest.
+    // Cache the last non-empty trackTitle/trackArtist. Some players
+    // (pear-desktop / youtube-music) clear metadata briefly during a track
+    // change before emitting the new track's values; binding the UI
+    // directly to player.trackTitle would make the title flash to
+    // "Untitled" mid-skip and would also invalidate the trackKey, dropping
+    // the cover image.
+    property string _stableTitle: ""
+    property string _stableArtist: ""
+    Connections {
+        target: root.player
+        function onTrackTitleChanged() {
+            if (root.player?.trackTitle) root._stableTitle = root.player.trackTitle;
+        }
+        function onTrackArtistChanged() {
+            if (root.player?.trackArtist) root._stableArtist = root.player.trackArtist;
+        }
+    }
+    Component.onCompleted: {
+        if (root.player?.trackTitle) _stableTitle = root.player.trackTitle;
+        if (root.player?.trackArtist) _stableArtist = root.player.trackArtist;
+    }
+
     // title|artist only; see MprisController._trackKeyOf for why album is omitted.
-    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`
+    readonly property string _trackKey: `${_stableTitle}|${_stableArtist}`
     readonly property string displayedArtFilePath: {
         const entry = MprisController.getBestArt(player, _trackKey);
         return entry ? Qt.resolvedUrl(entry.artFilePath) : "";
@@ -175,7 +197,7 @@ Item { // Player instance
                     font.pixelSize: Appearance.font.pixelSize.large
                     color: blendedColors.colOnLayer0
                     elide: Text.ElideRight
-                    text: StringUtils.cleanMusicTitle(root.player?.trackTitle) || "Untitled"
+                    text: StringUtils.cleanMusicTitle(root._stableTitle) || "Untitled"
                     animateChange: true
                     animationDistanceX: 6
                     animationDistanceY: 0
@@ -186,7 +208,7 @@ Item { // Player instance
                     font.pixelSize: Appearance.font.pixelSize.smaller
                     color: blendedColors.colSubtext
                     elide: Text.ElideRight
-                    text: root.player?.trackArtist
+                    text: root._stableArtist
                     animateChange: true
                     animationDistanceX: 6
                     animationDistanceY: 0

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -15,18 +15,39 @@ import Quickshell.Services.Mpris
 Item { // Player instance
     id: root
     required property MprisPlayer player
-    property var artUrl: player?.trackArtUrl
+    // Some MPRIS players (Firefox via firefox-mpris, Spotify) emit empty
+    // trackArtUrl between/during tracks. MprisController persists the last
+    // non-empty value per player so we can fall back to it when the panel is
+    // (re)opened during an empty window.
+    property string artUrl: {
+        const cur = player?.trackArtUrl ?? "";
+        if (cur.length > 0) return cur;
+        const id = player?.uniqueId;
+        if (id === undefined) return "";
+        return MprisController.stableArtUrlByPlayer[id] ?? "";
+    }
     property string artDownloadLocation: Directories.coverArt
     property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: `${artDownloadLocation}/${artFileName}`
+    property string artFilePath: artUrl.length > 0 ? `${artDownloadLocation}/${artFileName}` : ""
     property color artDominantColor: ColorUtils.mix((colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary), Appearance.colors.colPrimaryContainer, 0.8) || Appearance.m3colors.m3secondaryContainer
-    property bool downloaded: false
     property list<real> visualizerPoints: []
     property real maxVisualizerValue: 1000 // Max value in the data points
     property int visualizerSmoothing: 2 // Number of points to average for smoothing
     property real radius
 
-    property string displayedArtFilePath: root.downloaded ? Qt.resolvedUrl(artFilePath) : ""
+    // Only advances when a new file is confirmed on disk. Never clears, so the
+    // cover stays visible across track changes (transient empty trackArtUrl
+    // from Spotify/browsers) and panel close/reopen (cached file already on
+    // disk; previous design reset `downloaded` to false on every remount).
+    property string displayedArtFilePath: ""
+
+    // Track identity used to decide whether to reset best-quality tracking.
+    // Firefox emits multiple artUrls per song at different resolutions (e.g.,
+    // 544x544 followed by a 60x60 thumbnail); without this we'd swap to the
+    // smaller thumbnail and the cover would visibly degrade.
+    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}|${player?.trackAlbum ?? ""}`
+    property int _bestArtBytes: 0
+    on_TrackKeyChanged: { _bestArtBytes = 0; refreshArt(); }
 
     component TrackChangeButton: RippleButton {
         implicitWidth: 24
@@ -59,27 +80,65 @@ Item { // Player instance
         }
     }
 
-    onArtFilePathChanged: {
-        if (root.artUrl.length == 0) {
-            root.artDominantColor = Appearance.m3colors.m3secondaryContainer
-            return;
-        }
-
-        // Binding does not work in Process
-        coverArtDownloader.targetFile = root.artUrl 
-        coverArtDownloader.artFilePath = root.artFilePath
-        // Download
-        root.downloaded = false
-        coverArtDownloader.running = true
+    function refreshArt() {
+        if (root.artUrl.length === 0) return;
+        // Compute the path here rather than reading root.artFilePath: on
+        // onArtUrlChanged, QML may fire this handler before the chained
+        // artFilePath binding re-evaluates, giving us a stale (often empty)
+        // path. Deriving from artUrl directly avoids that race.
+        const path = `${root.artDownloadLocation}/${Qt.md5(root.artUrl)}`;
+        coverArtDownloader.targetFile = root.artUrl;
+        coverArtDownloader.artFilePath = path;
+        coverArtDownloader.running = true;
     }
 
-    Process { // Cover art downloader
+    // Trigger on artUrl change AND on (re)mount, so a cached file on disk
+    // surfaces immediately when the panel is reopened. On mount we also
+    // consult MprisController's per-player best-art cache so reopening the
+    // panel doesn't downgrade to a thumbnail when the current trackArtUrl
+    // points at a low-res variant the player emitted later (Firefox).
+    Component.onCompleted: {
+        const best = MprisController.getBestArt(root.player, root._trackKey);
+        if (best) {
+            root._bestArtBytes = best.artBytes;
+            root.displayedArtFilePath = Qt.resolvedUrl(best.artFilePath);
+        }
+        refreshArt();
+    }
+    onArtUrlChanged: refreshArt()
+
+    Process { // Cover art downloader. Emits the file size on stdout so we can
+              // pick the highest-quality variant when a player advertises
+              // multiple sizes for one track (Firefox does this).
         id: coverArtDownloader
-        property string targetFile: root.artUrl
-        property string artFilePath: root.artFilePath
-        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'` ]
+        property string targetFile
+        property string artFilePath
+        property int sizeBytes: 0
+        stdout: SplitParser {
+            onRead: data => {
+                const n = parseInt(data.trim());
+                if (!isNaN(n)) coverArtDownloader.sizeBytes = n;
+            }
+        }
+        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null` ]
         onExited: (exitCode, exitStatus) => {
-            root.downloaded = true
+            if (exitCode !== 0 || artFilePath.length === 0 || sizeBytes <= 0) return;
+            // Never downgrade or rerun-flicker: only swap when the new file is
+            // strictly larger than the best we've seen for this track.
+            // _trackKey changes reset _bestArtBytes to 0 so a new track always
+            // accepts the first hit. Strict > also rejects same-size
+            // re-emissions (Chromium emits several near-identical tmp files
+            // per track) which would otherwise cause StyledImage opacity flicker.
+            if (sizeBytes <= root._bestArtBytes) return;
+            root._bestArtBytes = sizeBytes;
+            const url = Qt.resolvedUrl(artFilePath);
+            if (root.displayedArtFilePath.toString() !== url.toString()) {
+                root.displayedArtFilePath = url;
+            }
+            // Persist into MprisController so a panel close/reopen on the same
+            // track can restore this best variant directly, bypassing whatever
+            // (possibly lower-res) URL the player is currently advertising.
+            MprisController.rememberBestArt(root.player, root._trackKey, artFilePath, sizeBytes);
         }
     }
 

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -41,6 +41,47 @@ Singleton {
             !(player.dbusName?.endsWith('.mpd') && !player.dbusName.endsWith('MediaPlayer2.mpd')));
     }
 
+	// Last non-empty trackArtUrl seen per player (keyed by uniqueId). Some
+	// MPRIS players (Firefox via firefox-mpris, Spotify) emit transient empty
+	// trackArtUrl between/during tracks. Consumers like PlayerControl that get
+	// recreated on panel open/close need a stable fallback so the cover
+	// doesn't vanish whenever they happen to mount during an empty window.
+	property var stableArtUrlByPlayer: ({})
+
+	function _captureArtUrl(player) {
+		if (player?.trackArtUrl?.length > 0 && player?.uniqueId !== undefined) {
+			const map = Object.assign({}, root.stableArtUrlByPlayer);
+			map[player.uniqueId] = player.trackArtUrl;
+			root.stableArtUrlByPlayer = map;
+		}
+	}
+
+	// Best (largest) downloaded cover file seen per player for the current
+	// track, keyed by uniqueId. Persists across PlayerControl lifecycles so
+	// reopening the panel doesn't downgrade to a thumbnail when Firefox
+	// happens to be sitting on its low-res variant. Entry shape:
+	//   { trackKey: string, artFilePath: string, artBytes: number }
+	property var bestArtByPlayer: ({})
+
+	function rememberBestArt(player, trackKey, artFilePath, artBytes) {
+		const id = player?.uniqueId;
+		if (id === undefined || artBytes <= 0 || !artFilePath) return;
+		const existing = root.bestArtByPlayer[id];
+		// Same track and existing is already >= new size: nothing to do.
+		if (existing && existing.trackKey === trackKey && existing.artBytes >= artBytes) return;
+		const map = Object.assign({}, root.bestArtByPlayer);
+		map[id] = { trackKey: trackKey, artFilePath: artFilePath, artBytes: artBytes };
+		root.bestArtByPlayer = map;
+	}
+
+	function getBestArt(player, trackKey) {
+		const id = player?.uniqueId;
+		if (id === undefined) return null;
+		const entry = root.bestArtByPlayer[id];
+		if (!entry || entry.trackKey !== trackKey) return null;
+		return entry;
+	}
+
 	// Original stuff from fox below
 	Instantiator {
 		model: Mpris.players;
@@ -53,6 +94,7 @@ Singleton {
 				if (root.trackedPlayer == null || modelData.isPlaying) {
 					root.trackedPlayer = modelData;
 				}
+				root._captureArtUrl(modelData);
 			}
 
 			Component.onDestruction: {
@@ -72,6 +114,10 @@ Singleton {
 
 			function onPlaybackStateChanged() {
 				if (root.trackedPlayer !== modelData) root.trackedPlayer = modelData;
+			}
+
+			function onTrackArtUrlChanged() {
+				root._captureArtUrl(modelData);
 			}
 		}
 	}

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -41,31 +41,35 @@ Singleton {
             !(player.dbusName?.endsWith('.mpd') && !player.dbusName.endsWith('MediaPlayer2.mpd')));
     }
 
-	// Last non-empty trackArtUrl seen per player (keyed by uniqueId). Some
+	// Last non-empty trackArtUrl seen per player (keyed by dbusName). Some
 	// MPRIS players (Firefox via firefox-mpris, Spotify) emit transient empty
 	// trackArtUrl between/during tracks. Consumers like PlayerControl that get
 	// recreated on panel open/close need a stable fallback so the cover
 	// doesn't vanish whenever they happen to mount during an empty window.
+	// dbusName is the right key here: MprisPlayer.uniqueId in Quickshell is a
+	// per-track identifier (it increments when the track changes), not a
+	// per-player one, so keying on it cross-contaminates between players that
+	// happen to share a uniqueId value.
 	property var stableArtUrlByPlayer: ({})
 
 	function _captureArtUrl(player) {
-		if (player?.trackArtUrl?.length > 0 && player?.uniqueId !== undefined) {
+		if (player?.trackArtUrl?.length > 0 && !!player?.dbusName) {
 			const map = Object.assign({}, root.stableArtUrlByPlayer);
-			map[player.uniqueId] = player.trackArtUrl;
+			map[player.dbusName] = player.trackArtUrl;
 			root.stableArtUrlByPlayer = map;
 		}
 	}
 
 	// Best (largest) downloaded cover file seen per player for the current
-	// track, keyed by uniqueId. Persists across PlayerControl lifecycles so
+	// track, keyed by dbusName. Persists across PlayerControl lifecycles so
 	// reopening the panel doesn't downgrade to a thumbnail when Firefox
 	// happens to be sitting on its low-res variant. Entry shape:
 	//   { trackKey: string, artFilePath: string, artBytes: number }
 	property var bestArtByPlayer: ({})
 
 	function rememberBestArt(player, trackKey, artFilePath, artBytes) {
-		const id = player?.uniqueId;
-		if (id === undefined || artBytes <= 0 || !artFilePath) return;
+		const id = player?.dbusName;
+		if (!id || artBytes <= 0 || !artFilePath) return;
 		const existing = root.bestArtByPlayer[id];
 		// Same track and existing is already >= new size: nothing to do.
 		if (existing && existing.trackKey === trackKey && existing.artBytes >= artBytes) return;
@@ -75,50 +79,99 @@ Singleton {
 	}
 
 	function getBestArt(player, trackKey) {
-		const id = player?.uniqueId;
-		if (id === undefined) return null;
+		const id = player?.dbusName;
+		if (!id) return null;
 		const entry = root.bestArtByPlayer[id];
 		if (!entry || entry.trackKey !== trackKey) return null;
 		return entry;
 	}
 
-	// Original stuff from fox below
-	Instantiator {
-		model: Mpris.players;
+	function _trackKeyOf(player) {
+		// title|artist (album omitted on purpose). Some players (Firefox via
+		// firefox-mpris) emit metadata progressively: first trackArtUrl +
+		// title + artist with album="", then a moment later update album.
+		// If album were part of the key, the high-res variant emitted with
+		// the partial metadata and the low-res variant emitted with the
+		// completed metadata would look like different tracks to the
+		// "never-downgrade" guard.
+		return `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`;
+	}
 
-		Connections {
-			required property MprisPlayer modelData;
-			target: modelData;
+	// Per-player worker. Holds a Process that downloads each new trackArtUrl
+	// the player emits, regardless of whether the media controls panel is
+	// open. This is what makes the cover stay sharp across panel
+	// close/reopen and across auto-advance while the panel is closed —
+	// PlayerControl is no longer the only thing watching for art emissions.
+	component PlayerWorker: QtObject {
+		id: worker
+		required property MprisPlayer player
 
-			Component.onCompleted: {
-				if (root.trackedPlayer == null || modelData.isPlaying) {
-					root.trackedPlayer = modelData;
+		function _fetchArt() {
+			const url = worker.player?.trackArtUrl;
+			if (!url || url.length === 0) return;
+			artDownloader.trackKey = root._trackKeyOf(worker.player);
+			artDownloader.targetFile = url;
+			artDownloader.artFilePath = `${Directories.coverArt}/${Qt.md5(url)}`;
+			artDownloader.running = true;
+		}
+
+		property Process artDownloader: Process {
+			property string trackKey
+			property string targetFile
+			property string artFilePath
+			property int sizeBytes: 0
+			stdout: SplitParser {
+				onRead: data => {
+					const n = parseInt(data.trim());
+					if (!isNaN(n)) artDownloader.sizeBytes = n;
 				}
-				root._captureArtUrl(modelData);
 			}
-
-			Component.onDestruction: {
-				if (root.trackedPlayer == null || !root.trackedPlayer.isPlaying) {
-					for (const player of Mpris.players.values) {
-						if (player.playbackState.isPlaying) {
-							root.trackedPlayer = player;
-							break;
-						}
-					}
-
-					if (trackedPlayer == null && Mpris.players.values.length != 0) {
-						trackedPlayer = Mpris.players.values[0];
-					}
-				}
+			command: ["bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null`]
+			onExited: (exitCode, exitStatus) => {
+				if (exitCode !== 0 || sizeBytes <= 0 || artFilePath.length === 0) return;
+				root.rememberBestArt(worker.player, trackKey, artFilePath, sizeBytes);
 			}
+		}
 
+		property Connections _conn: Connections {
+			target: worker.player
 			function onPlaybackStateChanged() {
-				if (root.trackedPlayer !== modelData) root.trackedPlayer = modelData;
+				if (root.trackedPlayer !== worker.player) root.trackedPlayer = worker.player;
 			}
-
 			function onTrackArtUrlChanged() {
-				root._captureArtUrl(modelData);
+				root._captureArtUrl(worker.player);
+				worker._fetchArt();
 			}
+		}
+
+		Component.onCompleted: {
+			if (root.trackedPlayer == null || worker.player.isPlaying) {
+				root.trackedPlayer = worker.player;
+			}
+			root._captureArtUrl(worker.player);
+			worker._fetchArt();
+		}
+
+		Component.onDestruction: {
+			if (root.trackedPlayer == null || !root.trackedPlayer.isPlaying) {
+				for (const p of Mpris.players.values) {
+					if (p.playbackState.isPlaying) {
+						root.trackedPlayer = p;
+						break;
+					}
+				}
+				if (root.trackedPlayer == null && Mpris.players.values.length != 0) {
+					root.trackedPlayer = Mpris.players.values[0];
+				}
+			}
+		}
+	}
+
+	Instantiator {
+		model: Mpris.players
+		delegate: PlayerWorker {
+			required property MprisPlayer modelData
+			player: modelData
 		}
 	}
 

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -107,7 +107,9 @@ Singleton {
 		required property MprisPlayer player
 
 		function _fetchArt() {
-			const url = worker.player?.trackArtUrl;
+			let url = worker.player?.trackArtUrl;
+			if (!url || url.length === 0)
+				url = StringUtils.getYoutubeArtUrl(worker.player?.metadata?.["xesam:url"] ?? "");
 			if (!url || url.length === 0) return;
 			artDownloader.trackKey = root._trackKeyOf(worker.player);
 			artDownloader.targetFile = url;
@@ -126,7 +128,15 @@ Singleton {
 					if (!isNaN(n)) artDownloader.sizeBytes = n;
 				}
 			}
-			command: ["bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null`]
+			command: ["bash", "-c", `
+				out=$1; url=$2
+				[ -f "$out" ] && { stat -c %s "$out" 2>/dev/null; exit 0; }
+				case "$url" in *"/oembed?"*)
+					url=$(curl -4 -fsSL "$url" | sed -n 's/.*"thumbnail_url":"\\([^"]*\\)".*/\\1/p') ;;
+				esac
+				[ -n "$url" ] && curl -4 -fsSL "$url" -o "$out"
+				stat -c %s "$out" 2>/dev/null
+			`, "qs-coverart", artFilePath, targetFile]
 			onExited: (exitCode, exitStatus) => {
 				if (exitCode !== 0 || sizeBytes <= 0 || artFilePath.length === 0) return;
 				root.rememberBestArt(worker.player, trackKey, artFilePath, sizeBytes);


### PR DESCRIPTION
## Symptom

When music is played in a browser tab (typical case: YouTube Music in Firefox or any Firefox-derived browser such as Zen, LibreWolf, Floorp), the media-controls popup shows correct title / artist / progress, but the cover-art slot stays empty and falls back to the placeholder square.

## Root cause

The empty slot is **not** an end-4 / Quickshell layout bug — it is missing upstream metadata. `PlayerControl.artUrl` binds straight to `MprisPlayer.trackArtUrl`, which is read from the standard `mpris:artUrl` MPRIS2 dict key. Two of the most common browser-side MPRIS sources never publish that key for YT Music:

1. **Firefox built-in MPRIS bridge** (`org.mpris.MediaPlayer2.firefox.instance_*`)
   only exposes a minimal set of fields (`xesam:title`, `xesam:url`, `mpris:length`, …). The MediaSession `artwork` array is not forwarded to D-Bus.

2. **plasma-browser-integration** (`org.mpris.MediaPlayer2.plasma-browser-integration`)
   does forward MediaSession metadata for many sites, but for YouTube Music in particular the `mpris:artUrl` key is simply absent from the metadata dict.

D-Bus snapshot during playback (one tab, two MPRIS proxies, **neither** has `mpris:artUrl`):

```
$ qdbus6 org.mpris.MediaPlayer2.firefox.instance_1_42 \
        /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2.Player.Metadata
mpris:length: 124000000
xesam:title:  SXPRA DRIFT | YouTube Music
xesam:url:    https://music.youtube.com/watch?v=MJJcY7uGFvw&list=...

$ qdbus6 org.mpris.MediaPlayer2.plasma-browser-integration \
        /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2.Player.Metadata
xesam:album:  SXPRA DRIFT
xesam:artist: blueberry
xesam:title:  SXPRA DRIFT
xesam:url:    https://music.youtube.com/watch?v=MJJcY7uGFvw&list=...
```

With `trackArtUrl == ""`, `coverArtDownloader` is invoked with an empty `targetFile`, so nothing is fetched and `displayedArtFilePath` stays empty.

## Fix

A narrow, opt-in fallback inside `PlayerControl.artUrl`: if the player publishes a non-empty `trackArtUrl`, use it (current behaviour, untouched). Only when it is empty AND `metadata["xesam:url"]` points at a YouTube URL, synthesize a cover URL via a new `StringUtils.getYoutubeArtUrl(url)` helper, and let the existing `coverArtDownloader` pipeline handle caching.

Two cases:

1. **Watch URL** (`?v=`, `youtu.be/`, `/embed/`, `/shorts/`) → return the deterministic thumbnail URL `https://i.ytimg.com/vi/<videoId>/hqdefault.jpg`. No API key, no scraping, no extra dependency. `hqdefault.jpg` is chosen because it is guaranteed to exist for every public video (unlike `maxresdefault.jpg`, which 404s for many uploads).

2. **Playlist / channel / other YouTube URL without a video id** (e.g. YT Music album auto-playlists `OLAK5uy_*`) → return YouTube's public oEmbed endpoint `https://www.youtube.com/oembed?url=<encoded>&format=json`. The downloader detects `/oembed?` in the URL, extracts the JSON `thumbnail_url` field with `sed`, and downloads the image. No new dependencies — `curl` + `sed` are already available everywhere.

## Why it cannot regress other players

The fallback is gated by `direct.length > 0`. Every player that already exports `mpris:artUrl` — Spotify desktop (`file:///tmp/...`), Spotify Web via plasma-browser-integration, Tidal, Deezer, mpv, VLC, any site that calls `MediaSession.setMetadata({artwork:[...]})` — takes the original code path and is not touched.

When `trackArtUrl` is empty AND the URL is **not** YouTube, `getYoutubeArtUrl` returns `""`, so the resulting `artUrl` is `""` — identical to today's behaviour for SoundCloud / Bandcamp / etc. with no MediaSession artwork.

| URL                                          | Result          |
|----------------------------------------------|-----------------|
| `https://music.youtube.com/watch?v=MJJ…`     | `…/MJJ…/hqdefault.jpg` |
| `https://www.youtube.com/watch?v=dQw…`       | `…/dQw…/hqdefault.jpg` |
| `https://youtu.be/dQw…?t=42`                 | `…/dQw…/hqdefault.jpg` |
| `https://www.youtube.com/embed/dQw…`         | `…/dQw…/hqdefault.jpg` |
| `https://www.youtube.com/shorts/AbCdEfGhIjK` | `…/AbCdE…/hqdefault.jpg` |
| `https://music.youtube.com/playlist?list=OLAK5uy_*` | oEmbed → resolved thumb |
| `https://soundcloud.com/foo`                 | `""` (host check)       |
| `https://example.com/?v=dQw4w9WgXcQ`         | `""` (host check)       |

## Downloader script: positional parameters

While `coverArtDownloader` was being touched, the script form is also adjusted. Before:

```qml
command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'` ]
```

After:

```qml
command: [
    "bash", "-c", `
        out=$1
        url=$2
        if [ -z "$url" ] || [ -f "$out" ]; then exit 0; fi
        case "$url" in *"/oembed?"*)
            url=$(curl -4 -fsSL "$url" | sed -n 's/.*"thumbnail_url":"\\([^"]*\\)".*/\\1/p') ;;
        esac
        if [ -n "$url" ]; then curl -4 -fsSL "$url" -o "$out"; fi
    `,
    "qs-coverart", artFilePath, targetFile
]
```

The path and URL are passed as positional parameters (`$1`, `$2`) rather than substituted into the script string. Inside the script the values are referenced as `"$1"` and `"$2"`. This is the canonical `bash -c '<script>' name arg1 arg2` form (see `bash` synopsis: `bash [...] -c STRING [ARGUMENT ...]`).

How the two forms compare for representative `targetFile` values that an MPRIS player on the session bus might set:

| Example `targetFile`                          | Old script behaviour     | This branch |
|-----------------------------------------------|--------------------------|-------------|
| `https://i.scdn.co/image/abc` (typical)       | works                    | works       |
| `file:///tmp/cover with spaces.jpg`           | word-split mid-token     | literal     |
| `https://example.com/img?key='abc'`           | breaks out of `'…'`      | literal     |
| `file:///tmp/foo$(whoami).jpg`                | `$(…)` expanded by shell | literal     |

`trackArtUrl` is set by whichever MPRIS player is currently on the session bus, so being explicit about how the downloader script consumes it felt worth doing here.

## Closes / supersedes

Supersedes #3265. Same YouTube fallback behaviour; downloader script form adjusted as above.

## Known limitation

Private playlists (Liked Music `list=LM`, Watch Later `list=WL`) cannot be resolved through public oEmbed — YouTube returns 404 because the artwork lives behind authenticated requests. Those keep the placeholder, same as today. Single tracks and public playlists are covered.

## Test plan

- [x] Smoke-tested in Quickshell 0.2.1 / Qt 6.11 with two real MPRIS sources (`firefox.instance_*` and `plasma-browser-integration`).
- [x] Cover-art file actually fetched — `~/.cache/quickshell/media/coverart/<md5>` materialized as a 480×360 JPEG, `<md5>` matching `md5("https://i.ytimg.com/vi/<id>/hqdefault.jpg")` for watch URLs and the resolved oEmbed thumbnail for playlists.
- [x] Other (non-YouTube) MPRIS sources keep their existing behaviour because the fallback short-circuits on a non-empty `trackArtUrl`.
- [x] Downloader script: dry-run with each row of the comparison table above as `targetFile`; in the new form every value reaches `curl` as a single literal argument.
