### PR TITLE
Restore nwg-displays entry

### DIFF
--- a/dots/.config/hypr/hyprland.lua
+++ b/dots/.config/hypr/hyprland.lua
@@ -8,7 +8,7 @@ require("hyprland.services")
 -- Environment variables --
 require("hyprland.env")
 if is_file_exists(HOME .. "/.config/hypr/custom/env.lua") then
-    require("custom.env")
+	require("custom.env")
 end
 
 -- Default configurations --
@@ -20,21 +20,21 @@ require("hyprland.keybinds")
 
 -- Custom configurations --
 if is_file_exists(HOME .. "/.config/hypr/custom/execs.lua") then
-    require("custom.execs")
+	require("custom.execs")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/general.lua") then
-    require("custom.general")
+	require("custom.general")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/rules.lua") then
-    require("custom.rules")
+	require("custom.rules")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/keybinds.lua") then
-    require("custom.keybinds")
+	require("custom.keybinds")
 end
 
--- nwg-displays support: re-add the files if it updates later
--- require("workspaces")
--- require("monitors")
+-- nwg-displays support --
+require("workspaces")
+require("monitors")
 
 -- Shell overrides --
 require("hyprland.shellOverrides.main")

--- a/dots/.config/hypr/hyprland.lua
+++ b/dots/.config/hypr/hyprland.lua
@@ -33,8 +33,12 @@ if is_file_exists(HOME .. "/.config/hypr/custom/keybinds.lua") then
 end
 
 -- nwg-displays support --
-require("workspaces")
-require("monitors")
+if is_file_exists(HOME .. "/.config/hypr/workspaces.lua") then
+    require("workspaces")
+end
+if is_file_exists(HOME .. "/.config/hypr/monitors.lua") then
+    require("monitors")
+end
 
 -- Shell overrides --
 require("hyprland.shellOverrides.main")

--- a/dots/.config/hypr/hyprland.lua
+++ b/dots/.config/hypr/hyprland.lua
@@ -8,7 +8,7 @@ require("hyprland.services")
 -- Environment variables --
 require("hyprland.env")
 if is_file_exists(HOME .. "/.config/hypr/custom/env.lua") then
-	require("custom.env")
+    require("custom.env")
 end
 
 -- Default configurations --
@@ -20,16 +20,16 @@ require("hyprland.keybinds")
 
 -- Custom configurations --
 if is_file_exists(HOME .. "/.config/hypr/custom/execs.lua") then
-	require("custom.execs")
+    require("custom.execs")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/general.lua") then
-	require("custom.general")
+    require("custom.general")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/rules.lua") then
-	require("custom.rules")
+    require("custom.rules")
 end
 if is_file_exists(HOME .. "/.config/hypr/custom/keybinds.lua") then
-	require("custom.keybinds")
+    require("custom.keybinds")
 end
 
 -- nwg-displays support --


### PR DESCRIPTION
## Describe your changes

The 0.4.3 update of nwg-displays now creates config files in both lua and hyprlang, so now we can bring back the entries in the main config.

