### PR TITLE
Fix screen corners only appearing on integrated monitor

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/screenCorners/ScreenCorners.qml
+++ b/dots/.config/quickshell/ii/modules/ii/screenCorners/ScreenCorners.qml
@@ -21,7 +21,6 @@ Scope {
 
     component CornerPanelWindow: PanelWindow {
         id: cornerPanelWindow
-        property var screen: QsWindow.window?.screen
         property var brightnessMonitor: Brightness.getMonitorForScreen(screen)
         property bool fullscreen
         visible: (Config.options.appearance.fakeScreenRounding === 1 || (Config.options.appearance.fakeScreenRounding === 2 && !fullscreen))


### PR DESCRIPTION
## Problem
- The fake rounded screen corners effect (quickshell:screenCorners) only appeared on the integrated monitor. External monitors showed no corner overlays.
- Scrolling on corner regions of external monitors adjusted brightness/volume for the wrong monitor (always the integrated one).
## Root cause
`CornerPanelWindow` in `ScreenCorners.qml` declared `property var screen: QsWindow.window?.screen`,
which shadowed `PanelWindow`'s built-in `screen` property. When the `Variants` delegate assigned
`screen: modelData`, it set the shadowed local property instead of the actual monitor target,
so all corner windows defaulted to the primary display. Since `brightnessMonitor` was also
computed from the shadowed `screen`, it always resolved to the integrated monitor regardless
of which display the corner overlay was on.
## Fix
Remove the shadowing `property var screen` declaration. This allows `screen: modelData` to
correctly target `PanelWindow.screen`, placing each corner overlay on its respective monitor.
`brightnessMonitor` now also reads from the real monitor, fixing per-monitor brightness control.
## Testing
- Verified corner overlays appear on all connected monitors
- Verified fullscreen-hide behavior still works per-monitor
- Verified sidebar corner-open interactions still function
- Verified brightness/volume scroll on corner regions affects the correct monitor