### PR TITLE
fix(qs): NotificationItem polish() loop on Qt 6.11 — freezes sidebar

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationItem.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationItem.qml
@@ -153,7 +153,7 @@ Item { // Notification item area
                 implicitHeight: summaryText.implicitHeight
                 StyledText {
                     id: summaryText
-                    Layout.fillWidth: summaryTextMetrics.width >= summaryRow.implicitWidth * root.summaryElideRatio
+                    Layout.fillWidth: summaryTextMetrics.width >= root.width * root.summaryElideRatio
                     visible: !root.onlyNotification
                     font.pixelSize: root.fontSize
                     color: Appearance.colors.colOnLayer3


### PR DESCRIPTION
## Describe your changes

### TL;DR
Fixes a circular property dependency in `NotificationItem.qml` that causes a `ColumnLayout::polish()` loop on Qt 6.11.1, pinning the CPU at 100% and freezing the sidebar whenever a notification is rendered.

### Symptom
After upgrading to Qt 6.11.1, opening the right sidebar (which contains the notification list) freezes Quickshell — the bar, sidebar, and dependent components become unresponsive for tens of seconds; in severe cases the whole Hyprland session crashes back to the display manager.

The Quickshell log fills with thousands of repeated warnings, all pointing at the same QML location:

```
QML ColumnLayout at @modules/common/widgets/NotificationItem.qml[139:9]: possible QQuickItem::polish() loop
QML ColumnLayout at @modules/common/widgets/NotificationItem.qml[139:9]: ColumnLayout called polish() inside updatePolish() of ColumnLayout
```

### Root cause

`NotificationItem.qml` line 156 binds the elision behaviour of `summaryText` to a property of its own parent `RowLayout`:

```qml
RowLayout {
    id: summaryRow
    Layout.fillWidth: true
    implicitHeight: summaryText.implicitHeight
    StyledText {
        id: summaryText
        Layout.fillWidth: summaryTextMetrics.width >= summaryRow.implicitWidth * root.summaryElideRatio
        ...
    }
}
```

This creates a self-referential dependency cycle:

```
summaryText.Layout.fillWidth
  → changes summaryText.width
  → changes summaryRow.implicitWidth (its parent recomputes implicit size from its children)
  → re-evaluates summaryText.Layout.fillWidth
  → loop
```

Qt 6.10 absorbed this through internal layout-settling heuristics and only emitted occasional warnings. Qt 6.11.1 detects the recursion explicitly and emits the polish() loop warning on every iteration, which the layout engine retries indefinitely — hence the 100% CPU and UI freeze.

### Fix

Replace the recursive reference to `summaryRow.implicitWidth` with `root.width`. `root` is the outer `NotificationItem` and its width is inherited from the parent `ListView`, which is a stable upstream value — there is no circular dependency back into `summaryText`.

```diff
-                    Layout.fillWidth: summaryTextMetrics.width >= summaryRow.implicitWidth * root.summaryElideRatio
+                    Layout.fillWidth: summaryTextMetrics.width >= root.width * root.summaryElideRatio
```

The elision behaviour is unchanged in practice because `summaryRow` is itself `Layout.fillWidth: true` inside a `ColumnLayout` that fills the notification item, so `summaryRow.implicitWidth` always converges to approximately `root.width` minus the surrounding padding. Using `root.width` directly produces the same visual result while breaking the cycle.

### Test plan
- [x] Reproduced the freeze on Arch Linux, Hyprland 0.55.2, Qt 6.11.1, quickshell pinned commit (illogical-impulse).
- [x] Confirmed the warning storm in `journalctl --user` / `qs` stderr.
- [x] Applied the patch, rebuilt nothing (QML hot-reload after `pkill qs` and clearing `~/.cache/quickshell/qmlcache`).
- [x] After the fix: opening the sidebar with active notifications produces **zero** polish() loop warnings; CPU stays idle; notifications render and animate normally.
- [x] Verified with `notify-send` of varying body lengths (short, multi-line, long body forcing wrap).

### Related
A previous attempt at the same symptom (PR #2324) tried to remove the `Behavior` animations and the `anchors.fill: parent` on the inner `ColumnLayout`. Those changes reduced the loop frequency but did not eliminate it because the root cause is the `summaryText.Layout.fillWidth` ↔ `summaryRow.implicitWidth` cycle, not the animation behaviours.

## Is it ready? Questions/feedback needed?

Ready for review. One-line change with no behavioural regression that I could observe locally. Happy to expand the diff if maintainers want to also address the unrelated `polish()` warnings still occasionally emitted by `NotificationAppIcon.qml`, `CookieClock.qml`, and `ToolbarTabBar.qml` under Qt 6.11.1 — those are not freezing the UI but are visible in the same log.