### PR TITLE
fix: hypridle Lua-dispatch compatibility for lock and DPMS

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -5,7 +5,7 @@ $suspend_cmd = systemctl suspend || loginctl suspend
 general {
     lock_cmd = $lock_cmd
     before_sleep_cmd = loginctl lock-session
-    after_sleep_cmd = hyprctl dispatch global quickshell:lockFocus
+    after_sleep_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lockFocus")'
     inhibit_sleep = 3
 }
 
@@ -16,8 +16,8 @@ listener {
 
 listener {
     timeout = 600 # 10mins
-    on-timeout = hyprctl dispatch dpms off
-    on-resume = hyprctl dispatch dpms on
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms(false)'
+    on-resume = hyprctl dispatch 'hl.dsp.dpms(true)'
 }
 
 listener {


### PR DESCRIPTION
## Summary
Update hypridle.conf dispatch commands so lock and DPMS actions work in Hyprland Lua config mode (0.55+).

## Why
In Lua mode, old dispatch command forms can be parsed as Lua and fail for commands like `global quickshell:lock`, `global quickshell:lockFocus`, and `dpms off/on`.

## Changes
- Convert hypridle dispatch commands to Lua-dispatch-compatible forms.
- Keep lock/focus/DPMS behavior unchanged.

## Validation
Tested on Hyprland 0.55.2:
- Super+L lock path works again.
- hypridle timeout lock path works.
- hypridle DPMS timeout/resume works.

## Related
- Closes #3341
- Related: #3366, #3320
