### PR TITLE
fix: remove duplicate SUPER+ALT+number keybinds

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -196,11 +196,11 @@ hl.bind("SUPER + ALT + F", hl.dsp.window.fullscreen_state({ internal = 0, client
 hl.bind("SUPER + P", hl.dsp.window.pin(), { description = "Window: Pin" })
 
 --#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
-for i = 1, 10 do
-    hl.bind("SUPER + ALT + " .. (i % 10), function()
-        hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
-    end, { description = "Window: Send to workspace " .. i })
-end
+-- for i = 1, 10 do
+--     hl.bind("SUPER + ALT + " .. (i % 10), function()
+--         hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
+--     end, { description = "Window: Send to workspace " .. i })
+-- end
 --# We also use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
 for i = 1, 10 do
     local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }


### PR DESCRIPTION
**Description:**

In commit c070625, character-based binds for `SUPER+ALT+<number>` were added back alongside the existing keycode-based binds for cheatsheet display purposes.

On standard keyboard layouts, pressing a number row key fires both the character bind (`"SUPER + ALT + 1"`) and the keycode bind (`"SUPER + ALT + code:10"`) simultaneously. This causes `hl.dsp.window.move` to dispatch twice per keypress, moving two windows to the target workspace instead of one.

The numpad binds are unaffected because they only have keycode binds, which is why the behavior differs between number row and numpad.

**Triage note:** This was initially suspected to be a Hyprland 0.55 regression. After ruling out groups, window rules, ydotool, and the Lua dispatcher itself (verified via `hyprctl dispatch 'hl.dsp.window.move({workspace=N})'` which correctly moves only the focused window), the duplicate bind was identified as the root cause.

**Fix:** Remove the character-based loop. The keycode binds (`code:10-19`) already cover all keyboard layouts including non-US ones. The `--#/#` cheatsheet comment line is preserved.