### PR TITLE
[bug+feature] Generate wallpaper thumbs efficiently with magisk (No more killing the OS)

### DIFF
--- a/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
+++ b/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
@@ -7,6 +7,20 @@
 
 set -e
 
+matches_pattern() {
+    local filename="$1"
+    local patterns_str="$2"
+    local IFS='|'
+    read -ra pattern_array <<< "$patterns_str"
+
+    for p in "${pattern_array[@]}"; do
+        if [[ "$filename" == $p ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Thumbnail sizes mapping
 get_thumbnail_size() {
     case "$1" in
@@ -19,7 +33,7 @@ get_thumbnail_size() {
 }
 
 usage() {
-    echo "Usage: $0 --file <path> | --directory <path>"
+    echo "Usage: $0 --file <path> | --directory <path> [--machine_progress] [--extensions <pattern>]"
     exit 1
 }
 
@@ -45,14 +59,14 @@ urlencode() {
 
 generate_thumbnail() {
     local src="$1"
+    local signal_dir="$2"
     local abs_path
     abs_path="$(realpath "$src")"
-    # Skip files with multiple frames (GIFs, videos, etc.)
-    case "${abs_path,,}" in
-        *.gif|*.mp4|*.webm|*.mkv|*.avi|*.mov)
-            return
-            ;;
-    esac
+
+    if ! matches_pattern "${abs_path,,}" "$ALLOWED_EXTENSIONS"; then
+        return
+    fi
+
     local encoded_path
     encoded_path="$(urlencode "$abs_path")"
     local uri
@@ -62,15 +76,26 @@ generate_thumbnail() {
     local out="$CACHE_DIR/$hash.png"
     mkdir -p "$CACHE_DIR"
     if [ -f "$out" ]; then
+        # If thumbnail already exists, consider it "done" and signal completion
+        if [ -n "$signal_dir" ]; then
+            echo "$abs_path" > "$signal_dir/$$.done"
+        fi
         return
     fi
     magick "$abs_path" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" "$out"
+
+    # Signal completion after successful thumbnail generation
+    if [ -n "$signal_dir" ]; then
+        echo "$abs_path" > "$signal_dir/$$.done"
+    fi
 }
 
 # Parse arguments
 SIZE_NAME="normal"
 MODE=""
 TARGET=""
+ALLOWED_EXTENSIONS="*.jpg|*.jpeg|*.png|*.webp|*.avif|*.bmp|*.svg" # Default extensions if nothing is given
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --file|-f)
@@ -82,6 +107,14 @@ while [[ $# -gt 0 ]]; do
             MODE="dir"
             TARGET="$2"
             shift 2
+            ;;
+        --extensions|-e)
+            ALLOWED_EXTENSIONS="$2"
+            shift 2
+            ;;
+        --machine_progress)
+            MACHINE_PROGRESS=1
+            shift 1
             ;;
         --size|-s)
             SIZE_NAME="$2"
@@ -108,6 +141,10 @@ case "$MODE" in
             echo "File not found: $TARGET"
             exit 2
         fi
+        if ! matches_pattern "${TARGET,,}" "$ALLOWED_EXTENSIONS"; then
+            echo "File type for '$TARGET' does not match allowed extensions pattern."
+            exit 1
+        fi
         generate_thumbnail "$TARGET"
         ;;
     dir)
@@ -115,14 +152,77 @@ case "$MODE" in
             echo "Directory not found: $TARGET"
             exit 2
         fi
+
+        # Temp dir for completion signals
+        signal_dir=$(mktemp -d -t thumbnail_progress_signals_XXXXXX)
+        # Ensure cleanup on exit
+        trap "rm -rf '$signal_dir'" EXIT
+
+        # Limit to half the number of CPUs so the whole OS doesn't implode
+        NUM_CPUS=$(nproc)
+        MAX_JOBS=$(( NUM_CPUS / 2 ))
+
+        # If someone is using a 90s PC
+        if (( MAX_JOBS == 0 )); then
+            MAX_JOBS=1
+        fi
+
+        total_files=0
+        # First pass to count total files that will be processed
+        for f_count in "$TARGET"/*; do
+            [ -f "$f_count" ] || continue
+
+            if matches_pattern "${f_count,,}" "$ALLOWED_EXTENSIONS"; then
+                total_files=$(( total_files + 1 ))
+            else
+                continue # Skip this file
+            fi
+        done
+
+        completed_files=0
+        active_jobs_count=0
+
+        process_completion_signals() {
+            local processed_count=0
+            for signal_file in "$signal_dir"/*.done; do
+                if [ -f "$signal_file" ]; then
+                    local finished_filepath
+                    finished_filepath=$(cat "$signal_file")
+                    completed_files=$(( completed_files + 1 ))
+                    echo "PROGRESS $completed_files/$total_files FILE $finished_filepath"
+                    rm "$signal_file"
+                    processed_count=$(( processed_count + 1 ))
+                fi
+            done
+            active_jobs_count=$(( active_jobs_count - processed_count ))
+        }
+
         for f in "$TARGET"/*; do
             [ -f "$f" ] || continue
-            generate_thumbnail "$f" &
+
+            if ! matches_pattern "${f,,}" "$ALLOWED_EXTENSIONS"; then
+                continue # Skip this file
+            fi
+
+            if (( active_jobs_count >= MAX_JOBS )); then
+                wait -n
+                process_completion_signals
+            fi
+
+            generate_thumbnail "$f" "$signal_dir" &
+            active_jobs_count=$(( active_jobs_count + 1 ))
         done
-        wait
+
+        # Remaining jobs
+        while (( active_jobs_count > 0 )); do
+            wait -n
+            process_completion_signals
+        done
+
+        # Just to be sure
+        process_completion_signals
         ;;
     *)
         usage
         ;;
 esac
-

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -139,7 +139,7 @@ Singleton {
         thumbgenProc.running = false
         thumbgenProc.command = [
             "bash", "-c",
-            `${thumbgenScriptPath} --size ${size} --machine_progress -d ${FileUtils.trimFileProtocol(root.directory)} || ${generateThumbnailsMagickScriptPath} --size ${size} -d ${FileUtils.trimFileProtocol(root.directory)}`,
+            `${thumbgenScriptPath} --size ${size} --machine_progress -d ${FileUtils.trimFileProtocol(root.directory)} || ${generateThumbnailsMagickScriptPath} --size ${size} --machine_progress --extensions '*.${extensions.join("|*.")}' -d ${FileUtils.trimFileProtocol(root.directory)}`,
         ]
         // console.log("[Wallpapers] Updating thumbnails with command ", thumbgenProc.command.join(" "))
         root.thumbnailGenerationProgress = 0


### PR DESCRIPTION
## Describe your changes

This does 2 things:

1) First it stops the fallback thumbnail generation (the one that uses magisk through a bash script) from killing the OS. Because it just creates as many processes as there are images on the folder, so you end up with hundreds of processes loading hundreds of images. This can cause the kernel from dumping quickshell out of the memory or even worse. Now the script only runs on half the CPUs so the PC barely notices anything.
2) It adds the same behaviour from the normal thumb generation that shows the thumbs on the UI as they are generated.

## Is it ready? Questions/feedback needed?
Yes. I've tested on my PC and it generates the thumbs updating the UI as the thumbs are generated and the OS doesn't kill itself because there are 1 billion magisk processes running at 100%.

But my bash skills are not pro, so there's always a chance of bugs. The `signal_dir` was a suggestion from an AI as I was stuck on how to get the progress with async background processes, but it does makes sense.