### PR TITLE
feat(weather): redesign popup layout and refactor data structure for i18n support

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherCard.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherCard.qml
@@ -6,39 +6,73 @@ import qs.modules.common.widgets
 
 Rectangle {
     id: root
+    
     radius: Appearance.rounding.small
     color: Appearance.colors.colSurfaceContainerHigh
-    implicitWidth: columnLayout.implicitWidth + 14 * 2
-    implicitHeight: columnLayout.implicitHeight + 14 * 2
-    Layout.fillWidth: parent
+    
+    Layout.fillWidth: true
+    implicitWidth: mainRow.implicitWidth + 32
+    implicitHeight: mainRow.implicitHeight + 12
 
     property alias title: title.text
     property alias value: value.text
     property alias symbol: symbol.text
 
-    ColumnLayout {
-        id: columnLayout
-        anchors.fill: parent
-        spacing: -10
-        RowLayout {
-            Layout.alignment: Qt.AlignHCenter
+    RowLayout {
+        id: mainRow
+        anchors {
+             left: parent.left
+             verticalCenter: parent.verticalCenter
+             leftMargin: 8
+             rightMargin: 16
+        }
+        spacing: 8
+
+        Rectangle {
+            id: iconContainer
+            width: Appearance.font.pixelSize.title * 2
+            height: Appearance.font.pixelSize.title * 2
+            radius: Appearance.rounding.small
+            color: Appearance.colors.colSurfaceContainerHighest ?? Appearance.colors.colSurfaceVariant
+            
+            Layout.alignment: Qt.AlignVCenter
+
             MaterialSymbol {
                 id: symbol
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenterOffset: 1
                 fill: 0
-                iconSize: Appearance.font.pixelSize.normal
-                color: Appearance.colors.colOnSurfaceVariant
-            }
-            StyledText {
-                id: title
-                font.pixelSize: Appearance.font.pixelSize.smaller
-                color: Appearance.colors.colOnSurfaceVariant
+                iconSize: Appearance.font.pixelSize.title
+                color: Appearance.colors.colOnSurface
             }
         }
-        StyledText {
-            id: value
-            Layout.alignment: Qt.AlignHCenter
-            font.pixelSize: Appearance.font.pixelSize.small
-            color: Appearance.colors.colOnSurfaceVariant
+
+        ColumnLayout {
+            id: textColumn
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 1 
+            
+
+            StyledText {
+                id: title
+                font {
+                    pixelSize: Appearance.font.pixelSize.smaller
+                    weight: Font.Normal
+                }
+                color: Appearance.colors.colOutline
+                elide: Text.ElideRight
+            }
+
+            StyledText {
+                id: value
+                font {
+                    pixelSize: Appearance.font.pixelSize.small
+                    weight: Font.Bold
+                }
+                color: Appearance.colors.colOnSurface 
+                elide: Text.ElideRight
+            }
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherPopup.qml
@@ -8,108 +8,134 @@ import qs.modules.ii.bar
 
 StyledPopup {
     id: root
-
-    ColumnLayout {
-        id: columnLayout
+    
+    Item {
         anchors.centerIn: parent
-        implicitWidth: Math.max(header.implicitWidth, gridLayout.implicitWidth)
-        implicitHeight: gridLayout.implicitHeight
-        spacing: 5
+        implicitWidth: gridLayout.implicitWidth + 8
+        implicitHeight: columnLayout.implicitHeight + 8
 
-        // Header
         ColumnLayout {
-            id: header
-            Layout.alignment: Qt.AlignHCenter
-            spacing: 2
+            id: columnLayout
+            anchors.centerIn: parent
+            spacing: 8
 
+            // Header
             RowLayout {
-                Layout.alignment: Qt.AlignHCenter
-                spacing: 6
+                id: header
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter 
 
-                MaterialSymbol {
-                    fill: 0
-                    font.weight: Font.Medium
-                    text: "location_on"
-                    iconSize: Appearance.font.pixelSize.large
-                    color: Appearance.colors.colOnSurfaceVariant
-                }
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignLeft
+                    spacing: 0
 
-                StyledText {
-                    text: Weather.data.city
-                    font {
-                        weight: Font.Medium
-                        pixelSize: Appearance.font.pixelSize.normal
+                    StyledText {
+                        text: Weather.data.city
+                        font {
+                            weight: Font.Bold
+                            pixelSize: Appearance.font.pixelSize.small
+                        }
+                        color: Appearance.colors.colOnSurface
                     }
-                    color: Appearance.colors.colOnSurfaceVariant
+
+                    StyledText {
+                        text: Translation.tr("Feels like %1").arg(Weather.data.tempFeelsLike)
+                        font {
+                            weight: Font.Normal
+                            pixelSize: Appearance.font.pixelSize.smaller
+                        }
+                        color: Appearance.colors.colOutline
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignRight
+                    spacing: 8
+
+                    StyledText {
+                        text: Weather.data.temp
+                        font {
+                            weight: Font.SemiBold
+                            pixelSize: Appearance.font.pixelSize.small * 2
+                        }
+                        color: Appearance.colors.colOnSurface
+                    }
+
+                    MaterialSymbol {
+                        text: Icons.getWeatherIcon(Weather.data.wCode) ?? "cloud"
+                        fill: 0
+                        font.weight: Font.Normal
+                        iconSize: Appearance.font.pixelSize.small * 2
+                        color: Appearance.colors.colOnSurface
+                    }
                 }
             }
+
+            // Metrics grid
+            GridLayout {
+                id: gridLayout
+                Layout.fillWidth: true
+                columns: 2
+                rowSpacing: 8
+                columnSpacing: 8
+                uniformCellWidths: true
+
+                WeatherCard {
+                    title: Translation.tr("UV Index")
+                    symbol: "wb_sunny"
+                    value: Weather.data.uv
+                }
+                WeatherCard {
+                    title: Translation.tr("Wind")
+                    symbol: "air"
+                    value: `${Weather.data.windDirArrow} ${Weather.data.wind} ${Translation.tr(Weather.data.windUnit)}`
+                }
+                WeatherCard {
+                    title: Translation.tr("Precipitation")
+                    symbol: "rainy_light"
+                    value: `${Weather.data.precip} ${Translation.tr(Weather.data.precipUnit)}`
+                }
+                WeatherCard {
+                    title: Translation.tr("Humidity")
+                    symbol: "humidity_low"
+                    value: Weather.data.humidity
+                }
+                WeatherCard {
+                    title: Translation.tr("Visibility")
+                    symbol: "visibility"
+                    value: `${Weather.data.visib} ${Translation.tr(Weather.data.visibUnit)}`
+                }
+                WeatherCard {
+                    title: Translation.tr("Pressure")
+                    symbol: "readiness_score"
+                    value: `${Weather.data.press} ${Translation.tr(Weather.data.pressUnit)}`
+                }
+                WeatherCard {
+                    title: Translation.tr("Sunrise")
+                    symbol: "wb_twilight"
+                    value: Weather.data.sunrise
+                }
+                WeatherCard {
+                    title: Translation.tr("Sunset")
+                    symbol: "bedtime"
+                    value: Weather.data.sunset
+                }
+            }
+
+            // Footer: last refresh
             StyledText {
-                id: temp
-                font.pixelSize: Appearance.font.pixelSize.smaller
-                color: Appearance.colors.colOnSurfaceVariant
-                text: Weather.data.temp + " • " + Translation.tr("Feels like %1").arg(Weather.data.tempFeelsLike)
+                Layout.alignment: Qt.AlignHCenter
+                text: Translation.tr("Last refresh: %1").arg(Weather.data.lastRefresh)
+                font {
+                    weight: Font.Normal
+                    pixelSize: Appearance.font.pixelSize.smaller
+                }
+                color: Appearance.colors.colOutline
             }
-        }
-
-        // Metrics grid
-        GridLayout {
-            id: gridLayout
-            columns: 2
-            rowSpacing: 5
-            columnSpacing: 5
-            uniformCellWidths: true
-
-            WeatherCard {
-                title: Translation.tr("UV Index")
-                symbol: "wb_sunny"
-                value: Weather.data.uv
-            }
-            WeatherCard {
-                title: Translation.tr("Wind")
-                symbol: "air"
-                value: `(${Weather.data.windDir}) ${Weather.data.wind}`
-            }
-            WeatherCard {
-                title: Translation.tr("Precipitation")
-                symbol: "rainy_light"
-                value: Weather.data.precip
-            }
-            WeatherCard {
-                title: Translation.tr("Humidity")
-                symbol: "humidity_low"
-                value: Weather.data.humidity
-            }
-            WeatherCard {
-                title: Translation.tr("Visibility")
-                symbol: "visibility"
-                value: Weather.data.visib
-            }
-            WeatherCard {
-                title: Translation.tr("Pressure")
-                symbol: "readiness_score"
-                value: Weather.data.press
-            }
-            WeatherCard {
-                title: Translation.tr("Sunrise")
-                symbol: "wb_twilight"
-                value: Weather.data.sunrise
-            }
-            WeatherCard {
-                title: Translation.tr("Sunset")
-                symbol: "bedtime"
-                value: Weather.data.sunset
-            }
-        }
-
-        // Footer: last refresh
-        StyledText {
-            Layout.alignment: Qt.AlignHCenter
-            text: Translation.tr("Last refresh: %1").arg(Weather.data.lastRefresh)
-            font {
-                weight: Font.Medium
-                pixelSize: Appearance.font.pixelSize.smaller
-            }
-            color: Appearance.colors.colOnSurfaceVariant
         }
     }
 }

--- a/dots/.config/quickshell/ii/services/Weather.qml
+++ b/dots/.config/quickshell/ii/services/Weather.qml
@@ -38,39 +38,77 @@ Singleton {
         wCode: 0,
         city: 0,
         wind: 0,
+        windUnit: "km/h",
+        windDirArrow: "↑",
         precip: 0,
+        precipUnit: "mm",
         visib: 0,
+        visibUnit: "km",
         press: 0,
+        pressUnit: "hPa",
         temp: 0,
         tempFeelsLike: 0,
         lastRefresh: 0,
     })
 
+    function windDirToArrow(dir) {
+        const map = {
+            "N": "↑", "NNE": "↗", "NE": "↗", "ENE": "→",
+            "E": "→", "ESE": "↘", "SE": "↘", "SSE": "↓",
+            "S": "↓", "SSW": "↙", "SW": "↙", "WSW": "←",
+            "W": "←", "WNW": "↖", "NW": "↖", "NNW": "↑"
+        };
+        return map[dir] ?? "→";
+    }
+
+    function formatAstroTime(timeStr) {
+        // API returns fixed 12h format like "04:50 AM" — convert to user's configured format
+        const parts = timeStr.match(/(\d+):(\d+)\s*(AM|PM)/i);
+        if (!parts) return timeStr;
+        let hours = parseInt(parts[1]);
+        const minutes = parseInt(parts[2]);
+        const ampm = parts[3].toUpperCase();
+        if (ampm === "PM" && hours !== 12) hours += 12;
+        if (ampm === "AM" && hours === 12) hours = 0;
+        const d = new Date();
+        d.setHours(hours, minutes, 0, 0);
+        return Qt.locale().toString(d, Config.options?.time.format ?? "hh:mm");
+    }
+
     function refineData(data) {
         let temp = {};
         temp.uv = data?.current?.uvIndex || 0;
         temp.humidity = (data?.current?.humidity || 0) + "%";
-        temp.sunrise = data?.astronomy?.sunrise || "0.0";
-        temp.sunset = data?.astronomy?.sunset || "0.0";
+        temp.sunrise = formatAstroTime(data?.astronomy?.sunrise || "12:00 AM");
+        temp.sunset = formatAstroTime(data?.astronomy?.sunset || "12:00 AM");
         temp.windDir = data?.current?.winddir16Point || "N";
+        temp.windDirArrow = windDirToArrow(temp.windDir);
         temp.wCode = data?.current?.weatherCode || "113";
         temp.city = data?.location?.areaName[0]?.value || "City";
         temp.temp = "";
         temp.tempFeelsLike = "";
         if (root.useUSCS) {
-            temp.wind = (data?.current?.windspeedMiles || 0) + " mph";
-            temp.precip = (data?.current?.precipInches || 0) + " in";
-            temp.visib = (data?.current?.visibilityMiles || 0) + " m";
-            temp.press = (data?.current?.pressureInches || 0) + " psi";
+            temp.wind = data?.current?.windspeedMiles || 0;
+            temp.windUnit = "mph";
+            temp.precip = data?.current?.precipInches || 0;
+            temp.precipUnit = "in";
+            temp.visib = data?.current?.visibilityMiles || 0;
+            temp.visibUnit = "mi";
+            temp.press = data?.current?.pressureInches || 0;
+            temp.pressUnit = "psi";
             temp.temp += (data?.current?.temp_F || 0);
             temp.tempFeelsLike += (data?.current?.FeelsLikeF || 0);
             temp.temp += "°F";
             temp.tempFeelsLike += "°F";
         } else {
-            temp.wind = (data?.current?.windspeedKmph || 0) + " km/h";
-            temp.precip = (data?.current?.precipMM || 0) + " mm";
-            temp.visib = (data?.current?.visibility || 0) + " km";
-            temp.press = (data?.current?.pressure || 0) + " hPa";
+            temp.wind = data?.current?.windspeedKmph || 0;
+            temp.windUnit = "km/h";
+            temp.precip = data?.current?.precipMM || 0;
+            temp.precipUnit = "mm";
+            temp.visib = data?.current?.visibility || 0;
+            temp.visibUnit = "km";
+            temp.press = data?.current?.pressure || 0;
+            temp.pressUnit = "hPa";
             temp.temp += (data?.current?.temp_C || 0);
             temp.tempFeelsLike += (data?.current?.FeelsLikeC || 0);
             temp.temp += "°C";

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -611,5 +611,13 @@
   "Use varying shapes for password characters": "Use varying shapes for password characters",
   "Battery full": "Battery full",
   "Pin": "Pin",
-  "Unpin": "Unpin"
+  "Unpin": "Unpin",
+  "km/h": "km/h",
+  "mm": "mm",
+  "km": "km",
+  "hPa": "hPa",
+  "mph": "mph",
+  "in": "in",
+  "mi": "mi",
+  "psi": "psi"
 }

--- a/dots/.config/quickshell/ii/translations/uk_UA.json
+++ b/dots/.config/quickshell/ii/translations/uk_UA.json
@@ -338,5 +338,15 @@
   "Tool set to: %1": "Інструмет вказано: %1",
   "Commands, edit configs, search.\nTakes an extra turn to switch to search mode if that's needed": "Команди, редагування конфігурацій, пошук.\nВиконує додаткову дію для переходу в режим пошуку, якщо це потрібно",
   "To set an API key, pass it with the %4 command\n\nTo view the key, pass \"get\" with the command<br/>\n\n### For %1:\n\n**Link**: %2\n\n%3": "Щоб задати ключ API, передайте його командою %4\n\nЩоб переглянути ключ, передайте \"get\" командою<br/>\n\n### Для %1:\n\n**Лінк**: %2\n\n%3",
-  "Online | Google's model\nNewer model that's slower than its predecessor but should deliver higher quality answers": "Онлайн | Модель Google\nНовіша модель, яка повільніша за свою попередницю, але має надавати якісніші відповіді"
+  "Online | Google's model\nNewer model that's slower than its predecessor but should deliver higher quality answers": "Онлайн | Модель Google\nНовіша модель, яка повільніша за свою попередницю, але має надавати якісніші відповіді",
+  "Feels like %1": "Відчувається як %1",
+  "Last refresh: %1": "Останнє оновлення: %1",
+  "km/h": "км/год",
+  "mm": "мм",
+  "km": "км",
+  "hPa": "гПа",
+  "mph": "миль/год",
+  "in": "дюйм",
+  "mi": "ми",
+  "psi": "фунт/дюйм²"
 }


### PR DESCRIPTION
## Overview
<img width="695" height="413" alt="Frame 77" src="https://github.com/user-attachments/assets/9857ade2-20eb-4d84-8ced-3b6252a02ecf" />

This PR delivers a comprehensive redesign of the weather widget, updating the popup layout, refactoring metric cards, and splitting weather data from presentation units to enable proper localization (i18n) and improve overall readability.

### 🎨 Visual Changes (UI/UX)
* **WeatherPopup Overhaul:** * Re-architected the header into a clean, separated layout: current temperature and the state icon are pushed to the right, while the city name and localized "Feels like" string sit on the left.
  * Adjusted the grid spacing and layout padding to prevent layout clipping and match Material 3 Expressive guidelines.
  * Simplified the footer text style for a cleaner look.
* **WeatherCard Redesign:**
  * Converted from a vertical stack to a polished horizontal layout.
  * Placed weather symbols inside a dedicated contrast container to anchor the design.
  * Properly aligned text columns (`title` and `value`) to a single vertical baseline across all cards.
  * Re-introduced explicit `Layout.fillWidth` and smart `implicitWidth` calculation to handle dynamic string lengths gracefully via `Text.ElideRight`.

### ⚙️ Functional & i18n Refactoring
* **Data & Presentation Separation:** * Refactored `WeatherService` to store raw numbers separately from their measurement units (previously joined as hardcoded strings like `"22 km/h"`).
  * Passed units dynamically through the `Translation.tr()` engine.
* **New Data Fields Added:**
  * Dedicated fields for units: `windUnit`, `precipUnit`, `visibUnit`, `pressUnit`.
  * Added `windDirArrow` string generated via a new helper function `windDirToArrow()` (maps `N`, `SW`, `ENE` to arrow symbols like `↑`, `↙`, `→`).
* **Time Formatting:**
  * Implemented `formatAstroTime()` to convert fixed 12h API strings for sunrise/sunset into the user's localized system time format.

### 🌐 Added Translations (`uk_UA.json`)
* `"Feels like %1"`
* `"Last refresh: %1"`
* Measurement units: `km/h`, `mm`, `km`, `hPa`, `mph`, `in`, `mi`, `psi`.

---

### 📋 Short Changelog
- redesign weather popup layout
- refactor weather cards visual structure
- split metric values from units for i18n
- add wind direction arrows
- localize sunrise/sunset time formatting
- add missing weather-related translations