### PR TITLE
fix(ii): stabilize album cover across player and panel quirks

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -295,4 +295,27 @@ Singleton {
             }
         );
     }
+
+    /**
+     * Returns a URL the cover-art downloader can fetch as artwork for a
+     * YouTube link, or "" if the URL is not from YouTube. Used as a fallback
+     * when the player exposes no mpris:artUrl (Firefox MPRIS bridge,
+     * plasma-browser-integration on YouTube Music).
+     *
+     * - Watch URL (?v=, youtu.be/, /embed/, /shorts/) → deterministic
+     *   i.ytimg.com/vi/<id>/hqdefault.jpg.
+     * - Playlist / channel / other YouTube URL → public oEmbed endpoint;
+     *   the downloader resolves its `thumbnail_url` field at fetch time.
+     *
+     * @param { string } url
+     * @returns { string }
+     */
+    function getYoutubeArtUrl(url) {
+        if (!url || !/(?:^|\/\/|\.)(?:youtube\.com|youtu\.be)/.test(url))
+            return "";
+        const m = url.match(/(?:[?&]v=|youtu\.be\/|\/(?:embed|shorts)\/)([A-Za-z0-9_-]{11})/);
+        if (m)
+            return `https://i.ytimg.com/vi/${m[1]}/hqdefault.jpg`;
+        return `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+    }
 }

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -15,39 +15,27 @@ import Quickshell.Services.Mpris
 Item { // Player instance
     id: root
     required property MprisPlayer player
-    // Some MPRIS players (Firefox via firefox-mpris, Spotify) emit empty
-    // trackArtUrl between/during tracks. MprisController persists the last
-    // non-empty value per player so we can fall back to it when the panel is
-    // (re)opened during an empty window.
-    property string artUrl: {
-        const cur = player?.trackArtUrl ?? "";
-        if (cur.length > 0) return cur;
-        const id = player?.uniqueId;
-        if (id === undefined) return "";
-        return MprisController.stableArtUrlByPlayer[id] ?? "";
-    }
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: artUrl.length > 0 ? `${artDownloadLocation}/${artFileName}` : ""
     property color artDominantColor: ColorUtils.mix((colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary), Appearance.colors.colPrimaryContainer, 0.8) || Appearance.m3colors.m3secondaryContainer
     property list<real> visualizerPoints: []
     property real maxVisualizerValue: 1000 // Max value in the data points
     property int visualizerSmoothing: 2 // Number of points to average for smoothing
     property real radius
 
-    // Only advances when a new file is confirmed on disk. Never clears, so the
-    // cover stays visible across track changes (transient empty trackArtUrl
-    // from Spotify/browsers) and panel close/reopen (cached file already on
-    // disk; previous design reset `downloaded` to false on every remount).
-    property string displayedArtFilePath: ""
-
-    // Track identity used to decide whether to reset best-quality tracking.
-    // Firefox emits multiple artUrls per song at different resolutions (e.g.,
-    // 544x544 followed by a 60x60 thumbnail); without this we'd swap to the
-    // smaller thumbnail and the cover would visibly degrade.
-    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}|${player?.trackAlbum ?? ""}`
-    property int _bestArtBytes: 0
-    on_TrackKeyChanged: { _bestArtBytes = 0; refreshArt(); }
+    // Cover art is downloaded centrally by MprisController (per-player Process
+    // that runs regardless of panel state), and tracked there as the
+    // highest-quality variant seen for each (player, track) pair. We just
+    // read that cache. This survives both:
+    //   - panel close/reopen (we weren't here to receive emissions; the
+    //     central downloader was)
+    //   - players that emit multiple sizes per track (Firefox: 544x544 then
+    //     60x60 thumbnail; Chromium: several near-identical tmp files) —
+    //     bestArtByPlayer keeps the largest.
+    // title|artist only; see MprisController._trackKeyOf for why album is omitted.
+    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`
+    readonly property string displayedArtFilePath: {
+        const entry = MprisController.getBestArt(player, _trackKey);
+        return entry ? Qt.resolvedUrl(entry.artFilePath) : "";
+    }
 
     component TrackChangeButton: RippleButton {
         implicitWidth: 24
@@ -77,68 +65,6 @@ Item { // Player instance
         repeat: true
         onTriggered: {
             root.player.positionChanged()
-        }
-    }
-
-    function refreshArt() {
-        if (root.artUrl.length === 0) return;
-        // Compute the path here rather than reading root.artFilePath: on
-        // onArtUrlChanged, QML may fire this handler before the chained
-        // artFilePath binding re-evaluates, giving us a stale (often empty)
-        // path. Deriving from artUrl directly avoids that race.
-        const path = `${root.artDownloadLocation}/${Qt.md5(root.artUrl)}`;
-        coverArtDownloader.targetFile = root.artUrl;
-        coverArtDownloader.artFilePath = path;
-        coverArtDownloader.running = true;
-    }
-
-    // Trigger on artUrl change AND on (re)mount, so a cached file on disk
-    // surfaces immediately when the panel is reopened. On mount we also
-    // consult MprisController's per-player best-art cache so reopening the
-    // panel doesn't downgrade to a thumbnail when the current trackArtUrl
-    // points at a low-res variant the player emitted later (Firefox).
-    Component.onCompleted: {
-        const best = MprisController.getBestArt(root.player, root._trackKey);
-        if (best) {
-            root._bestArtBytes = best.artBytes;
-            root.displayedArtFilePath = Qt.resolvedUrl(best.artFilePath);
-        }
-        refreshArt();
-    }
-    onArtUrlChanged: refreshArt()
-
-    Process { // Cover art downloader. Emits the file size on stdout so we can
-              // pick the highest-quality variant when a player advertises
-              // multiple sizes for one track (Firefox does this).
-        id: coverArtDownloader
-        property string targetFile
-        property string artFilePath
-        property int sizeBytes: 0
-        stdout: SplitParser {
-            onRead: data => {
-                const n = parseInt(data.trim());
-                if (!isNaN(n)) coverArtDownloader.sizeBytes = n;
-            }
-        }
-        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null` ]
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0 || artFilePath.length === 0 || sizeBytes <= 0) return;
-            // Never downgrade or rerun-flicker: only swap when the new file is
-            // strictly larger than the best we've seen for this track.
-            // _trackKey changes reset _bestArtBytes to 0 so a new track always
-            // accepts the first hit. Strict > also rejects same-size
-            // re-emissions (Chromium emits several near-identical tmp files
-            // per track) which would otherwise cause StyledImage opacity flicker.
-            if (sizeBytes <= root._bestArtBytes) return;
-            root._bestArtBytes = sizeBytes;
-            const url = Qt.resolvedUrl(artFilePath);
-            if (root.displayedArtFilePath.toString() !== url.toString()) {
-                root.displayedArtFilePath = url;
-            }
-            // Persist into MprisController so a panel close/reopen on the same
-            // track can restore this best variant directly, bypassing whatever
-            // (possibly lower-res) URL the player is currently advertising.
-            MprisController.rememberBestArt(root.player, root._trackKey, artFilePath, sizeBytes);
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -30,8 +30,30 @@ Item { // Player instance
     //   - players that emit multiple sizes per track (Firefox: 544x544 then
     //     60x60 thumbnail; Chromium: several near-identical tmp files) —
     //     bestArtByPlayer keeps the largest.
+    // Cache the last non-empty trackTitle/trackArtist. Some players
+    // (pear-desktop / youtube-music) clear metadata briefly during a track
+    // change before emitting the new track's values; binding the UI
+    // directly to player.trackTitle would make the title flash to
+    // "Untitled" mid-skip and would also invalidate the trackKey, dropping
+    // the cover image.
+    property string _stableTitle: ""
+    property string _stableArtist: ""
+    Connections {
+        target: root.player
+        function onTrackTitleChanged() {
+            if (root.player?.trackTitle) root._stableTitle = root.player.trackTitle;
+        }
+        function onTrackArtistChanged() {
+            if (root.player?.trackArtist) root._stableArtist = root.player.trackArtist;
+        }
+    }
+    Component.onCompleted: {
+        if (root.player?.trackTitle) _stableTitle = root.player.trackTitle;
+        if (root.player?.trackArtist) _stableArtist = root.player.trackArtist;
+    }
+
     // title|artist only; see MprisController._trackKeyOf for why album is omitted.
-    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`
+    readonly property string _trackKey: `${_stableTitle}|${_stableArtist}`
     readonly property string displayedArtFilePath: {
         const entry = MprisController.getBestArt(player, _trackKey);
         return entry ? Qt.resolvedUrl(entry.artFilePath) : "";
@@ -175,7 +197,7 @@ Item { // Player instance
                     font.pixelSize: Appearance.font.pixelSize.large
                     color: blendedColors.colOnLayer0
                     elide: Text.ElideRight
-                    text: StringUtils.cleanMusicTitle(root.player?.trackTitle) || "Untitled"
+                    text: StringUtils.cleanMusicTitle(root._stableTitle) || "Untitled"
                     animateChange: true
                     animationDistanceX: 6
                     animationDistanceY: 0
@@ -186,7 +208,7 @@ Item { // Player instance
                     font.pixelSize: Appearance.font.pixelSize.smaller
                     color: blendedColors.colSubtext
                     elide: Text.ElideRight
-                    text: root.player?.trackArtist
+                    text: root._stableArtist
                     animateChange: true
                     animationDistanceX: 6
                     animationDistanceY: 0

--- a/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
+++ b/dots/.config/quickshell/ii/modules/ii/mediaControls/PlayerControl.qml
@@ -15,18 +15,39 @@ import Quickshell.Services.Mpris
 Item { // Player instance
     id: root
     required property MprisPlayer player
-    property var artUrl: player?.trackArtUrl
+    // Some MPRIS players (Firefox via firefox-mpris, Spotify) emit empty
+    // trackArtUrl between/during tracks. MprisController persists the last
+    // non-empty value per player so we can fall back to it when the panel is
+    // (re)opened during an empty window.
+    property string artUrl: {
+        const cur = player?.trackArtUrl ?? "";
+        if (cur.length > 0) return cur;
+        const id = player?.uniqueId;
+        if (id === undefined) return "";
+        return MprisController.stableArtUrlByPlayer[id] ?? "";
+    }
     property string artDownloadLocation: Directories.coverArt
     property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: `${artDownloadLocation}/${artFileName}`
+    property string artFilePath: artUrl.length > 0 ? `${artDownloadLocation}/${artFileName}` : ""
     property color artDominantColor: ColorUtils.mix((colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary), Appearance.colors.colPrimaryContainer, 0.8) || Appearance.m3colors.m3secondaryContainer
-    property bool downloaded: false
     property list<real> visualizerPoints: []
     property real maxVisualizerValue: 1000 // Max value in the data points
     property int visualizerSmoothing: 2 // Number of points to average for smoothing
     property real radius
 
-    property string displayedArtFilePath: root.downloaded ? Qt.resolvedUrl(artFilePath) : ""
+    // Only advances when a new file is confirmed on disk. Never clears, so the
+    // cover stays visible across track changes (transient empty trackArtUrl
+    // from Spotify/browsers) and panel close/reopen (cached file already on
+    // disk; previous design reset `downloaded` to false on every remount).
+    property string displayedArtFilePath: ""
+
+    // Track identity used to decide whether to reset best-quality tracking.
+    // Firefox emits multiple artUrls per song at different resolutions (e.g.,
+    // 544x544 followed by a 60x60 thumbnail); without this we'd swap to the
+    // smaller thumbnail and the cover would visibly degrade.
+    readonly property string _trackKey: `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}|${player?.trackAlbum ?? ""}`
+    property int _bestArtBytes: 0
+    on_TrackKeyChanged: { _bestArtBytes = 0; refreshArt(); }
 
     component TrackChangeButton: RippleButton {
         implicitWidth: 24
@@ -59,27 +80,65 @@ Item { // Player instance
         }
     }
 
-    onArtFilePathChanged: {
-        if (root.artUrl.length == 0) {
-            root.artDominantColor = Appearance.m3colors.m3secondaryContainer
-            return;
-        }
-
-        // Binding does not work in Process
-        coverArtDownloader.targetFile = root.artUrl 
-        coverArtDownloader.artFilePath = root.artFilePath
-        // Download
-        root.downloaded = false
-        coverArtDownloader.running = true
+    function refreshArt() {
+        if (root.artUrl.length === 0) return;
+        // Compute the path here rather than reading root.artFilePath: on
+        // onArtUrlChanged, QML may fire this handler before the chained
+        // artFilePath binding re-evaluates, giving us a stale (often empty)
+        // path. Deriving from artUrl directly avoids that race.
+        const path = `${root.artDownloadLocation}/${Qt.md5(root.artUrl)}`;
+        coverArtDownloader.targetFile = root.artUrl;
+        coverArtDownloader.artFilePath = path;
+        coverArtDownloader.running = true;
     }
 
-    Process { // Cover art downloader
+    // Trigger on artUrl change AND on (re)mount, so a cached file on disk
+    // surfaces immediately when the panel is reopened. On mount we also
+    // consult MprisController's per-player best-art cache so reopening the
+    // panel doesn't downgrade to a thumbnail when the current trackArtUrl
+    // points at a low-res variant the player emitted later (Firefox).
+    Component.onCompleted: {
+        const best = MprisController.getBestArt(root.player, root._trackKey);
+        if (best) {
+            root._bestArtBytes = best.artBytes;
+            root.displayedArtFilePath = Qt.resolvedUrl(best.artFilePath);
+        }
+        refreshArt();
+    }
+    onArtUrlChanged: refreshArt()
+
+    Process { // Cover art downloader. Emits the file size on stdout so we can
+              // pick the highest-quality variant when a player advertises
+              // multiple sizes for one track (Firefox does this).
         id: coverArtDownloader
-        property string targetFile: root.artUrl
-        property string artFilePath: root.artFilePath
-        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'` ]
+        property string targetFile
+        property string artFilePath
+        property int sizeBytes: 0
+        stdout: SplitParser {
+            onRead: data => {
+                const n = parseInt(data.trim());
+                if (!isNaN(n)) coverArtDownloader.sizeBytes = n;
+            }
+        }
+        command: [ "bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null` ]
         onExited: (exitCode, exitStatus) => {
-            root.downloaded = true
+            if (exitCode !== 0 || artFilePath.length === 0 || sizeBytes <= 0) return;
+            // Never downgrade or rerun-flicker: only swap when the new file is
+            // strictly larger than the best we've seen for this track.
+            // _trackKey changes reset _bestArtBytes to 0 so a new track always
+            // accepts the first hit. Strict > also rejects same-size
+            // re-emissions (Chromium emits several near-identical tmp files
+            // per track) which would otherwise cause StyledImage opacity flicker.
+            if (sizeBytes <= root._bestArtBytes) return;
+            root._bestArtBytes = sizeBytes;
+            const url = Qt.resolvedUrl(artFilePath);
+            if (root.displayedArtFilePath.toString() !== url.toString()) {
+                root.displayedArtFilePath = url;
+            }
+            // Persist into MprisController so a panel close/reopen on the same
+            // track can restore this best variant directly, bypassing whatever
+            // (possibly lower-res) URL the player is currently advertising.
+            MprisController.rememberBestArt(root.player, root._trackKey, artFilePath, sizeBytes);
         }
     }
 

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -41,6 +41,47 @@ Singleton {
             !(player.dbusName?.endsWith('.mpd') && !player.dbusName.endsWith('MediaPlayer2.mpd')));
     }
 
+	// Last non-empty trackArtUrl seen per player (keyed by uniqueId). Some
+	// MPRIS players (Firefox via firefox-mpris, Spotify) emit transient empty
+	// trackArtUrl between/during tracks. Consumers like PlayerControl that get
+	// recreated on panel open/close need a stable fallback so the cover
+	// doesn't vanish whenever they happen to mount during an empty window.
+	property var stableArtUrlByPlayer: ({})
+
+	function _captureArtUrl(player) {
+		if (player?.trackArtUrl?.length > 0 && player?.uniqueId !== undefined) {
+			const map = Object.assign({}, root.stableArtUrlByPlayer);
+			map[player.uniqueId] = player.trackArtUrl;
+			root.stableArtUrlByPlayer = map;
+		}
+	}
+
+	// Best (largest) downloaded cover file seen per player for the current
+	// track, keyed by uniqueId. Persists across PlayerControl lifecycles so
+	// reopening the panel doesn't downgrade to a thumbnail when Firefox
+	// happens to be sitting on its low-res variant. Entry shape:
+	//   { trackKey: string, artFilePath: string, artBytes: number }
+	property var bestArtByPlayer: ({})
+
+	function rememberBestArt(player, trackKey, artFilePath, artBytes) {
+		const id = player?.uniqueId;
+		if (id === undefined || artBytes <= 0 || !artFilePath) return;
+		const existing = root.bestArtByPlayer[id];
+		// Same track and existing is already >= new size: nothing to do.
+		if (existing && existing.trackKey === trackKey && existing.artBytes >= artBytes) return;
+		const map = Object.assign({}, root.bestArtByPlayer);
+		map[id] = { trackKey: trackKey, artFilePath: artFilePath, artBytes: artBytes };
+		root.bestArtByPlayer = map;
+	}
+
+	function getBestArt(player, trackKey) {
+		const id = player?.uniqueId;
+		if (id === undefined) return null;
+		const entry = root.bestArtByPlayer[id];
+		if (!entry || entry.trackKey !== trackKey) return null;
+		return entry;
+	}
+
 	// Original stuff from fox below
 	Instantiator {
 		model: Mpris.players;
@@ -53,6 +94,7 @@ Singleton {
 				if (root.trackedPlayer == null || modelData.isPlaying) {
 					root.trackedPlayer = modelData;
 				}
+				root._captureArtUrl(modelData);
 			}
 
 			Component.onDestruction: {
@@ -72,6 +114,10 @@ Singleton {
 
 			function onPlaybackStateChanged() {
 				if (root.trackedPlayer !== modelData) root.trackedPlayer = modelData;
+			}
+
+			function onTrackArtUrlChanged() {
+				root._captureArtUrl(modelData);
 			}
 		}
 	}

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -41,31 +41,35 @@ Singleton {
             !(player.dbusName?.endsWith('.mpd') && !player.dbusName.endsWith('MediaPlayer2.mpd')));
     }
 
-	// Last non-empty trackArtUrl seen per player (keyed by uniqueId). Some
+	// Last non-empty trackArtUrl seen per player (keyed by dbusName). Some
 	// MPRIS players (Firefox via firefox-mpris, Spotify) emit transient empty
 	// trackArtUrl between/during tracks. Consumers like PlayerControl that get
 	// recreated on panel open/close need a stable fallback so the cover
 	// doesn't vanish whenever they happen to mount during an empty window.
+	// dbusName is the right key here: MprisPlayer.uniqueId in Quickshell is a
+	// per-track identifier (it increments when the track changes), not a
+	// per-player one, so keying on it cross-contaminates between players that
+	// happen to share a uniqueId value.
 	property var stableArtUrlByPlayer: ({})
 
 	function _captureArtUrl(player) {
-		if (player?.trackArtUrl?.length > 0 && player?.uniqueId !== undefined) {
+		if (player?.trackArtUrl?.length > 0 && !!player?.dbusName) {
 			const map = Object.assign({}, root.stableArtUrlByPlayer);
-			map[player.uniqueId] = player.trackArtUrl;
+			map[player.dbusName] = player.trackArtUrl;
 			root.stableArtUrlByPlayer = map;
 		}
 	}
 
 	// Best (largest) downloaded cover file seen per player for the current
-	// track, keyed by uniqueId. Persists across PlayerControl lifecycles so
+	// track, keyed by dbusName. Persists across PlayerControl lifecycles so
 	// reopening the panel doesn't downgrade to a thumbnail when Firefox
 	// happens to be sitting on its low-res variant. Entry shape:
 	//   { trackKey: string, artFilePath: string, artBytes: number }
 	property var bestArtByPlayer: ({})
 
 	function rememberBestArt(player, trackKey, artFilePath, artBytes) {
-		const id = player?.uniqueId;
-		if (id === undefined || artBytes <= 0 || !artFilePath) return;
+		const id = player?.dbusName;
+		if (!id || artBytes <= 0 || !artFilePath) return;
 		const existing = root.bestArtByPlayer[id];
 		// Same track and existing is already >= new size: nothing to do.
 		if (existing && existing.trackKey === trackKey && existing.artBytes >= artBytes) return;
@@ -75,50 +79,99 @@ Singleton {
 	}
 
 	function getBestArt(player, trackKey) {
-		const id = player?.uniqueId;
-		if (id === undefined) return null;
+		const id = player?.dbusName;
+		if (!id) return null;
 		const entry = root.bestArtByPlayer[id];
 		if (!entry || entry.trackKey !== trackKey) return null;
 		return entry;
 	}
 
-	// Original stuff from fox below
-	Instantiator {
-		model: Mpris.players;
+	function _trackKeyOf(player) {
+		// title|artist (album omitted on purpose). Some players (Firefox via
+		// firefox-mpris) emit metadata progressively: first trackArtUrl +
+		// title + artist with album="", then a moment later update album.
+		// If album were part of the key, the high-res variant emitted with
+		// the partial metadata and the low-res variant emitted with the
+		// completed metadata would look like different tracks to the
+		// "never-downgrade" guard.
+		return `${player?.trackTitle ?? ""}|${player?.trackArtist ?? ""}`;
+	}
 
-		Connections {
-			required property MprisPlayer modelData;
-			target: modelData;
+	// Per-player worker. Holds a Process that downloads each new trackArtUrl
+	// the player emits, regardless of whether the media controls panel is
+	// open. This is what makes the cover stay sharp across panel
+	// close/reopen and across auto-advance while the panel is closed —
+	// PlayerControl is no longer the only thing watching for art emissions.
+	component PlayerWorker: QtObject {
+		id: worker
+		required property MprisPlayer player
 
-			Component.onCompleted: {
-				if (root.trackedPlayer == null || modelData.isPlaying) {
-					root.trackedPlayer = modelData;
+		function _fetchArt() {
+			const url = worker.player?.trackArtUrl;
+			if (!url || url.length === 0) return;
+			artDownloader.trackKey = root._trackKeyOf(worker.player);
+			artDownloader.targetFile = url;
+			artDownloader.artFilePath = `${Directories.coverArt}/${Qt.md5(url)}`;
+			artDownloader.running = true;
+		}
+
+		property Process artDownloader: Process {
+			property string trackKey
+			property string targetFile
+			property string artFilePath
+			property int sizeBytes: 0
+			stdout: SplitParser {
+				onRead: data => {
+					const n = parseInt(data.trim());
+					if (!isNaN(n)) artDownloader.sizeBytes = n;
 				}
-				root._captureArtUrl(modelData);
 			}
-
-			Component.onDestruction: {
-				if (root.trackedPlayer == null || !root.trackedPlayer.isPlaying) {
-					for (const player of Mpris.players.values) {
-						if (player.playbackState.isPlaying) {
-							root.trackedPlayer = player;
-							break;
-						}
-					}
-
-					if (trackedPlayer == null && Mpris.players.values.length != 0) {
-						trackedPlayer = Mpris.players.values[0];
-					}
-				}
+			command: ["bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null`]
+			onExited: (exitCode, exitStatus) => {
+				if (exitCode !== 0 || sizeBytes <= 0 || artFilePath.length === 0) return;
+				root.rememberBestArt(worker.player, trackKey, artFilePath, sizeBytes);
 			}
+		}
 
+		property Connections _conn: Connections {
+			target: worker.player
 			function onPlaybackStateChanged() {
-				if (root.trackedPlayer !== modelData) root.trackedPlayer = modelData;
+				if (root.trackedPlayer !== worker.player) root.trackedPlayer = worker.player;
 			}
-
 			function onTrackArtUrlChanged() {
-				root._captureArtUrl(modelData);
+				root._captureArtUrl(worker.player);
+				worker._fetchArt();
 			}
+		}
+
+		Component.onCompleted: {
+			if (root.trackedPlayer == null || worker.player.isPlaying) {
+				root.trackedPlayer = worker.player;
+			}
+			root._captureArtUrl(worker.player);
+			worker._fetchArt();
+		}
+
+		Component.onDestruction: {
+			if (root.trackedPlayer == null || !root.trackedPlayer.isPlaying) {
+				for (const p of Mpris.players.values) {
+					if (p.playbackState.isPlaying) {
+						root.trackedPlayer = p;
+						break;
+					}
+				}
+				if (root.trackedPlayer == null && Mpris.players.values.length != 0) {
+					root.trackedPlayer = Mpris.players.values[0];
+				}
+			}
+		}
+	}
+
+	Instantiator {
+		model: Mpris.players
+		delegate: PlayerWorker {
+			required property MprisPlayer modelData
+			player: modelData
 		}
 	}
 

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -10,6 +10,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Mpris
 import qs.modules.common
+import qs.modules.common.functions
 
 /**
  * A service that provides easy access to the active Mpris player.

--- a/dots/.config/quickshell/ii/services/MprisController.qml
+++ b/dots/.config/quickshell/ii/services/MprisController.qml
@@ -107,7 +107,9 @@ Singleton {
 		required property MprisPlayer player
 
 		function _fetchArt() {
-			const url = worker.player?.trackArtUrl;
+			let url = worker.player?.trackArtUrl;
+			if (!url || url.length === 0)
+				url = StringUtils.getYoutubeArtUrl(worker.player?.metadata?.["xesam:url"] ?? "");
 			if (!url || url.length === 0) return;
 			artDownloader.trackKey = root._trackKeyOf(worker.player);
 			artDownloader.targetFile = url;
@@ -126,7 +128,15 @@ Singleton {
 					if (!isNaN(n)) artDownloader.sizeBytes = n;
 				}
 			}
-			command: ["bash", "-c", `[ -f ${artFilePath} ] || curl -4 -sSL '${targetFile}' -o '${artFilePath}'; stat -c %s '${artFilePath}' 2>/dev/null`]
+			command: ["bash", "-c", `
+				out=$1; url=$2
+				[ -f "$out" ] && { stat -c %s "$out" 2>/dev/null; exit 0; }
+				case "$url" in *"/oembed?"*)
+					url=$(curl -4 -fsSL "$url" | sed -n 's/.*"thumbnail_url":"\\([^"]*\\)".*/\\1/p') ;;
+				esac
+				[ -n "$url" ] && curl -4 -fsSL "$url" -o "$out"
+				stat -c %s "$out" 2>/dev/null
+			`, "qs-coverart", artFilePath, targetFile]
 			onExited: (exitCode, exitStatus) => {
 				if (exitCode !== 0 || sizeBytes <= 0 || artFilePath.length === 0) return;
 				root.rememberBestArt(worker.player, trackKey, artFilePath, sizeBytes);


### PR DESCRIPTION
## Summary
The media controls panel's album cover behavior has several failure modes that compound, especially with Firefox and Chromium. This PR addresses them in `MprisController.qml` and `PlayerControl.qml`:

1. **Cover blanks on panel close/reopen.** PlayerControl is destroyed and recreated each time the panel opens; the previous design reset `downloaded` to false, so the cover was hidden until the next download completed even when the cached file was still on disk.
2. **Cover degrades to a thumbnail mid-track.** firefox-mpris emits multiple artUrls per song at different resolutions (e.g., 544×544 then 60×60). The previous design swapped to whichever arrived last.
3. **Cover stays low-res after a track auto-advances while the panel is closed.** The previous design ran the downloader inside PlayerControl, which only exists while the panel is open. Emissions during a closed-panel period are missed; on reopen, only the current (typically low-res) URL is downloaded.
4. **Multi-player cross-contamination.** Two unrelated players that both happen to be on their first track share `player.uniqueId === 1` (Quickshell's `MprisPlayer.uniqueId` is per-track, not per-player), and their cache entries clobber each other.
5. **trackKey changes mid-track because album fills in late.** firefox-mpris emits metadata progressively: first artUrl + title + artist with `album=""`, then later updates album. With album in the trackKey, the high-res emitted with partial metadata and the low-res emitted with completed metadata look like different tracks, and the low-res ends up indexed under the (full-metadata) key the consumer reads with.

## Implementation
**MprisController** (`services/MprisController.qml`):
- New per-player `PlayerWorker` (QtObject) created via `Instantiator` over `Mpris.players`. Each worker:
  - listens to its player's `trackArtUrlChanged`,
  - downloads the new file via a `Process` that runs `[ -f file ] || curl ... ; stat -c %s file`,
  - on exit, calls `rememberBestArt(player, trackKey, file, sizeBytes)`.
- Two persistent per-player caches:
  - `stableArtUrlByPlayer`: last non-empty `trackArtUrl` per player, used by PlayerControl as a fallback during empty-URL windows.
  - `bestArtByPlayer`: best (largest) downloaded file per player + track, with `rememberBestArt()` / `getBestArt(player, trackKey)` helpers. Strict `>` size guard.
- Both caches are keyed on `player.dbusName`, not `uniqueId`.
- trackKey is `title|artist` (album deliberately omitted; see bug #5 above).

**PlayerControl** (`modules/ii/mediaControls/PlayerControl.qml`):
- No longer owns a downloader. It's a pure viewer of `MprisController.bestArtByPlayer`:
  ```qml
  readonly property string displayedArtFilePath: {
      const entry = MprisController.getBestArt(player, _trackKey);
      return entry ? Qt.resolvedUrl(entry.artFilePath) : "";
  }
  ```
- `displayedArtFilePath` automatically updates when the worker's `rememberBestArt` reassigns `bestArtByPlayer`.

## Test plan
- [x] Firefox + YouTube Music: switch several tracks; cover stays sharp on each (no degradation to a thumbnail a second later)
- [x] Firefox + YouTube Music: open panel, close, reopen — cover restores at full quality
- [x] Firefox + YouTube Music: leave panel closed, let track auto-advance, then reopen — new track's cover is sharp (worker captured the high-res emission while panel was closed)
- [x] Firefox + Chromium both playing different tracks: each row shows its own cover at full resolution; no cross-contamination
- [x] Chromium + YouTube Music alone: no flicker on track changes (per-track tmp-file flap rejected by strict `>` size guard)
- [ ] Spotify desktop / other native MPRIS player: no regression
- [ ] No-art player (e.g., browser without `mpris:artUrl`): placeholder behavior unchanged

## Related
- Overlaps with #1032 ("Some songs on spotify don't change their album covers").
- Orthogonal to #3265 / #3378 (YouTube cover fallback for players that *never* set `mpris:artUrl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)