### PR TITLE
Fix wrong dpms syntax

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -16,8 +16,8 @@ listener {
 
 listener {
     timeout = 600 # 10mins
-    on-timeout = hyprctl dispatch 'hl.dsp.dpms(false)'
-    on-resume = hyprctl dispatch 'hl.dsp.dpms(true)'
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
 }
 
 listener {


### PR DESCRIPTION
## Describe your changes

Reopening #3372 because #3393 uses the wrong syntax for dkms, causing black lockscreen after sleep.

Source: https://wiki.hypr.land/Configuring/Basics/Dispatchers/#cursor

## Is it ready? Questions/feedback needed?

Yes, bro did not read the wiki
