### PR TITLE
feat(lock): add native dpmsTimeout and unlockHook support

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -374,6 +374,8 @@ Singleton {
             property JsonObject lock: JsonObject {
                 property bool useHyprlock: false
                 property bool launchOnStartup: false
+                property int dpmsTimeout: 3
+                property string unlockHook: ""
                 property JsonObject blur: JsonObject {
                     property bool enable: true
                     property real radius: 100

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
@@ -54,6 +54,11 @@ Scope {
                 if (GlobalStates.screenLocked) {
                     lockContext.reset();
                     lockContext.tryFingerUnlock();
+
+                    // Отключаем экран по таймауту, если параметр больше нуля
+                    if (Config.options.lock.dpmsTimeout > 0) {
+                        Quickshell.execDetached(["bash", "-c", `sleep ${Config.options.lock.dpmsTimeout} && hyprctl dispatch dpms off`]);
+                    }
                 }
             }
         }
@@ -70,6 +75,11 @@ Scope {
 
             // Unlock the keyring if configured to do so
             if (Config.options.lock.security.unlockKeyring) root.unlockKeyring(); // Async
+
+            // Выполняем пользовательский хук разблокировки, если он задан
+            if (Config.options.lock.unlockHook && Config.options.lock.unlockHook !== "") {
+                Quickshell.execDetached(["bash", "-c", Config.options.lock.unlockHook]);
+            }
 
             // Unlock the screen before exiting, or the compositor will display a
             // fallback lock you can't interact with.

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
@@ -57,7 +57,7 @@ Scope {
 
                     // Отключаем экран по таймауту, если параметр больше нуля
                     if (Config.options.lock.dpmsTimeout > 0) {
-                        Quickshell.execDetached(["bash", "-c", `sleep ${Config.options.lock.dpmsTimeout} && hyprctl dispatch dpms off`]);
+                        Quickshell.execDetached(["bash", "-c", `sleep ${Config.options.lock.dpmsTimeout} && hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'`]);
                     }
                 }
             }


### PR DESCRIPTION
- Adds dpmsTimeout option to config for native screen blanking
- Adds unlockHook option to run custom scripts on successful auth

## Describe your changes
This PR introduces two native options to the Quickshell configuration schema and lockscreen module to handle display power management and custom scripts upon unlocking. 

- **Config Schema (`Config.qml`)**: Added `dpmsTimeout` (int) and `unlockHook` (string) properties under the `lock` object.
- **Lockscreen Logic (`LockScreen.qml`)**:
  - Implemented an automated `hyprctl dispatch dpms off` call after a specified timeout when the screen locks.
  - Added support for running custom bash scripts (`Quickshell.execDetached`) immediately upon a successful user authentication event.

## Is it ready? Questions/feedback needed?
Yes, it is ready. It provides a robust, native alternative for handling screen blanking and execution hooks directly within Quickshell, avoiding potential race conditions with external idlers.
