### PR TITLE
fix: Translation ignoring line for expanded tooltip

### DIFF
--- a/dots/.config/quickshell/ii/translations/de_DE.json
+++ b/dots/.config/quickshell/ii/translations/de_DE.json
@@ -530,7 +530,7 @@
   "Japanese": "Japanisch",
   "Layers": "Ebenen",
   "Listening...": "Hören...",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "LMB zum Aktivieren/Deaktivieren\nRMB zum Umschalten der Größe\nScrollen zum Tauschen der Position",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nLMB zum Aktivieren/Deaktivieren\nRMB zum Umschalten der Größe\nScrollen zum Tauschen der Position",
   "Identify Music": "Musik erkennen",
   "Quick toggles": "Schnellumschalter",
   "Hide sussy/anime wallpapers": "Verdächtige/Anime-Hintergrundbilder ausblenden",

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -535,7 +535,7 @@
   "Japanese": "Japanese",
   "Layers": "Layers",
   "Listening...": "Listening...",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "LMB to enable/disable\nRMB to toggle size\nScroll to swap position",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position",
   "Identify Music": "Identify Music",
   "Quick toggles": "Quick toggles",
   "Hide sussy/anime wallpapers": "Hide sussy/anime wallpapers",

--- a/dots/.config/quickshell/ii/translations/es_MX.json
+++ b/dots/.config/quickshell/ii/translations/es_MX.json
@@ -585,7 +585,7 @@
   "Cancel wallpaper selection": "Cancelar selección de fondo de pantalla",
   "See fewer": "Ver menos",
   "Click to toggle light/dark mode\n(applied when wallpaper is chosen)": "Clic para alternar modo claro/oscuro\n(se aplica al elegir el fondo de pantalla)",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "Clic izq. para activar/desactivar\nClic der. para alternar tamaño\nDesplazar para cambiar posición",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nClic izq. para activar/desactivar\nClic der. para alternar tamaño\nDesplazar para cambiar posición",
   "Window": "Ventana",
   "Cancel": "Cancelar",
   "Unknown Artist": "Artista desconocido",

--- a/dots/.config/quickshell/ii/translations/fr_FR.json
+++ b/dots/.config/quickshell/ii/translations/fr_FR.json
@@ -535,7 +535,7 @@
   "Japanese": "Japonais",
   "Layers": "Calques",
   "Listening...": "Écoute en cours...",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "LMB pour activer/désactiver\nRMB pour changer la taille\nDéfiler pour changer la position",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nLMB pour activer/désactiver\nRMB pour changer la taille\nDéfiler pour changer la position",
   "Identify Music": "Identifier la musique",
   "Quick toggles": "Bascules rapides",
   "Hide sussy/anime wallpapers": "Masquer les fonds d'écran douteux/anime",

--- a/dots/.config/quickshell/ii/translations/pt_BR.json
+++ b/dots/.config/quickshell/ii/translations/pt_BR.json
@@ -107,7 +107,7 @@
   "When not fullscreen": "Quando não estiver em tela cheia",
   "Run": "Executar",
   "Sounds": "Sons",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "Botão Esq. p/ ativar/desativar\nBotão Dir. p/ mudar tamanho\nScroll p/ trocar posição",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nBotão Esq. p/ ativar/desativar\nBotão Dir. p/ mudar tamanho\nScroll p/ trocar posição",
   "☕ Break: %1 minutes": "☕ Pausa: %1 minutos",
   "Enter a valid number": "Digite um número válido",
   "Split buttons": "Botões divididos",

--- a/dots/.config/quickshell/ii/translations/ru_RU.json
+++ b/dots/.config/quickshell/ii/translations/ru_RU.json
@@ -493,7 +493,7 @@
   "Eye protection": "Защита глаз",
   "Layers": "Слоёв",
   "Listening...": "Слушаю...",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "ЛКМ - вкл/выкл\nПКМ - изменить размер\nПрокрутка - поменять позицию",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nЛКМ - вкл/выкл\nПКМ - изменить размер\nПрокрутка - поменять позицию",
   "Identify Music": "Определить музыку",
   "Quick toggles": "Быстрые тогглы",
   "Hide sussy/anime wallpapers": "Скрывать подозрительные/аниме обои",

--- a/dots/.config/quickshell/ii/translations/tr_TR.json
+++ b/dots/.config/quickshell/ii/translations/tr_TR.json
@@ -530,7 +530,7 @@
   "Japanese": "Japonca",
   "Layers": "Katmanlar",
   "Listening...": "Dinleniyor...",
-  "LMB to enable/disable\nRMB to toggle size\nScroll to swap position": "Etkinleştirmek/devre dışı bırakmak için Sol Tık\nBoyutu değiştirmek için Sağ Tık\nKonumu değiştirmek için kaydırın",
+  "\nLMB to enable/disable\nRMB to toggle size\nScroll to swap position": "\nEtkinleştirmek/devre dışı bırakmak için Sol Tık\nBoyutu değiştirmek için Sağ Tık\nKonumu değiştirmek için kaydırın",
   "Identify Music": "Müziği Tanı",
   "Quick toggles": "Hızlı geçişler",
   "Hide sussy/anime wallpapers": "Şüpheli/anime duvar kağıtlarını gizle",


### PR DESCRIPTION
due to missing "\n" in most of the translations, there will be no translation for expanded tooltip