### PR TITLE
fix(regionSelector): keep snip interactive when another grab is open

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
@@ -18,7 +18,7 @@ PanelWindow {
     color: "transparent"
     WlrLayershell.namespace: "quickshell:regionSelector"
     WlrLayershell.layer: WlrLayer.Overlay
-    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
     exclusionMode: ExclusionMode.Ignore
     anchors {
         left: true
@@ -26,6 +26,16 @@ PanelWindow {
         top: true
         bottom: true
     }
+
+    // Join the shared HyprlandFocusGrab while the selector is open. Otherwise, if
+    // another grabbing surface (e.g. the overview) is already open when the snip is
+    // triggered, that grab confines all compositor input to its own window: the
+    // selector renders on top (Overlay layer) but receives no clicks or keys and
+    // appears frozen until the other surface is dismissed. Adding the selector to
+    // the grab's window list routes input to it too, and Exclusive keyboard focus
+    // ensures Escape/keys reach the selector while it is up.
+    Component.onCompleted: GlobalFocusGrab.addDismissable(root)
+    Component.onDestruction: GlobalFocusGrab.removeDismissable(root)
 
     // Modes
     // TODO: Ask: sidebar AI


### PR DESCRIPTION
if you open the region snip while the overview is open it just freezes. you can see it drawn on top but clicks go straight through to the app grid underneath and nothing happens until you close the grid.

turns out the overview is holding the shared focusgrab so all input is locked to its window. the region selector never adds itself to the grab so it gets nothing even tho its sitting on the overlay layer above everything.

fix is just having it join the grab while its open:

```qml
Component.onCompleted: GlobalFocusGrab.addDismissable(root)
Component.onDestruction: GlobalFocusGrab.removeDismissable(root)
```

also bumped keyboardFocus to Exclusive so escape reaches it. tested on hyprland, open the grid then hit snip and it works now, grid still underneath.