### PR TITLE
fix(bar): anchor scroll hint tooltip away from the bar edge

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ScrollHint.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ScrollHint.qml
@@ -1,6 +1,7 @@
 import qs.modules.common
 import qs.modules.common.widgets
 import QtQuick
+import Quickshell
 
 Revealer { // Scroll hint
     id: root
@@ -32,6 +33,9 @@ Revealer { // Scroll hint
         PopupToolTip {
             extraVisibleCondition: (tooltipText.length > 0 && mouseArea.showHintTimedOut)
             text: tooltipText
+            anchorEdges: Config.options.bar.bottom ? Edges.Top : Edges.Bottom
+            anchorGravity: anchorEdges
+            verticalMargin: 8
         }
 
         Column {


### PR DESCRIPTION
the tooltip on the scroll hints (volume/brightness edges) was using the default anchor so on a top bar it tries to pop upward off screen and just flickers when you hover.

made it anchor toward the inside of the screen depending on where the bar is, plus a tiny margin so it isnt glued to the edge.

```qml
anchorEdges: Config.options.bar.bottom ? Edges.Top : Edges.Bottom
anchorGravity: anchorEdges
verticalMargin: 8
```

tested on a top bar, no more flicker and the tooltip shows below the hint like youd expect.