### PR TITLE
Feat/video wallpaper selector and implementation

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/ThumbnailImage.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/ThumbnailImage.qml
@@ -38,12 +38,20 @@ StyledImage {
         thumbnailGeneration.running = false;
         thumbnailGeneration.running = true;
     }
+    readonly property bool isVideoSource: /\.(mp4|webm|mkv|avi|mov)$/i.test(root.sourcePath)
     Process {
         id: thumbnailGeneration
         command: {
             const maxSize = Images.thumbnailSizes[root.thumbnailSizeName];
-            return ["bash", "-c", 
-                `[ -f '${FileUtils.trimFileProtocol(root.thumbnailPath)}' ] && exit 0 || { magick '${root.sourcePath}' -resize ${maxSize}x${maxSize} '${FileUtils.trimFileProtocol(root.thumbnailPath)}' && exit 1; }`
+            const thumbPath = FileUtils.trimFileProtocol(root.thumbnailPath);
+            const srcPath = root.sourcePath;
+            if (root.isVideoSource) {
+                return ["bash", "-c",
+                    `[ -f '${thumbPath}' ] && exit 0 || { ffmpeg -y -i '${srcPath}' -vframes 1 -vf "scale=${maxSize}:${maxSize}:force_original_aspect_ratio=decrease" '${thumbPath}' 2>/dev/null && exit 1; }`
+                ];
+            }
+            return ["bash", "-c",
+                `[ -f '${thumbPath}' ] && exit 0 || { magick '${srcPath}' -resize ${maxSize}x${maxSize} '${thumbPath}' && exit 1; }`
             ]
         }
         onExited: (exitCode, exitStatus) => {

--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
@@ -10,7 +10,8 @@ MouseArea {
     id: root
     required property var fileModelData
     property bool isDirectory: fileModelData.fileIsDir
-    property bool useThumbnail: Images.isValidImageByName(fileModelData.fileName)
+    property bool isVideo: /\.(mp4|webm|mkv|avi|mov)$/i.test(fileModelData.fileName)
+    property bool useThumbnail: Images.isValidImageByName(fileModelData.fileName) || isVideo
 
     property alias colBackground: background.color
     property alias colText: wallpaperItemName.color
@@ -96,11 +97,29 @@ MouseArea {
 
                 Loader {
                     id: iconLoader
-                    active: !root.useThumbnail
+                    active: !root.useThumbnail && !root.isVideo
                     anchors.fill: parent
-                    sourceComponent: DirectoryIcon {
-                        fileModelData: root.fileModelData
+                    sourceComponent: MaterialSymbol {
+                        anchors.centerIn: parent
+                        iconSize: 64
+                        text: root.isDirectory ? "folder" : "description"
+                        fill: 1
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        color: Appearance.colors.colOnLayer0
+                        opacity: 0.5
                     }
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    font.pixelSize: 28
+                    text: "▶"
+                    color: "#ffffff"
+                    style: Text.Raised
+                    styleColor: "#000000"
+                    opacity: 0.7
+                    visible: root.isVideo
                 }
             }
 

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -125,7 +125,7 @@ create_restore_script() {
 pkill -f -9 mpvpaper
 
 for monitor in \$(hyprctl monitors -j | jq -r '.[] | .name'); do
-    mpvpaper -o "$VIDEO_OPTS" "\$monitor" "$video_path" &
+    nohup mpvpaper -o "$VIDEO_OPTS" "\$monitor" "$video_path" >/dev/null 2>&1 &
     sleep 0.1
 done
 EOF
@@ -230,7 +230,7 @@ switch() {
             local video_path="$imgpath"
             monitors=$(hyprctl monitors -j | jq -r '.[] | .name')
             for monitor in $monitors; do
-                mpvpaper -o "$VIDEO_OPTS" "$monitor" "$video_path" &
+                nohup mpvpaper -o "$VIDEO_OPTS" "$monitor" "$video_path" >/dev/null 2>&1 &
                 sleep 0.1
             done
 

--- a/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
+++ b/dots/.config/quickshell/ii/scripts/thumbnails/generate-thumbnails-magick.sh
@@ -47,12 +47,6 @@ generate_thumbnail() {
     local src="$1"
     local abs_path
     abs_path="$(realpath "$src")"
-    # Skip files with multiple frames (GIFs, videos, etc.)
-    case "${abs_path,,}" in
-        *.gif|*.mp4|*.webm|*.mkv|*.avi|*.mov)
-            return
-            ;;
-    esac
     local encoded_path
     encoded_path="$(urlencode "$abs_path")"
     local uri
@@ -64,7 +58,17 @@ generate_thumbnail() {
     if [ -f "$out" ]; then
         return
     fi
-    magick "$abs_path" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" "$out"
+    case "${abs_path,,}" in
+        *.mp4|*.webm|*.mkv|*.avi|*.mov)
+            ffmpeg -y -i "$abs_path" -vframes 1 -vf "scale=${THUMBNAIL_SIZE}:${THUMBNAIL_SIZE}:force_original_aspect_ratio=decrease" "$out" 2>/dev/null
+            ;;
+        *.gif)
+            magick "$abs_path" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" "$out"
+            ;;
+        *)
+            magick "$abs_path" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" "$out"
+            ;;
+    esac
 }
 
 # Parse arguments

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -22,9 +22,11 @@ Singleton {
     property url defaultFolder: Qt.resolvedUrl(`${Directories.pictures}/Wallpapers`)
     property alias folderModel: folderModel // Expose for direct binding when needed
     property string searchQuery: ""
-    readonly property list<string> extensions: [ // TODO: add videos
-        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg"
+    readonly property list<string> extensions: [
+        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg",
+        "mp4", "webm", "mkv", "avi", "mov"
     ]
+    readonly property list<string> videoExtensions: ["mp4", "webm", "mkv", "avi", "mov"]
     property list<string> wallpapers: [] // List of absolute file paths (without file://)
     readonly property bool thumbnailGenerationRunning: thumbgenProc.running
     property real thumbnailGenerationProgress: 0

--- a/sdata/deps-info.md
+++ b/sdata/deps-info.md
@@ -194,7 +194,9 @@ Tips:
 - `libqalculate`
   - Used in Quickshell config, providing math ability in searchbar.
   - Note that `qalc` is the needed executable. In Arch Linux [libqalculate](https://archlinux.org/packages/extra/x86_64/libqalculate) provides it, but in Fedora [qalculate](https://packages.fedoraproject.org/pkgs/libqalculate/qalculate/fedora-43.html#files) does and [libqalculate](https://packages.fedoraproject.org/pkgs/libqalculate/libqalculate/fedora-43.html#files) does not.
-
+- `mpvpaper`
+  - Used for rendering video wallpapers with mpv on Wayland.
+  - Depends on `mpv` and `ffmpeg` (ffmpeg also used for video thumbnail generation).
 
 # Actual packages
 ## illogical-impulse-quickshell-git

--- a/sdata/dist-arch/illogical-impulse-widgets/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-widgets/PKGBUILD
@@ -1,17 +1,19 @@
 groups=(illogical-impulse)
 pkgname=illogical-impulse-widgets
 pkgver=1.0
-pkgrel=7
+pkgrel=8
 pkgdesc='Illogical Impulse Widget Dependencies'
 arch=(any)
 license=(None)
 depends=(
   fuzzel
+  ffmpeg
   glib2
   imagemagick
   hypridle
   hyprlock
   hyprpicker
+  mpvpaper
   songrec
   translate-shell
   wlogout


### PR DESCRIPTION
## Describe your changes

I just noticed that I'm not able to use a video as a wallpaper, I checked other opened pull request and the code and found out its commented as a Todo.
So then I just implemented the following Changes:

- Adds mp4/webm/mkv/avi/mov support to the wallpaper selector
- Generates video thumbnails via ffmpeg instead of imagemagick (as that did not work for me)
- Shows a play overlay on video items
- Replaces DirectoryIcon with MaterialSymbol for reliable icons (as for some reason I was not able to see folder icons in selector)
- Adds mpvpaper + ffmpeg to Arch PKGBUILD
- Wraps mpvpaper with nohup to prevent 50/50 application failure

## Is it ready? Questions/feedback needed?

Yes, tested and working locally on my both setups, I did not do Gifs -only real videos- , I tested with a bunch of different videos and videos format

https://github.com/user-attachments/assets/cfab0915-23d4-4cb7-9b1f-1374439495a5


