### PR TITLE
feat(quickshell): add custom widgets (audio visualizer, stats, system…

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -209,6 +209,31 @@ Singleton {
                         property real x: 400
                         property real y: 100
                     }
+                    property JsonObject visualizer: JsonObject {
+                        property bool enable: false
+                        property string placementStrategy: "free"
+                        property real x: 500
+                        property real y: 500
+                        property int bars: 30
+                        property string style: "bars"
+                        property bool vertical: false
+                    }
+                    property JsonObject stats: JsonObject {
+                        property bool enable: false
+                        property string placementStrategy: "free"
+                        property real x: 150
+                        property real y: 300
+                        property string githubUsername: ""
+                        property string codeforcesUsername: ""
+                        property bool showGraphs: false
+                    }
+                    property JsonObject systemResources: JsonObject {
+                        property bool enable: false
+                        property string placementStrategy: "free"
+                        property real x: 150
+                        property real y: 600
+                        property bool showGraphs: false
+                    }
                 }
                 property string wallpaperPath: ""
                 property string thumbnailPath: ""

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -17,6 +17,9 @@ import Quickshell.Hyprland
 import qs.modules.ii.background.widgets
 import qs.modules.ii.background.widgets.clock
 import qs.modules.ii.background.widgets.weather
+import qs.modules.ii.background.widgets.visualizer
+import qs.modules.ii.background.widgets.stats
+import qs.modules.ii.background.widgets.resources
 
 Variants {
     id: root
@@ -274,6 +277,31 @@ Variants {
                         scaledScreenHeight: bgRoot.screen.height
                         wallpaperScale: 1
                         wallpaperSafetyTriggered: bgRoot.wallpaperSafetyTriggered
+                    }
+                }
+
+                FadeLoader {
+                    shown: Config.options.background.widgets.visualizer.enable
+                    sourceComponent: VisualizerWidget {
+                        screenWidth: bgRoot.screen.width; screenHeight: bgRoot.screen.height
+                        scaledScreenWidth: bgRoot.screen.width; scaledScreenHeight: bgRoot.screen.height
+                        wallpaperScale: 1
+                    }
+                }
+                FadeLoader {
+                    shown: Config.options.background.widgets.stats.enable
+                    sourceComponent: StatsWidget {
+                        screenWidth: bgRoot.screen.width; screenHeight: bgRoot.screen.height
+                        scaledScreenWidth: bgRoot.screen.width; scaledScreenHeight: bgRoot.screen.height
+                        wallpaperScale: 1
+                    }
+                }
+                FadeLoader {
+                    shown: Config.options.background.widgets.systemResources.enable
+                    sourceComponent: SystemResourcesWidget {
+                        screenWidth: bgRoot.screen.width; screenHeight: bgRoot.screen.height
+                        scaledScreenWidth: bgRoot.screen.width; scaledScreenHeight: bgRoot.screen.height
+                        wallpaperScale: 1
                     }
                 }
             }

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/resources/SystemResourcesWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/resources/SystemResourcesWidget.qml
@@ -1,0 +1,141 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.functions
+import qs.modules.common.widgets
+import qs.modules.common.widgets.widgetCanvas
+import qs.modules.ii.background.widgets
+
+AbstractBackgroundWidget {
+    id: root
+    configEntryName: "systemResources"
+    implicitHeight: backgroundShape.implicitHeight
+    implicitWidth: backgroundShape.implicitWidth
+
+    property bool showGraphs: Config.options.background.widgets.systemResources.showGraphs || false
+    property int maxHistory: ResourceUsage.historyLength
+    property var gpuUsageHistory: []
+    property real currentGpuUsage: 0
+
+    Component.onCompleted: {
+        var arr = [];
+        for (var i = 0; i < maxHistory; i++) arr.push(0);
+        gpuUsageHistory = arr;
+    }
+
+    Timer { interval: 3000; running: true; repeat: true; triggeredOnStart: true; onTriggered: gpuProcess.running = true }
+
+    Process {
+        id: gpuProcess
+        running: false
+        command: ["bash", "-c",
+            "if command -v nvidia-smi &>/dev/null; then nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits; " +
+            "elif [ -f /sys/class/drm/card0/device/gpu_busy_percent ]; then cat /sys/class/drm/card0/device/gpu_busy_percent; " +
+            "else echo 0; fi"]
+        stdout: SplitParser {
+            onRead: (line) => {
+                var v = parseFloat(line.trim());
+                if (!isNaN(v)) {
+                    root.currentGpuUsage = v;
+                    var arr = [...root.gpuUsageHistory, v/100.0];
+                    if (arr.length > root.maxHistory) arr.shift();
+                    root.gpuUsageHistory = arr;
+                }
+            }
+        }
+    }
+
+    StyledDropShadow { target: backgroundShape }
+
+    Rectangle {
+        id: backgroundShape
+        anchors.fill: parent
+        radius: Appearance.rounding.windowRounding
+        color: Appearance.colors.colPrimaryContainer
+        implicitWidth: 350
+        implicitHeight: contentCol.implicitHeight + 40
+
+        Column {
+            id: contentCol
+            anchors.centerIn: parent
+            spacing: 20
+            width: parent.width - 40
+
+            Row {
+                spacing: 15
+                MaterialSymbol { iconSize: 32; color: Appearance.colors.colOnPrimaryContainer; text: "memory"; anchors.verticalCenter: parent.verticalCenter }
+                StyledText { font.pixelSize: 18; font.weight: Font.Bold; color: Appearance.colors.colOnPrimaryContainer; text: "System Resources"; anchors.verticalCenter: parent.verticalCenter }
+            }
+
+            Row {
+                spacing: 30
+                anchors.horizontalCenter: parent.horizontalCenter
+                Column {
+                    StyledText { text: "CPU"; font.pixelSize: 12; color: Appearance.colors.colPrimary }
+                    StyledText { text: Math.round(ResourceUsage.cpuUsage * 100) + "%"; font.pixelSize: 18; color: Appearance.colors.colOnPrimaryContainer; font.weight: Font.Bold }
+                }
+                Column {
+                    StyledText { text: "RAM"; font.pixelSize: 12; color: Appearance.colors.colPrimary }
+                    StyledText { text: Math.round(ResourceUsage.memoryUsedPercentage * 100) + "%"; font.pixelSize: 18; color: Appearance.colors.colOnPrimaryContainer; font.weight: Font.Bold }
+                }
+                Column {
+                    StyledText { text: "GPU"; font.pixelSize: 12; color: Appearance.colors.colPrimary }
+                    StyledText { text: Math.round(root.currentGpuUsage) + "%"; font.pixelSize: 18; color: Appearance.colors.colOnPrimaryContainer; font.weight: Font.Bold }
+                }
+            }
+
+            Canvas {
+                id: graphCanvas
+                width: parent.width; height: 100; visible: root.showGraphs
+                onPaint: {
+                    var ctx = getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
+
+                    function drawSmooth(arr, color) {
+                        if (!arr || arr.length < 2) return;
+                        ctx.beginPath();
+                        ctx.strokeStyle = color; ctx.lineWidth = 2;
+                        ctx.lineCap = "round"; ctx.lineJoin = "round";
+                        var n = arr.length, step = width/(n-1);
+                        ctx.moveTo(0, height - arr[0]*(height-4) - 2);
+                        for (var i=1; i<n; i++) {
+                            var cpx = ((i-1)*step + i*step)/2;
+                            var py = height - arr[i-1]*(height-4) - 2;
+                            var cy = height - arr[i]*(height-4) - 2;
+                            ctx.bezierCurveTo(cpx, py, cpx, cy, i*step, cy);
+                        }
+                        ctx.stroke();
+                    }
+
+                    drawSmooth(root.gpuUsageHistory, Appearance.colors.colError);
+                    drawSmooth(ResourceUsage.memoryUsageHistory, Appearance.colors.colSecondary);
+                    drawSmooth(ResourceUsage.cpuUsageHistory, Appearance.colors.colPrimary);
+                }
+                Timer { interval: 1000; running: root.showGraphs; repeat: true; onTriggered: parent.requestPaint() }
+
+                Row {
+                    anchors.top: parent.bottom; anchors.topMargin: 5
+                    anchors.horizontalCenter: parent.horizontalCenter; spacing: 15
+                    Repeater {
+                        model: [
+                            { label: "CPU",  color: Appearance.colors.colPrimary },
+                            { label: "RAM",  color: Appearance.colors.colSecondary },
+                            { label: "GPU",  color: Appearance.colors.colError }
+                        ]
+                        Row {
+                            spacing: 5
+                            required property var modelData
+                            Rectangle { width: 10; height: 10; radius: 5; color: modelData.color; anchors.verticalCenter: parent.verticalCenter }
+                            StyledText { text: modelData.label; font.pixelSize: 10; color: Appearance.colors.colOnPrimaryContainer }
+                        }
+                    }
+                }
+            }
+
+            Item { width: 1; height: root.showGraphs ? 20 : 0 }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/stats/StatsWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/stats/StatsWidget.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.functions
+import qs.modules.common.widgets
+import qs.modules.common.widgets.widgetCanvas
+import qs.modules.ii.background.widgets
+
+AbstractBackgroundWidget {
+    id: root
+    configEntryName: "stats"
+    implicitHeight: backgroundShape.implicitHeight
+    implicitWidth: backgroundShape.implicitWidth
+
+    property string githubUsername: Config.options.background.widgets.stats.githubUsername
+    property string codeforcesUsername: Config.options.background.widgets.stats.codeforcesUsername
+    property bool showGraphs: Config.options.background.widgets.stats.showGraphs || false
+
+    property int ghFollowers: 0
+    property int ghRepos: 0
+    property string cfRank: "--"
+    property int cfRating: 0
+    property var githubActivityArray: []
+    property var cfActivityArray: []
+    property int maxGithubActivity: 1
+    property int maxCfActivity: 1
+
+    function fetchGithub() {
+        if (!githubUsername) return;
+        var req = new XMLHttpRequest();
+        req.onreadystatechange = function() {
+            if (req.readyState === 4 && req.status === 200) {
+                var data = JSON.parse(req.responseText);
+                ghFollowers = data.followers || 0;
+                ghRepos = data.public_repos || 0;
+            }
+        }
+        req.open("GET", "https://api.github.com/users/" + githubUsername, true);
+        req.send();
+
+        if (showGraphs) {
+            var ereq = new XMLHttpRequest();
+            ereq.onreadystatechange = function() {
+                if (ereq.readyState !== 4 || ereq.status !== 200) return;
+                var events = JSON.parse(ereq.responseText);
+                var bins = new Array(30).fill(0), maxV = 0, now = new Date();
+                for (var i = 0; i < events.length; i++) {
+                    var d = Math.floor(Math.abs(now - new Date(events[i].created_at)) / 86400000);
+                    if (d < 30) { bins[29-d]++; if (bins[29-d] > maxV) maxV = bins[29-d]; }
+                }
+                maxGithubActivity = Math.max(1, maxV);
+                githubActivityArray = bins;
+            }
+            ereq.open("GET", "https://api.github.com/users/" + githubUsername + "/events/public?per_page=100", true);
+            ereq.send();
+        }
+    }
+
+    function fetchCodeforces() {
+        if (!codeforcesUsername) return;
+        var req = new XMLHttpRequest();
+        req.onreadystatechange = function() {
+            if (req.readyState === 4 && req.status === 200) {
+                var data = JSON.parse(req.responseText);
+                if (data.status === "OK" && data.result.length > 0) {
+                    cfRank = data.result[0].rank || "--";
+                    cfRating = data.result[0].rating || 0;
+                }
+            }
+        }
+        req.open("GET", "https://codeforces.com/api/user.info?handles=" + codeforcesUsername, true);
+        req.send();
+
+        if (showGraphs) {
+            var sreq = new XMLHttpRequest();
+            sreq.onreadystatechange = function() {
+                if (sreq.readyState !== 4 || sreq.status !== 200) return;
+                var data = JSON.parse(sreq.responseText);
+                if (data.status !== "OK") return;
+                var bins = new Array(30).fill(0), maxV = 0, nowS = Date.now()/1000;
+                for (var i = 0; i < data.result.length; i++) {
+                    var d = Math.floor((nowS - data.result[i].creationTimeSeconds) / 86400);
+                    if (d < 30) { bins[29-d]++; if (bins[29-d] > maxV) maxV = bins[29-d]; }
+                }
+                maxCfActivity = Math.max(1, maxV);
+                cfActivityArray = bins;
+            }
+            sreq.open("GET", "https://codeforces.com/api/user.status?handle=" + codeforcesUsername + "&from=1&count=200", true);
+            sreq.send();
+        }
+    }
+
+    Timer { interval: 600000; running: true; repeat: true; triggeredOnStart: true; onTriggered: { fetchGithub(); fetchCodeforces(); } }
+    onGithubUsernameChanged: fetchGithub()
+    onCodeforcesUsernameChanged: fetchCodeforces()
+    onShowGraphsChanged: { if (showGraphs) { fetchGithub(); fetchCodeforces(); } }
+
+    StyledDropShadow { target: backgroundShape }
+
+    Rectangle {
+        id: backgroundShape
+        anchors.fill: parent
+        radius: Appearance.rounding.windowRounding
+        color: Appearance.colors.colPrimaryContainer
+        implicitWidth: 320
+        implicitHeight: contentCol.implicitHeight + 40
+
+        Column {
+            id: contentCol
+            anchors.centerIn: parent
+            spacing: 20
+            width: parent.width - 40
+
+            // GitHub
+            Row {
+                spacing: 15
+                MaterialSymbol { iconSize: 40; color: Appearance.colors.colOnPrimaryContainer; text: "code"; anchors.verticalCenter: parent.verticalCenter }
+                Column {
+                    StyledText { font.pixelSize: 18; font.weight: Font.Bold; color: Appearance.colors.colOnPrimaryContainer; text: "GitHub: " + (githubUsername || "Not set") }
+                    StyledText { font.pixelSize: 14; color: Appearance.colors.colPrimary; text: ghFollowers + " Followers  •  " + ghRepos + " Repos" }
+                }
+            }
+            Canvas {
+                width: parent.width; height: root.showGraphs ? 40 : 0; visible: root.showGraphs
+                onPaint: {
+                    var ctx = getContext("2d"); ctx.clearRect(0,0,width,height);
+                    var arr = root.githubActivityArray;
+                    if (!arr || arr.length < 2) return;
+                    ctx.beginPath(); ctx.strokeStyle = Appearance.colors.colSecondary;
+                    ctx.lineWidth = 2; ctx.lineCap = "round"; ctx.lineJoin = "round";
+                    var step = width/(arr.length-1);
+                    ctx.moveTo(0, height - (arr[0]/root.maxGithubActivity)*(height-4)-2);
+                    for(var i=1;i<arr.length;i++){
+                        var cpx=((i-1)*step+i*step)/2;
+                        var py=height-(arr[i-1]/root.maxGithubActivity)*(height-4)-2;
+                        var cy=height-(arr[i]/root.maxGithubActivity)*(height-4)-2;
+                        ctx.bezierCurveTo(cpx,py,cpx,cy,i*step,cy);
+                    }
+                    ctx.stroke();
+                }
+                Timer { interval: 1000; running: root.showGraphs; repeat: true; onTriggered: parent.requestPaint() }
+            }
+
+            // Codeforces
+            Row {
+                spacing: 15
+                MaterialSymbol { iconSize: 40; color: Appearance.colors.colOnPrimaryContainer; text: "bar_chart"; anchors.verticalCenter: parent.verticalCenter }
+                Column {
+                    StyledText { font.pixelSize: 18; font.weight: Font.Bold; color: Appearance.colors.colOnPrimaryContainer; text: "Codeforces: " + (codeforcesUsername || "Not set") }
+                    StyledText { font.pixelSize: 14; color: Appearance.colors.colPrimary; text: "Rating: " + cfRating + "  •  " + cfRank }
+                }
+            }
+            Canvas {
+                width: parent.width; height: root.showGraphs ? 40 : 0; visible: root.showGraphs
+                onPaint: {
+                    var ctx = getContext("2d"); ctx.clearRect(0,0,width,height);
+                    var arr = root.cfActivityArray;
+                    if (!arr || arr.length < 2) return;
+                    ctx.beginPath(); ctx.strokeStyle = Appearance.colors.colError;
+                    ctx.lineWidth = 2; ctx.lineCap = "round"; ctx.lineJoin = "round";
+                    var step = width/(arr.length-1);
+                    ctx.moveTo(0, height - (arr[0]/root.maxCfActivity)*(height-4)-2);
+                    for(var i=1;i<arr.length;i++){
+                        var cpx=((i-1)*step+i*step)/2;
+                        var py=height-(arr[i-1]/root.maxCfActivity)*(height-4)-2;
+                        var cy=height-(arr[i]/root.maxCfActivity)*(height-4)-2;
+                        ctx.bezierCurveTo(cpx,py,cpx,cy,i*step,cy);
+                    }
+                    ctx.stroke();
+                }
+                Timer { interval: 1000; running: root.showGraphs; repeat: true; onTriggered: parent.requestPaint() }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/visualizer/VisualizerWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/visualizer/VisualizerWidget.qml
@@ -1,0 +1,197 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.functions
+import qs.modules.common.widgets
+import qs.modules.common.widgets.widgetCanvas
+import qs.modules.ii.background.widgets
+
+AbstractBackgroundWidget {
+    id: root
+    configEntryName: "visualizer"
+    implicitHeight: backgroundShape.implicitHeight
+    implicitWidth: backgroundShape.implicitWidth
+
+    property int numBars: {
+        // cava requires even bar count in stereo mode — force even
+        var raw = Config.options.background.widgets.visualizer.bars;
+        return raw % 2 === 0 ? raw : raw + 1;
+    }
+    property bool isVertical: Config.options.background.widgets.visualizer.vertical
+    property string style: Config.options.background.widgets.visualizer.style
+    property var amplitudeArray: []
+    property bool cavaReady: false
+
+    // Cava config path — /tmp is cleared on reboot, we always regenerate it
+    readonly property string cavaConfigPath: "/tmp/quickshell_cava_config"
+
+    function buildCavaConfig() {
+        return "[general]\nbars = " + root.numBars + "\nchannels = mono\n" +
+               "[output]\nmethod = raw\nraw_target = /dev/stdout\n" +
+               "data_format = ascii\nascii_max_range = 100\n";
+    }
+
+    // Watchdog: every 2s, if cava isn't running, write config and start it
+    Timer {
+        id: watchdog
+        interval: 2000
+        running: true
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: {
+            if (!cavaProcess.running) {
+                root.cavaReady = false;
+                writeConfigProcess.running = false;
+                writeConfigProcess.running = true;
+            }
+        }
+    }
+
+    // Step 1: Write the cava config to /tmp
+    Process {
+        id: writeConfigProcess
+        running: false
+        command: ["bash", "-c",
+            "printf '%s' '" + root.buildCavaConfig().replace(/'/g, "'\\''") + "' > " + root.cavaConfigPath]
+        onExited: (code) => {
+            if (code === 0) startDelay.start();
+        }
+    }
+
+    Timer {
+        id: startDelay
+        interval: 100
+        repeat: false
+        onTriggered: {
+            cavaProcess.running = true;
+            root.cavaReady = true;
+        }
+    }
+
+    // Step 2: Run cava, read its ascii stdout
+    Process {
+        id: cavaProcess
+        running: false
+        command: ["cava", "-p", root.cavaConfigPath]
+        stdout: SplitParser {
+            onRead: (line) => {
+                var vals = line.split(';')
+                    .map(s => parseInt(s, 10))
+                    .filter(v => !isNaN(v) && v >= 0);
+                if (vals.length > 0) root.amplitudeArray = vals;
+            }
+        }
+        onRunningChanged: {
+            if (!running) root.cavaReady = false;
+        }
+    }
+
+    // When bar count changes, restart cava with new config
+    onNumBarsChanged: {
+        cavaProcess.running = false;
+        writeConfigProcess.running = false;
+        writeConfigProcess.running = true;
+        var arr = [];
+        for (let i = 0; i < numBars; i++) arr.push(0);
+        amplitudeArray = arr;
+    }
+
+    Rectangle {
+        id: backgroundShape
+        anchors.fill: parent
+        color: "transparent"
+        implicitWidth:  isVertical ? 200 : (root.numBars * 10 + 40)
+        implicitHeight: isVertical ? (root.numBars * 10 + 40) : 200
+
+        Item {
+            anchors.fill: parent
+            anchors.margins: 20
+
+            // Horizontal base line
+            Rectangle {
+                visible: !isVertical
+                color: Appearance.colors.colPrimary
+                height: 4; width: parent.width
+                anchors.bottom: parent.bottom
+                radius: 2
+            }
+            // Vertical base line
+            Rectangle {
+                visible: isVertical
+                color: Appearance.colors.colPrimary
+                width: 4; height: parent.height
+                anchors.left: parent.left
+                radius: 2
+            }
+
+            // Horizontal bars
+            Row {
+                anchors.fill: parent; spacing: 4
+                visible: !isVertical && root.style === "bars"
+                Repeater {
+                    model: root.amplitudeArray
+                    Rectangle {
+                        required property int modelData
+                        width: Math.max(1, parent.width / root.amplitudeArray.length - parent.spacing)
+                        height: Math.max(2, (modelData / 100) * parent.height)
+                        anchors.bottom: parent.bottom
+                        color: Appearance.colors.colPrimary; radius: 2
+                        Behavior on height { NumberAnimation { duration: 60; easing.type: Easing.OutSine } }
+                    }
+                }
+            }
+
+            // Vertical bars
+            Column {
+                anchors.fill: parent; spacing: 4
+                visible: isVertical && root.style === "bars"
+                Repeater {
+                    model: root.amplitudeArray
+                    Rectangle {
+                        required property int modelData
+                        height: Math.max(1, parent.height / root.amplitudeArray.length - parent.spacing)
+                        width: Math.max(2, (modelData / 100) * parent.width)
+                        anchors.left: parent.left
+                        color: Appearance.colors.colPrimary; radius: 2
+                        Behavior on width { NumberAnimation { duration: 60; easing.type: Easing.OutSine } }
+                    }
+                }
+            }
+
+            // Wave — smooth bezier curve
+            Canvas {
+                anchors.fill: parent
+                visible: root.style === "wave"
+                onPaint: {
+                    var ctx = getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
+                    var arr = root.amplitudeArray;
+                    if (arr.length < 2) return;
+                    ctx.beginPath();
+                    ctx.strokeStyle = Appearance.colors.colPrimary;
+                    ctx.lineWidth = 4; ctx.lineCap = "round"; ctx.lineJoin = "round";
+                    if (!isVertical) {
+                        var stepX = width / (arr.length - 1);
+                        ctx.moveTo(0, height - (arr[0]/100)*height);
+                        for(var i=1; i<arr.length; i++) {
+                            var cpx = ((i-1)*stepX + i*stepX) / 2;
+                            ctx.bezierCurveTo(cpx, height-(arr[i-1]/100)*height, cpx, height-(arr[i]/100)*height, i*stepX, height-(arr[i]/100)*height);
+                        }
+                    } else {
+                        var stepY = height / (arr.length - 1);
+                        ctx.moveTo((arr[0]/100)*width, 0);
+                        for(var j=1; j<arr.length; j++) {
+                            var cpy = ((j-1)*stepY + j*stepY) / 2;
+                            ctx.bezierCurveTo((arr[j-1]/100)*width, cpy, (arr[j]/100)*width, cpy, (arr[j]/100)*width, j*stepY);
+                        }
+                    }
+                    ctx.stroke();
+                }
+                Timer { interval: 33; running: root.style === "wave"; repeat: true; onTriggered: parent.requestPaint() }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -614,4 +614,144 @@ ContentPage {
             }
         }
     }
+
+    ContentSection {
+        icon: "equalizer"
+        title: Translation.tr("Widget: Audio Visualizer")
+
+        ConfigRow {
+            Layout.fillWidth: true
+            ConfigSwitch {
+                Layout.fillWidth: false
+                buttonIcon: "check"
+                text: Translation.tr("Enable")
+                checked: Config.options.background.widgets.visualizer.enable
+                onCheckedChanged: { Config.options.background.widgets.visualizer.enable = checked; }
+            }
+            Item { Layout.fillWidth: true }
+            ConfigSelectionArray {
+                Layout.fillWidth: false
+                currentValue: Config.options.background.widgets.visualizer.placementStrategy
+                onSelected: newValue => { Config.options.background.widgets.visualizer.placementStrategy = newValue; }
+                options: [
+                    { displayName: Translation.tr("Draggable"), icon: "drag_pan", value: "free" },
+                    { displayName: Translation.tr("Least busy"), icon: "category", value: "leastBusy" },
+                    { displayName: Translation.tr("Most busy"), icon: "shapes", value: "mostBusy" },
+                ]
+            }
+        }
+        ConfigRow {
+            uniform: true
+            ConfigSwitch {
+                buttonIcon: "vertical_distribute"
+                text: Translation.tr("Vertical")
+                checked: Config.options.background.widgets.visualizer.vertical
+                onCheckedChanged: { Config.options.background.widgets.visualizer.vertical = checked; }
+            }
+        }
+        ConfigSelectionArray {
+            currentValue: Config.options.background.widgets.visualizer.style
+            onSelected: newValue => { Config.options.background.widgets.visualizer.style = newValue; }
+            options: [
+                { displayName: Translation.tr("Bars"), icon: "bar_chart", value: "bars" },
+                { displayName: Translation.tr("Wave"), icon: "water", value: "wave" }
+            ]
+        }
+        ConfigSpinBox {
+            icon: "add_chart"
+            text: Translation.tr("Bars")
+            value: Config.options.background.widgets.visualizer.bars
+            from: 10; to: 100; stepSize: 1
+            onValueChanged: { Config.options.background.widgets.visualizer.bars = value; }
+        }
+    }
+
+    ContentSection {
+        icon: "query_stats"
+        title: Translation.tr("Widget: Stats (GitHub & Codeforces)")
+
+        ConfigRow {
+            Layout.fillWidth: true
+            ConfigSwitch {
+                Layout.fillWidth: false
+                buttonIcon: "check"
+                text: Translation.tr("Enable")
+                checked: Config.options.background.widgets.stats.enable
+                onCheckedChanged: { Config.options.background.widgets.stats.enable = checked; }
+            }
+            Item { Layout.fillWidth: true }
+            ConfigSelectionArray {
+                Layout.fillWidth: false
+                currentValue: Config.options.background.widgets.stats.placementStrategy
+                onSelected: newValue => { Config.options.background.widgets.stats.placementStrategy = newValue; }
+                options: [
+                    { displayName: Translation.tr("Draggable"), icon: "drag_pan", value: "free" },
+                    { displayName: Translation.tr("Least busy"), icon: "category", value: "leastBusy" },
+                    { displayName: Translation.tr("Most busy"), icon: "shapes", value: "mostBusy" },
+                ]
+            }
+        }
+        ConfigRow {
+            uniform: true
+            ConfigSwitch {
+                buttonIcon: "show_chart"
+                text: Translation.tr("Show Graphs")
+                checked: Config.options.background.widgets.stats.showGraphs
+                onCheckedChanged: { Config.options.background.widgets.stats.showGraphs = checked; }
+            }
+        }
+        ContentSubsection {
+            title: Translation.tr("Usernames")
+            MaterialTextArea {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("GitHub Username")
+                text: Config.options.background.widgets.stats.githubUsername
+                wrapMode: TextEdit.Wrap
+                onTextChanged: { Config.options.background.widgets.stats.githubUsername = text; }
+            }
+            MaterialTextArea {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("Codeforces Username")
+                text: Config.options.background.widgets.stats.codeforcesUsername
+                wrapMode: TextEdit.Wrap
+                onTextChanged: { Config.options.background.widgets.stats.codeforcesUsername = text; }
+            }
+        }
+    }
+
+    ContentSection {
+        icon: "memory"
+        title: Translation.tr("Widget: System Resources")
+
+        ConfigRow {
+            Layout.fillWidth: true
+            ConfigSwitch {
+                Layout.fillWidth: false
+                buttonIcon: "check"
+                text: Translation.tr("Enable")
+                checked: Config.options.background.widgets.systemResources.enable
+                onCheckedChanged: { Config.options.background.widgets.systemResources.enable = checked; }
+            }
+            Item { Layout.fillWidth: true }
+            ConfigSelectionArray {
+                Layout.fillWidth: false
+                currentValue: Config.options.background.widgets.systemResources.placementStrategy
+                onSelected: newValue => { Config.options.background.widgets.systemResources.placementStrategy = newValue; }
+                options: [
+                    { displayName: Translation.tr("Draggable"), icon: "drag_pan", value: "free" },
+                    { displayName: Translation.tr("Least busy"), icon: "category", value: "leastBusy" },
+                    { displayName: Translation.tr("Most busy"), icon: "shapes", value: "mostBusy" },
+                ]
+            }
+        }
+        ConfigRow {
+            uniform: true
+            ConfigSwitch {
+                buttonIcon: "show_chart"
+                text: Translation.tr("Show Smooth Graphs")
+                checked: Config.options.background.widgets.systemResources.showGraphs
+                onCheckedChanged: { Config.options.background.widgets.systemResources.showGraphs = checked; }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR introduces three new optional background widgets:
- **Audio Visualizer**: Highly customizable `cava`-based visualizer (supports "Bars" and "Wave" styles).
- **Stats Widget**: Displays GitHub and Codeforces statistics and 30-day activity trends.
- **System Resources**: Real-time CPU, RAM, and GPU monitoring with historical graphs.

## Implementation Details & `CONTRIBUTING.md` Compliance

- **No New Dependencies**: Reuses the already installed `cava` backend for the visualizer.
- **Zero Default Impact**: All widgets are strictly configured to `enable: false` by default. Out-of-the-box configuration remains completely untouched.
- **Dynamic Loading**: Widgets are lazily loaded using `FadeLoader` and the `shown` property. If disabled, their backend scripts (like data fetching and `cava` instances) will not consume any background resources.
- **Seamless Integration**: Fully configurable via the native `Settings -> Background` application menu.

## How to Test

1. Pull the branch locally.
2. Open the Quickshell Settings app -> **Background**.
3. Toggle the widgets on and configure them directly from the UI.

*(Please see attached screenshots below showing the new settings UI and active desktop widgets)*

https://github.com/user-attachments/assets/3a771d73-0b96-4a1c-8820-c74fcb1e0803
