### PR TITLE
Fixed keybindings for workspace movement

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -197,23 +197,29 @@ hl.bind("SUPER + P", hl.dsp.window.pin(), { description = "Window: Pin" })
 
 --#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
 for i = 1, 10 do
-    hl.bind("SUPER + ALT + " .. (i % 10), function()
-        hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
-    end, { description = "Window: Send to workspace " .. i })
+    hl.bind(
+        "SUPER + ALT + " .. (i % 10),
+        hl.dsp.window.move({ workspace = tostring(i) }),
+        { description = "Window: Send to workspace " .. i }
+    )
 end
 --# We also use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
--- for i = 1, 10 do
---     local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
---     hl.bind("SUPER + ALT + code:" .. numberkey[i], function()
---         hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
---     end)
--- end
+for i = 1, 10 do
+    local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
+
+    hl.bind(
+        "SUPER + ALT + code:" .. numberkey[i],
+        hl.dsp.window.move({ workspace = tostring(i) })
+    )
+end
 --# keypad numbers
 for i = 1, 10 do
     local numpadkey = { 87, 88, 89, 83, 84, 85, 79, 80, 81, 90 }
-    hl.bind("SUPER + ALT + code:" .. numpadkey[i], function()
-        hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
-    end)
+
+    hl.bind(
+        "SUPER + ALT + code:" .. numpadkey[i],
+        hl.dsp.window.move({ workspace = tostring(i) })
+    )
 end
 
 --# #/# bind = SUPER+SHIFT, Scroll ↑/↓,, -- Send to workspace left/right


### PR DESCRIPTION
Fixed the functionality of moving windows to workspaces using SUPER+ALT+Workspace Number to work as intended


