### PR TITLE
qs: make super hold search suppression configurable

### DIFF
--- a/dots/.config/quickshell/ii/GlobalStates.qml
+++ b/dots/.config/quickshell/ii/GlobalStates.qml
@@ -28,8 +28,30 @@ Singleton {
     property bool sessionOpen: false
     property bool superDown: false
     property bool superReleaseMightTrigger: true
+    property real superPressTime: 0
+    property real superLastPressDuration: -1
+    property real superLastReleaseTime: 0
     property bool wallpaperSelectorOpen: false
     property bool workspaceShowNumbers: false
+
+    function superPressDuration() {
+        const now = Date.now();
+        if (root.superPressTime > 0)
+            return now - root.superPressTime;
+        if (root.superLastReleaseTime > 0 && now - root.superLastReleaseTime < 250)
+            return root.superLastPressDuration;
+        return -1;
+    }
+
+    function shouldSuppressSuperReleaseSearch() {
+        const autoHide = Config?.options?.bar?.autoHide;
+        const showWhenPressingSuper = autoHide?.showWhenPressingSuper;
+        if (!autoHide?.enable || !showWhenPressingSuper?.enable || !showWhenPressingSuper?.suppressSearchOnHold)
+            return false;
+
+        const duration = root.superPressDuration();
+        return duration >= (showWhenPressingSuper?.suppressSearchDelay ?? showWhenPressingSuper?.delay ?? 140);
+    }
 
     onSidebarRightOpenChanged: {
         if (GlobalStates.sidebarRightOpen) {
@@ -44,8 +66,15 @@ Singleton {
 
         onPressed: {
             root.superDown = true
+            root.superPressTime = Date.now()
+            root.superLastPressDuration = -1
         }
         onReleased: {
+            const now = Date.now()
+            if (root.superPressTime > 0)
+                root.superLastPressDuration = now - root.superPressTime
+            root.superLastReleaseTime = now
+            root.superPressTime = 0
             root.superDown = false
         }
     }

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -231,6 +231,8 @@ Singleton {
                     property JsonObject showWhenPressingSuper: JsonObject {
                         property bool enable: true
                         property int delay: 140
+                        property bool suppressSearchOnHold: true
+                        property int suppressSearchDelay: 200
                     }
                 }
                 property bool bottom: false // Instead of top

--- a/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
@@ -179,7 +179,7 @@ Scope {
         }
 
         onReleased: {
-            if (!GlobalStates.superReleaseMightTrigger) {
+            if (GlobalStates.shouldSuppressSuperReleaseSearch() || !GlobalStates.superReleaseMightTrigger) {
                 GlobalStates.superReleaseMightTrigger = true;
                 return;
             }

--- a/dots/.config/quickshell/ii/modules/waffle/startMenu/WaffleStartMenu.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/startMenu/WaffleStartMenu.qml
@@ -117,7 +117,7 @@ Scope {
         }
 
         onReleased: {
-            if (!GlobalStates.superReleaseMightTrigger) {
+            if (GlobalStates.shouldSuppressSuperReleaseSearch() || !GlobalStates.superReleaseMightTrigger) {
                 GlobalStates.superReleaseMightTrigger = true;
                 return;
             }


### PR DESCRIPTION
When bar.autoHide.enable and bar.autoHide.showWhenPressingSuper.enable are active, holding Super longer than suppressSearchDelay no longer toggles search on release. This keeps quick Super taps opening search while letting hidden-bar users hold Super to reveal the bar or workspace numbers.

• ## Describe your changes

  Adds a config-only option to suppress the Super release search toggle when the auto-hidden bar is being revealed by holding Super.

  This is active when:
  - `bar.autoHide.enable`
  - `bar.autoHide.showWhenPressingSuper.enable`
  - `bar.autoHide.showWhenPressingSuper.suppressSearchOnHold`

  are enabled. The hold threshold is configurable with `suppressSearchDelay`.

  ## Is it ready? Questions/feedback needed?

  Ready for review.


