### PR TITLE
Feat/cheatsheet: add search for keybinds and periodic table elements

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/Cheatsheet.qml
@@ -42,16 +42,45 @@ Scope { // Scope
             function hide() {
                 cheatsheetLoader.active = false;
             }
+            property bool keyboardReady: false
             exclusiveZone: 0
             implicitWidth: cheatsheetBackground.width + Appearance.sizes.elevationMargin * 2
             implicitHeight: cheatsheetBackground.height + Appearance.sizes.elevationMargin * 2
             WlrLayershell.namespace: "quickshell:cheatsheet"
-            // Setting this value makes it take its sweet time to open
-            // WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+            WlrLayershell.layer: WlrLayer.Overlay
+            //--> It dont take that sweet time to open Anymore!
+            WlrLayershell.keyboardFocus: cheatsheetRoot.keyboardReady ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
             color: "transparent"
 
             mask: Region {
                 item: cheatsheetBackground
+            }
+
+            Timer {
+                id: lockWidthTimer
+                interval: 150
+                repeat: false
+                onTriggered: {
+                    if (cheatsheetBackground.lockedWidth === 0) {
+                        const contentWidth = Math.max(
+                            headerColumn.implicitWidth,
+                            keybindsPage.implicitWidth,
+                            periodicTablePage.implicitWidth,
+                        );
+                        cheatsheetBackground.lockedWidth = contentWidth + cheatsheetBackground.padding * 2;
+                    }
+                }
+            }
+
+            Timer {
+                id: keyboardFocusTimer
+                interval: 150
+                repeat: false
+                onTriggered: {
+                    if (cheatsheetRoot.visible) {
+                        cheatsheetRoot.keyboardReady = true;
+                    }
+                }
             }
 
             Component.onCompleted: {
@@ -59,6 +88,21 @@ Scope { // Scope
             }
             Component.onDestruction: {
                 GlobalFocusGrab.removeDismissable(cheatsheetRoot);
+            }
+            Connections {
+                target: cheatsheetRoot
+                function onVisibleChanged() {
+                    if (cheatsheetRoot.visible) {
+                        cheatsheetRoot.keyboardReady = false;
+                        lockWidthTimer.restart();
+                        keyboardFocusTimer.restart();
+                    } else {
+                        keyboardFocusTimer.stop();
+                        cheatsheetRoot.keyboardReady = false;
+                        cheatsheetBackground.lockedWidth = 0;
+                        cheatsheetBackground.collapseSearch();
+                    }
+                }
             }
             Connections {
                 target: GlobalFocusGrab
@@ -74,17 +118,43 @@ Scope { // Scope
             Rectangle {
                 id: cheatsheetBackground
                 anchors.centerIn: parent
+                focus: cheatsheetRoot.visible
                 color: Appearance.colors.colLayer0
                 border.width: 1
                 border.color: Appearance.colors.colLayer0Border
                 radius: Appearance.rounding.windowRounding
                 property real padding: 20
-                implicitWidth: cheatsheetColumnLayout.implicitWidth + padding * 2
+                property real lockedWidth: 0
+                property bool searchExpanded: false
+
+                function collapseSearch() {
+                    searchExpanded = false;
+                    searchField.focus = false;
+                    if (searchField.text !== "") {
+                        searchField.text = "";
+                    }
+                    cheatsheetBackground.forceActiveFocus();
+                    GlobalFocusGrab.addDismissable(cheatsheetRoot);
+                }
+
+                function expandSearch() {
+                    GlobalFocusGrab.removeDismissable(cheatsheetRoot);
+                    searchExpanded = true;
+                    searchField.forceActiveFocus();
+                }
+
+                implicitWidth: lockedWidth > 0 ? lockedWidth : cheatsheetColumnLayout.implicitWidth + padding * 2
                 implicitHeight: cheatsheetColumnLayout.implicitHeight + padding * 2
 
-                Keys.onPressed: event => { // Esc to close
+                Keys.onPressed: event => {
                     if (event.key === Qt.Key_Escape) {
-                        cheatsheetRoot.hide();
+                        event.accepted = true;
+                        if (searchField.text.length > 0 || searchExpanded) {
+                            clearSearchButton.clicked();
+                        } else {
+                            cheatsheetRoot.hide();
+                        }
+                        return;
                     }
                     if (event.modifiers === Qt.ControlModifier) {
                         if (event.key === Qt.Key_PageDown) {
@@ -100,12 +170,36 @@ Scope { // Scope
                             tabBar.setCurrentIndex((tabBar.currentIndex - 1 + root.tabButtonList.length) % root.tabButtonList.length);
                             event.accepted = true;
                         }
+                        return;
+                    }
+
+                    if (searchField.activeFocus && cheatsheetBackground.searchExpanded) {
+                        event.accepted = false;
+                        return;
+                    }
+
+                    if (event.key === Qt.Key_Backspace) {
+                        if (!cheatsheetBackground.searchExpanded) {
+                            event.accepted = true;
+                            return;
+                        }
+                        if (searchField.text.length > 0) {
+                            searchField.text = searchField.text.substring(0, searchField.text.length - 1);
+                        }
+                        event.accepted = true;
+                        return;
+                    }
+                    if (event.text.length > 0) {
+                        expandSearch();
+                        searchField.text += event.text;
+                        searchField.cursorPosition = searchField.text.length;
+                        searchField.forceActiveFocus();
+                        event.accepted = true;
                     }
                 }
 
                 RippleButton { // Close button
                     id: closeButton
-                    focus: cheatsheetRoot.visible
                     implicitWidth: 40
                     implicitHeight: 40
                     buttonRadius: Appearance.rounding.full
@@ -133,15 +227,103 @@ Scope { // Scope
                     anchors.centerIn: parent
                     spacing: 10
 
-                    Toolbar {
+                    ColumnLayout {
+                        id: headerColumn
                         Layout.alignment: Qt.AlignHCenter
-                        enableShadow: false
-                        ToolbarTabBar {
-                            id: tabBar
-                            tabButtonList: root.tabButtonList
+                        spacing: 6
 
-                            Synchronizer on currentIndex {
-                                property alias source: swipeView.currentIndex
+                        Toolbar {
+                            id: tabToolbar
+                            Layout.alignment: Qt.AlignHCenter
+                            enableShadow: false
+                            ToolbarTabBar {
+                                id: tabBar
+                                tabButtonList: root.tabButtonList
+
+                                Synchronizer on currentIndex {
+                                    property alias source: swipeView.currentIndex
+                                }
+                            }
+                        }
+
+                        Item {
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.preferredWidth: Math.max(keybindsPage.implicitWidth, periodicTablePage.implicitWidth)
+                            implicitHeight: 30
+
+                            MouseArea {
+                                anchors.fill: parent
+                                enabled: !cheatsheetBackground.searchExpanded
+                                cursorShape: Qt.IBeamCursor
+                                onClicked: cheatsheetBackground.expandSearch()
+                            }
+
+                            RowLayout {
+                                id: searchHintRow
+                                anchors.centerIn: parent
+                                spacing: 4
+                                visible: !cheatsheetBackground.searchExpanded
+
+                                MaterialSymbol {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                    color: Appearance.colors.colSubtext
+                                    text: "search"
+                                }
+
+                                StyledText {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    color: Appearance.colors.colSubtext
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                    text: Translation.tr("Type or click here to search…")
+                                }
+                            }
+
+                            Item {
+                                id: searchFieldContainer
+                                anchors.centerIn: parent
+                                width: Math.max(tabBar.implicitWidth, 220)
+                                height: 30
+                                visible: cheatsheetBackground.searchExpanded
+                                enabled: cheatsheetBackground.searchExpanded
+
+                                ToolbarTextField {
+                                    id: searchField
+                                    anchors.fill: parent
+                                    enabled: cheatsheetBackground.searchExpanded
+                                    padding: 6
+                                    rightPadding: 32
+                                    placeholderText: ""
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+
+                                    Keys.onPressed: event => {
+                                        if (event.key === Qt.Key_Escape) {
+                                            event.accepted = true;
+                                            if (cheatsheetBackground.searchExpanded || text.length > 0) {
+                                                clearSearchButton.clicked();
+                                            }
+                                        }
+                                    }
+
+                                    onTextChanged: {
+                                        if (text.length === 0 && cheatsheetBackground.searchExpanded) {
+                                            cheatsheetBackground.collapseSearch();
+                                        }
+                                    }
+                                }
+
+                                IconToolbarButton {
+                                    id: clearSearchButton
+                                    anchors {
+                                        right: parent.right
+                                        verticalCenter: parent.verticalCenter
+                                        rightMargin: 2
+                                    }
+                                    implicitWidth: 26
+                                    implicitHeight: 26
+                                    text: "close"
+                                    onClicked: cheatsheetBackground.collapseSearch()
+                                }
                             }
                         }
                     }
@@ -149,8 +331,6 @@ Scope { // Scope
                     SwipeView { // Content pages
                         id: swipeView
                         Layout.topMargin: 5
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
                         spacing: 10
                         currentIndex: Persistent.states.cheatsheet.tabIndex
                         onCurrentIndexChanged: {
@@ -170,8 +350,14 @@ Scope { // Scope
                             }
                         }
 
-                        CheatsheetKeybinds {}
-                        CheatsheetPeriodicTable {}
+                        CheatsheetKeybinds {
+                            id: keybindsPage
+                            searchQuery: searchField.text
+                        }
+                        CheatsheetPeriodicTable {
+                            id: periodicTablePage
+                            searchQuery: searchField.text
+                        }
                     }
                 }
             }

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
@@ -12,16 +12,30 @@ import Quickshell
 Item {
     id: root
     property string searchQuery: ""
+    property bool noMatches: false
     property real padding: 4
     implicitWidth: QsWindow?.window?.screen.width * 0.7 ?? 0
     implicitHeight: QsWindow?.window?.screen.height * 0.7 ?? 0
 
-    readonly property bool hasResults: {
-        if (root.searchQuery.trim().length === 0) return true;
-        const query = root.searchQuery;
-        return HyprlandKeybinds.keybinds.some(bind =>
-            bind.description && CheatsheetSearch.matchesQuery(bind.description + " " + bind.key, query)
-        );
+    onSearchQueryChanged: matchUpdateTimer.restart()
+
+    Timer {
+        id: matchUpdateTimer
+        interval: 0
+        onTriggered: {
+            if (!root.searchQuery.trim()) {
+                root.noMatches = false;
+                return;
+            }
+            let any = false;
+            for (let i = 0; i < flow.children.length; i++) {
+                if (flow.children[i].visible) {
+                    any = true;
+                    break;
+                }
+            }
+            root.noMatches = !any;
+        }
     }
 
     StyledFlickable {
@@ -31,7 +45,6 @@ Item {
         anchors.margins: Appearance.rounding.small
         contentHeight: height
         contentWidth: flow.implicitWidth
-        visible: root.hasResults
 
         Flow {
             id: flow
@@ -53,12 +66,11 @@ Item {
         target: flickable
         vertical: false
         color: Appearance.colors.colLayer0Base
-        visible: flickable.visible
     }
 
     StyledText {
         anchors.centerIn: parent
-        visible: root.searchQuery.trim().length > 0 && !root.hasResults
+        visible: root.noMatches
         font.pixelSize: Appearance.font.pixelSize.large
         color: Appearance.colors.colSubtext
         text: Translation.tr("No matching keybinds")

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import "cheatsheet_search.js" as CheatsheetSearch
 import qs.services
 import qs.modules.common
 import qs.modules.common.functions
@@ -10,9 +11,18 @@ import Quickshell
 
 Item {
     id: root
+    property string searchQuery: ""
     property real padding: 4
     implicitWidth: QsWindow?.window?.screen.width * 0.7 ?? 0
     implicitHeight: QsWindow?.window?.screen.height * 0.7 ?? 0
+
+    readonly property bool hasResults: {
+        if (root.searchQuery.trim().length === 0) return true;
+        const query = root.searchQuery;
+        return HyprlandKeybinds.keybinds.some(bind =>
+            bind.description && CheatsheetSearch.matchesQuery(bind.description + " " + bind.key, query)
+        );
+    }
 
     StyledFlickable {
         id: flickable
@@ -21,6 +31,8 @@ Item {
         anchors.margins: Appearance.rounding.small
         contentHeight: height
         contentWidth: flow.implicitWidth
+        visible: root.hasResults
+
         Flow {
             id: flow
             height: flickable.height
@@ -31,6 +43,7 @@ Item {
                 delegate: CheatsheetKeybindsCategory {
                     required property var modelData
                     categoryName: modelData
+                    searchQuery: root.searchQuery
                 }
             }
         }
@@ -40,5 +53,14 @@ Item {
         target: flickable
         vertical: false
         color: Appearance.colors.colLayer0Base
+        visible: flickable.visible
+    }
+
+    StyledText {
+        anchors.centerIn: parent
+        visible: root.searchQuery.trim().length > 0 && !root.hasResults
+        font.pixelSize: Appearance.font.pixelSize.large
+        color: Appearance.colors.colSubtext
+        text: Translation.tr("No matching keybinds")
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
@@ -149,19 +149,6 @@ Column {
         return dedirectioned;
     }
 
-    function bindSearchText(bind) {
-        const mods = root.modMaskToStringList(bind.modmask)
-            .map(mod => root.keySubstitutions[mod] || mod)
-            .join(" ");
-        return [
-            mods,
-            bind.key,
-            root.transformKey(bind.key),
-            bind.description,
-            root.transformDescription(bind, root.categoryName),
-        ].join(" ");
-    }
-
     Column {
         spacing: 4
         Repeater {
@@ -174,7 +161,11 @@ Column {
                     binds = HyprlandKeybinds.keybinds.filter(bind => root.hasDescription(bind) && root.isCategory(bind, root.categoryName) && !root.containsNonFirstRepetitive(bind));
                 }
                 if (root.searchQuery.trim().length === 0) return binds;
-                return binds.filter(bind => CheatsheetSearch.matchesQuery(root.bindSearchText(bind), root.searchQuery));
+                const category = root.isCategorized ? root.categoryName : "";
+                return binds.filter(bind => CheatsheetSearch.matchesQuery(
+                    CheatsheetSearch.keybindHaystack(bind, root.keySubstitutions, category),
+                    root.searchQuery,
+                ));
             }
             delegate: BindLine {
                 required property var modelData

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import "cheatsheet_search.js" as CheatsheetSearch
 import qs.services
 import qs.modules.common
 import qs.modules.common.functions
@@ -13,6 +14,7 @@ import Quickshell
 Column {
     id: root
     required property string categoryName
+    property string searchQuery: ""
     readonly property bool isCategorized: categoryName?.length > 0
     property int maxBindWidth: 0
     property real columnSpacing: 40
@@ -147,15 +149,32 @@ Column {
         return dedirectioned;
     }
 
+    function bindSearchText(bind) {
+        const mods = root.modMaskToStringList(bind.modmask)
+            .map(mod => root.keySubstitutions[mod] || mod)
+            .join(" ");
+        return [
+            mods,
+            bind.key,
+            root.transformKey(bind.key),
+            bind.description,
+            root.transformDescription(bind, root.categoryName),
+        ].join(" ");
+    }
+
     Column {
         spacing: 4
         Repeater {
             id: repeater
             model: {
+                let binds;
                 if (!root.isCategorized) {
-                    return HyprlandKeybinds.keybinds.filter(bind => root.hasDescription(bind) && root.isUncategorized(bind) && !root.containsNonFirstRepetitive(bind));
+                    binds = HyprlandKeybinds.keybinds.filter(bind => root.hasDescription(bind) && root.isUncategorized(bind) && !root.containsNonFirstRepetitive(bind));
+                } else {
+                    binds = HyprlandKeybinds.keybinds.filter(bind => root.hasDescription(bind) && root.isCategory(bind, root.categoryName) && !root.containsNonFirstRepetitive(bind));
                 }
-                return HyprlandKeybinds.keybinds.filter(bind => root.hasDescription(bind) && root.isCategory(bind, root.categoryName) && !root.containsNonFirstRepetitive(bind));
+                if (root.searchQuery.trim().length === 0) return binds;
+                return binds.filter(bind => CheatsheetSearch.matchesQuery(root.bindSearchText(bind), root.searchQuery));
             }
             delegate: BindLine {
                 required property var modelData

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetPeriodicTable.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetPeriodicTable.qml
@@ -3,6 +3,7 @@ import QtQuick
 
 Item {
     id: root
+    property string searchQuery: ""
     readonly property var elements: PTable.elements
     readonly property var series: PTable.series
     property real spacing: 6
@@ -27,6 +28,7 @@ Item {
                     delegate: ElementTile {
                         required property var modelData
                         element: modelData
+                        searchQuery: root.searchQuery
                     }
 
                 }
@@ -52,6 +54,7 @@ Item {
                     delegate: ElementTile {
                         required property var modelData
                         element: modelData
+                        searchQuery: root.searchQuery
                     }
 
                 }

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/ElementTile.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/ElementTile.qml
@@ -1,3 +1,4 @@
+import "cheatsheet_search.js" as CheatsheetSearch
 import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
@@ -6,7 +7,14 @@ import QtQuick
 RippleButton {
     id: root
     required property var element
-    opacity: element.type != "empty" ? 1 : 0
+    property string searchQuery: ""
+
+    readonly property bool dimmed: searchQuery.trim().length > 0
+        && element.type !== "empty"
+        && !CheatsheetSearch.matchesElement(element, searchQuery)
+
+    opacity: element.type != "empty" ? (dimmed ? 0.28 : 1) : 0
+    enabled: element.type === "empty" || !dimmed
     implicitHeight: 70
     implicitWidth: 70
     colBackground: Appearance.colors.colLayer2

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/cheatsheet_search.js
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/cheatsheet_search.js
@@ -11,6 +11,75 @@ function matchesQuery(haystack, query) {
     return tokens.every(token => String(haystack).toLowerCase().includes(token));
 }
 
+function lookupSubstitution(substitutions, key) {
+    if (!key) return "";
+    if (substitutions[key]) return substitutions[key];
+    const title = key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+    if (substitutions[title]) return substitutions[title];
+    if (substitutions[key.toUpperCase()]) return substitutions[key.toUpperCase()];
+    if (substitutions[key.toLowerCase()]) return substitutions[key.toLowerCase()];
+    return key;
+}
+
+function modMaskToStringList(modMask) {
+    const list = [];
+    if (modMask & (1 << 2)) list.push("Ctrl");
+    if (modMask & (1 << 6)) list.push("Super");
+    if (modMask & (1 << 0)) list.push("Shift");
+    if (modMask & (1 << 3)) list.push("Alt");
+    if (modMask & (1 << 1)) list.push("Caps");
+    if (modMask & (1 << 4)) list.push("Mod2");
+    if (modMask & (1 << 5)) list.push("Mod3");
+    if (modMask & (1 << 7)) list.push("Mod5");
+    return list;
+}
+
+function containsFirstRepetitive(key) {
+    return key.includes("1") || /left/i.test(key);
+}
+
+function transformKey(key, substitutions) {
+    const replaced = lookupSubstitution(substitutions, key);
+    return replaced.replace("1", "<Number>").replace("Left", "<Direction>");
+}
+
+function transformDescription(bind, categoryName) {
+    const description = bind.description || "";
+    const decategorized = categoryName
+        ? description.replace(new RegExp("\\s*" + categoryName + "\\s*:\\s*"), "")
+        : description;
+    const key = bind.key || "";
+    if (!containsFirstRepetitive(key)) return decategorized;
+    const denumbered = decategorized.replace("1", "<Number>");
+    return denumbered.replace(/ \b(left|right|up|down)\b/i, " <Direction>");
+}
+
+function mouseKeySearchTerms(rawKey) {
+    switch (rawKey) {
+    case "mouse:272": return "LMB left mouse";
+    case "mouse:273": return "RMB right mouse";
+    case "mouse:275": return "MouseBack mouse back";
+    case "mouse_up": return "Scroll Down scroll down mouse up";
+    case "mouse_down": return "Scroll Up scroll up mouse down";
+    default: return "";
+    }
+}
+
+function keybindHaystack(bind, substitutions, categoryName) {
+    const modParts = [];
+    for (const mod of modMaskToStringList(bind.modmask)) {
+        modParts.push(mod);
+        modParts.push(lookupSubstitution(substitutions, mod));
+    }
+    const rawKey = bind.key || "";
+    const displayKey = transformKey(rawKey, substitutions);
+    const description = bind.description || "";
+    const displayDescription = transformDescription(bind, categoryName);
+    const categoryPrefix = categoryName || description.substring(0, description.indexOf(":"));
+    const keyTerms = [rawKey, displayKey, mouseKeySearchTerms(rawKey)].join(" ");
+    return [modParts.join(" "), keyTerms, description, displayDescription, categoryPrefix].join(" ");
+}
+
 function matchesElement(element, query) {
     if (!element || element.type === "empty") return false;
     if (queryTokens(query).length === 0) return true;

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/cheatsheet_search.js
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/cheatsheet_search.js
@@ -1,0 +1,19 @@
+.pragma library
+
+function queryTokens(query) {
+    if (!query) return [];
+    return query.trim().toLowerCase().split(/\s+/).filter(token => token.length > 0);
+}
+
+function matchesQuery(haystack, query) {
+    const tokens = queryTokens(query);
+    if (tokens.length === 0) return true;
+    return tokens.every(token => String(haystack).toLowerCase().includes(token));
+}
+
+function matchesElement(element, query) {
+    if (!element || element.type === "empty") return false;
+    if (queryTokens(query).length === 0) return true;
+    const haystack = [element.name, element.symbol, String(element.weight)].join(" ");
+    return matchesQuery(haystack, query);
+}

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -611,5 +611,7 @@
   "Use varying shapes for password characters": "Use varying shapes for password characters",
   "Battery full": "Battery full",
   "Pin": "Pin",
-  "Unpin": "Unpin"
+  "Unpin": "Unpin",
+  "Type or click here to search…": "Type or click here to search…",
+  "No matching keybinds": "No matching keybinds"
 }


### PR DESCRIPTION
## Describe your changes

Adds search to the Quickshell cheatsheet (Super+/):

!!(when I say "x" I mean the icon in the search/filter field and not the letter x letter)

-Search UI : Collapsible field under the tab bar with a “Type or click here to search…” hint, type-to-search, Esc/"x" to clear, and "x" inside the field
-Keybind filtering : Filters categories in place by description, key, and modifiers; shows “No matching keybinds” when nothing matches
-Key/mod matching : Shared cheatsheet_search.js haystack matches display names and symbols (Shift, Super, Enter, LMB/RMB, etc.), including case variants and mouse button text when symbols are shown
-Periodic table : Non-matching elements stay visible but dimmed (greyed out in place)
-Performance : Deferred keyboard focus (150ms after open) to avoid the slow spawn caused by WlrKeyboardFocus.OnDemand on creation.
-Translations : Two new en_US strings

### I made the field very compact to not mess with the visuals for those who don't use it, do its collapse in to the hint text when not used .


https://github.com/user-attachments/assets/dfb9f6f0-df76-4a0b-99c5-34cd420734ba

## Is it ready? Questions/feedback needed?


Ready for review, tested and working locally on my both setups, 

Open cheatsheet (Super+/) opens quickly with deferred focus
Type-to-search and click hint to search
Filter keybinds by description, key (e, enter), modifier (shift, super), and mouse buttons (lmb, rmb)
Periodic table grey-out filter ....
Esc clears search first, then closes, "x"and backspace clear search
Tab switching (Ctrl+PageUp/Down)

Feedback welcome on UX (e.g. hint wording, empty-state behavior) or whether deferred focus timing should be configurable.
