### PR TITLE
fix(sleep): pause MPRIS players before suspend, hibernate, and auto-suspend

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -1,6 +1,6 @@
 $lock_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lock")' & pidof qs quickshell hyprlock || hyprlock
 # $lock_cmd = pidof hyprlock || hyprlock
-$suspend_cmd = systemctl suspend || loginctl suspend
+$suspend_cmd = qs -c ii ipc call mpris pauseAll 2>/dev/null; systemctl suspend || loginctl suspend
 
 general {
     lock_cmd = $lock_cmd

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -333,7 +333,8 @@ hl.bind("SUPER + ALT + Equal",
 
 --##! Session
 hl.bind("SUPER + L", hl.dsp.exec_cmd("loginctl lock-session"), { description = "Session: Lock" })
-hl.bind("SUPER + SHIFT + L", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"),
+hl.bind("SUPER + SHIFT + L",
+    hl.dsp.exec_cmd("qs -c $qsConfig ipc call mpris pauseAll 2>/dev/null; systemctl suspend || loginctl suspend"),
     { locked = true, description = "Session: Sleep" }) -- Sleep
 -- hl.bind("switch:on:Lid Switch", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"), {locked = true} ) -- # [hidden] Suspend when laptop lid is closed, uncomment if for whatever reason it's not the default behavior
 

--- a/dots/.config/quickshell/ii/modules/common/functions/Session.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/Session.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 import Quickshell
+import Quickshell.Services.Mpris
 import qs.services
 import qs.modules.common
 
@@ -21,6 +22,7 @@ Singleton {
     }
 
     function suspend() {
+        pauseAllPlayers();
         Quickshell.execDetached(["bash", "-c", "systemctl suspend || loginctl suspend"]);
     }
 
@@ -34,7 +36,14 @@ Singleton {
     }
 
     function hibernate() {
+        pauseAllPlayers();
         Quickshell.execDetached(["bash", "-c", `systemctl hibernate || loginctl hibernate`]);
+    }
+
+    function pauseAllPlayers() {
+        for (const player of Mpris.players.values) {
+            if (player.canPause) player.pause();
+        }
     }
 
     function poweroff() {

--- a/dots/.config/quickshell/ii/services/Battery.qml
+++ b/dots/.config/quickshell/ii/services/Battery.qml
@@ -4,6 +4,7 @@ import qs.services
 import qs.modules.common
 import Quickshell
 import Quickshell.Services.UPower
+import Quickshell.Services.Mpris
 import QtQuick
 import Quickshell.Io
 
@@ -80,6 +81,9 @@ Singleton {
 
     onIsSuspendingAndNotChargingChanged: {
         if (root.available && isSuspendingAndNotCharging) {
+            for (const player of Mpris.players.values) {
+                if (player.canPause) player.pause();
+            }
             Quickshell.execDetached(["bash", "-c", `systemctl suspend || loginctl suspend`]);
         }
     }


### PR DESCRIPTION
[##](url) fix(sleep): pause MPRIS players before suspend, hibernate, and auto-suspend

**Bug:**
[Because the video is more than 10 Mb, I put it on Google Photos](https://photos.app.goo.gl/AzzTSkEDxHzgUEAj7)

**Description:**

**Problem**
When suspending or hibernating while media is playing, systemd freezes all processes with SIGSTOP, including PipeWire/MPRIS players. This causes audio glitches, pops, or volume state issues on resume.
Solution
Pause all MPRIS-compatible players before entering suspend/hibernate, ensuring a clean audio state transition. Falls back gracefully if the IPC call fails.

**Implementation**
- Session.qml — suspend() and hibernate() call pauseAllPlayers() via QML's Mpris service before systemctl
- Battery.qml — same for auto-suspend at critical battery level
- keybinds.lua — SUPER+SHIFT+L runs qs ipc call mpris pauseAll before suspend
- hypridle.conf — $suspend_cmd chains the same IPC call
Zero external dependencies — uses the existing Mpris.pauseAll() IPC handler instead of playerctl.
Covered Entry Points
- Sleep/hibernate buttons (lock screen, session menu, start menu)
- Keyboard shortcut SUPER+SHIFT+L
- hypridle auto-suspend (15 min idle)
- Battery auto-suspend (3% critical)

**How to Test**
1. Play audio in any MPRIS-compatible player (Spotify, Firefox, mpv, etc.)
2. Press sleep button or SUPER+SHIFT+L
3. Audio pauses before system suspends
4. On resume, audio stays paused (play manually to resume)

**Risks**
- None. If qs is not running, 2>/dev/null silences the error and suspend proceeds normally.

To be honest, it's mostly vibe coded so please give a look and change lines that doesn't suit or correct than it should be, in fact it's needed.

## Is it ready? Questions/feedback needed?

Yes, any revision are very much appreciated.