### PR TITLE
fix(ai-chat): guard code-block language label against unknown languages

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -56,7 +56,15 @@ ColumnLayout {
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 color: Appearance.colors.colOnLayer2
-                text: root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain"
+                text: {
+                    // Label a tool command request as "Command"; otherwise show the
+                    // language definition name, guarding against a null definition
+                    // (an unknown lang tag made `.name` throw before this).
+                    if (root.isCommandRequest) return Translation.tr("Command");
+                    if (!root.displayLang) return "plain";
+                    const def = Repository.definitionForName(root.displayLang);
+                    return (def && def.name) ? def.name : root.displayLang;
+                }
             }
 
             Item { Layout.fillWidth: true }


### PR DESCRIPTION
## Describe your changes

The AI chat code-block language label calls `Repository.definitionForName(lang).name` directly. For a language tag the syntax-highlighting repository doesn't recognise, `definitionForName` returns a null definition and `.name` throws, breaking the message render. This guards it (falls back to the raw tag) and labels tool command requests as "Command".

No behavioural change for known languages; no default changes.

## Is it ready? Questions/feedback needed?

Ready.
