### PR TITLE
feat(sidebar): configurable sidebar width

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/ii/modules/common/Appearance.qml
@@ -403,8 +403,8 @@ Singleton {
         property real osdWidth: 180
         property real searchWidthCollapsed: 210
         property real searchWidth: 360
-        property real sidebarWidth: 460
-        property real sidebarWidthExtended: 750
+        property real sidebarWidth: Config.options.sidebar.width
+        property real sidebarWidthExtended: Config.options.sidebar.widthExtended
         property real baseVerticalBarWidth: 46
         property real verticalBarWidth: Config.options.bar.cornerStyle === 1 ? 
             (baseVerticalBarWidth + root.sizes.hyprlandGapsOut * 2) : baseVerticalBarWidth

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -497,6 +497,8 @@ Singleton {
 
             property JsonObject sidebar: JsonObject {
                 property bool keepRightSidebarLoaded: true
+                property int width: 460 // Collapsed sidebar width in px
+                property int widthExtended: 750 // Extended (Ctrl+O) sidebar width in px
                 property JsonObject translator: JsonObject {
                     property bool enable: false
                     property int delay: 300 // Delay before sending request. Reduces (potential) rate limits and lag.


### PR DESCRIPTION
## Describe your changes

The sidebar width was hardcoded in `Appearance.qml`. This exposes `sidebar.width` and `sidebar.widthExtended` as config options so the sidebar can be widened without patching QML. Defaults (460 / 750) preserve current behaviour exactly.

## Is it ready? Questions/feedback needed?

Ready.
