### PR TITLE
feat(ai-chat): configurable message font size

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -503,6 +503,10 @@ Singleton {
                 }
                 property JsonObject ai: JsonObject {
                     property bool textFadeIn: false
+                    // Chat message text size. Defaults to the theme value (live
+                    // binding, like cheatsheet.fontSize) so a theme change tracks
+                    // automatically instead of pinning a literal.
+                    property int fontSize: Appearance.font.pixelSize.small
                 }
                 property JsonObject booru: JsonObject {
                     property bool allowNsfw: false

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
@@ -155,7 +155,7 @@ ColumnLayout {
             renderType: Text.NativeRendering
             font.family: Appearance.font.family.reading
             font.hintingPreference: Font.PreferNoHinting // Prevent weird bold text
-            font.pixelSize: Appearance.font.pixelSize.small
+            font.pixelSize: Config.options.sidebar.ai.fontSize
             selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
             selectionColor: Appearance.colors.colSecondaryContainer
             wrapMode: TextEdit.Wrap


### PR DESCRIPTION
## Describe your changes

The AI chat message font size was hardcoded to `Appearance.font.pixelSize.small`. This exposes `sidebar.ai.fontSize` so chat text can be enlarged for readability. The default is a live binding to the theme value (mirroring the existing `cheatsheet.fontSize` pattern), so it tracks theme changes and preserves current behaviour.

## Is it ready? Questions/feedback needed?

Ready.
