### PR TITLE
bar: add opt-in Claude (Pro/Max) subscription usage gauges

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -274,6 +274,12 @@ Singleton {
                     property bool useUSCS: false // Instead of metric (SI) units
                     property int fetchInterval: 10 // minutes
                 }
+                property JsonObject claudeUsage: JsonObject {
+                    property bool enable: false // Show Claude (Pro/Max) subscription usage gauges in the bar
+                    property bool showWeekly: true // Also show the 7-day window gauge next to the 5-hour one
+                    property int warningThreshold: 90 // Turn a gauge red at/above this utilization (%)
+                    property int fetchInterval: 5 // minutes
+                }
                 property JsonObject indicators: JsonObject {
                     property JsonObject notifications: JsonObject {
                         property bool showUnreadCount: false

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -275,9 +275,9 @@ Singleton {
                     property int fetchInterval: 10 // minutes
                 }
                 property JsonObject claudeUsage: JsonObject {
-                    property bool enable: false // Show Claude (Pro/Max) subscription usage gauges in the bar
-                    property bool showWeekly: true // Also show the 7-day window gauge next to the 5-hour one
-                    property int warningThreshold: 90 // Turn a gauge red at/above this utilization (%)
+                    property bool enable: false // Show a Claude (Pro/Max) subscription usage gauge in the bar
+                    property bool defaultWeekly: false // Start on the 7-day window; click the gauge to switch session <-> week
+                    property int warningThreshold: 90 // Turn the gauge red at/above this utilization (%)
                     property int fetchInterval: 5 // minutes
                 }
                 property JsonObject indicators: JsonObject {

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -122,6 +122,12 @@ Item { // Bar content region
                 visible: root.useShortenedForm < 2
                 Layout.fillWidth: true
             }
+
+            Loader {
+                active: Config.options.bar.claudeUsage.enable
+                visible: root.useShortenedForm < 2 && active
+                sourceComponent: ClaudeUsageBar {}
+            }
         }
 
         VerticalBarSeparator {

--- a/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
@@ -12,9 +12,17 @@ MouseArea {
     implicitWidth: rowLayout.implicitWidth + rowLayout.anchors.leftMargin + rowLayout.anchors.rightMargin
     implicitHeight: Appearance.sizes.barHeight
     hoverEnabled: !Config.options.bar.tooltips.clickToShow
-    acceptedButtons: Qt.LeftButton
+    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
 
-    onPressed: ClaudeUsage.getData() // click to refresh now
+    // Which window the single gauge shows; toggled by clicking.
+    property bool showingWeekly: Config.options.bar.claudeUsage.defaultWeekly
+
+    onPressed: event => {
+        if (event.button === Qt.MiddleButton)
+            ClaudeUsage.getData(); // middle-click to refresh now
+        else
+            root.showingWeekly = !root.showingWeekly; // click to switch session <-> week
+    }
 
     // A single Claude-usage gauge: icon inside a ring + percentage number.
     component UsageGauge: Item {
@@ -72,16 +80,9 @@ MouseArea {
         anchors.leftMargin: 4
         anchors.rightMargin: 4
 
-        UsageGauge { // 5-hour session window
-            iconName: "auto_awesome"
-            percentage: ClaudeUsage.fiveHour / 100
-        }
-
-        UsageGauge { // 7-day window
-            iconName: "calendar_month"
-            percentage: ClaudeUsage.sevenDay / 100
-            visible: Config.options.bar.claudeUsage.showWeekly
-            Layout.leftMargin: visible ? 2 : 0
+        UsageGauge { // Click the module to switch between the two windows
+            iconName: root.showingWeekly ? "calendar_month" : "auto_awesome"
+            percentage: (root.showingWeekly ? ClaudeUsage.sevenDay : ClaudeUsage.fiveHour) / 100
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
@@ -1,0 +1,142 @@
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+
+MouseArea {
+    id: root
+    property bool borderless: Config.options.bar.borderless
+
+    implicitWidth: rowLayout.implicitWidth + rowLayout.anchors.leftMargin + rowLayout.anchors.rightMargin
+    implicitHeight: Appearance.sizes.barHeight
+    hoverEnabled: !Config.options.bar.tooltips.clickToShow
+    acceptedButtons: Qt.LeftButton
+
+    onPressed: ClaudeUsage.getData() // click to refresh now
+
+    // A single Claude-usage gauge: icon inside a ring + percentage number.
+    component UsageGauge: Item {
+        id: gauge
+        required property string iconName
+        required property real percentage // 0..1
+        property int warningThreshold: Config.options.bar.claudeUsage.warningThreshold
+        property bool warning: percentage * 100 >= warningThreshold
+
+        implicitWidth: gaugeRow.implicitWidth
+        implicitHeight: Appearance.sizes.barHeight
+
+        RowLayout {
+            id: gaugeRow
+            spacing: 2
+            anchors.verticalCenter: parent.verticalCenter
+
+            ClippedFilledCircularProgress {
+                Layout.alignment: Qt.AlignVCenter
+                lineWidth: Appearance.rounding.unsharpen
+                value: Math.max(0, Math.min(1, gauge.percentage))
+                implicitSize: 20
+                colPrimary: gauge.warning ? Appearance.colors.colError : Appearance.colors.colOnSecondaryContainer
+                accountForLightBleeding: !gauge.warning
+                enableAnimation: false
+
+                Item {
+                    anchors.centerIn: parent
+                    width: 20
+                    height: 20
+                    MaterialSymbol {
+                        anchors.centerIn: parent
+                        font.weight: Font.DemiBold
+                        fill: 1
+                        text: gauge.iconName
+                        iconSize: Appearance.font.pixelSize.normal
+                        color: Appearance.m3colors.m3onSecondaryContainer
+                    }
+                }
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignVCenter
+                color: Appearance.colors.colOnLayer1
+                font.pixelSize: Appearance.font.pixelSize.small
+                text: ClaudeUsage.available ? `${Math.round(gauge.percentage * 100)}` : "–"
+            }
+        }
+    }
+
+    RowLayout {
+        id: rowLayout
+        spacing: 6
+        anchors.fill: parent
+        anchors.leftMargin: 4
+        anchors.rightMargin: 4
+
+        UsageGauge { // 5-hour session window
+            iconName: "auto_awesome"
+            percentage: ClaudeUsage.fiveHour / 100
+        }
+
+        UsageGauge { // 7-day window
+            iconName: "calendar_month"
+            percentage: ClaudeUsage.sevenDay / 100
+            visible: Config.options.bar.claudeUsage.showWeekly
+            Layout.leftMargin: visible ? 2 : 0
+        }
+    }
+
+    StyledPopup {
+        hoverTarget: root
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 8
+
+            StyledPopupHeaderRow {
+                icon: "auto_awesome"
+                label: ClaudeUsage.subscriptionType.length > 0 ? `Claude ${ClaudeUsage.subscriptionType.charAt(0).toUpperCase() + ClaudeUsage.subscriptionType.slice(1)}` : "Claude usage"
+            }
+
+            ColumnLayout {
+                spacing: 4
+                visible: ClaudeUsage.available
+
+                StyledPopupValueRow {
+                    icon: "timer"
+                    label: Translation.tr("Session (5h):")
+                    value: `${Math.round(ClaudeUsage.fiveHour)}%  ·  ${ClaudeUsage.timeUntil(ClaudeUsage.fiveHourReset)}`
+                }
+                StyledPopupValueRow {
+                    icon: "calendar_month"
+                    label: Translation.tr("Week (7d):")
+                    value: `${Math.round(ClaudeUsage.sevenDay)}%  ·  ${ClaudeUsage.timeUntil(ClaudeUsage.sevenDayReset)}`
+                }
+                StyledPopupValueRow {
+                    visible: ClaudeUsage.sevenDayOpus >= 0
+                    icon: "neurology"
+                    label: Translation.tr("Week · Opus:")
+                    value: `${Math.round(ClaudeUsage.sevenDayOpus)}%`
+                }
+                StyledPopupValueRow {
+                    visible: ClaudeUsage.sevenDaySonnet >= 0
+                    icon: "graph_3"
+                    label: Translation.tr("Week · Sonnet:")
+                    value: `${Math.round(ClaudeUsage.sevenDaySonnet)}%`
+                }
+                StyledPopupValueRow {
+                    visible: ClaudeUsage.extraEnabled && ClaudeUsage.extraMonthlyLimit > 0
+                    icon: "paid"
+                    label: Translation.tr("Extra credits:")
+                    value: `${ClaudeUsage.extraUsedCredits.toFixed(2)} / ${ClaudeUsage.extraMonthlyLimit} ${ClaudeUsage.extraCurrency}`
+                }
+            }
+
+            StyledText {
+                visible: !ClaudeUsage.available
+                color: Appearance.colors.colOnSurfaceVariant
+                font.pixelSize: Appearance.font.pixelSize.small
+                text: ClaudeUsage.lastError.length > 0 ? Translation.tr("Unavailable: %1").arg(ClaudeUsage.lastError) : Translation.tr("Loading…")
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClaudeUsageBar.qml
@@ -29,6 +29,7 @@ MouseArea {
         id: gauge
         required property string iconName
         required property real percentage // 0..1
+        property string label: "" // short window identifier, e.g. "5h" / "7d"
         property int warningThreshold: Config.options.bar.claudeUsage.warningThreshold
         property bool warning: percentage * 100 >= warningThreshold
 
@@ -70,6 +71,14 @@ MouseArea {
                 font.pixelSize: Appearance.font.pixelSize.small
                 text: ClaudeUsage.available ? `${Math.round(gauge.percentage * 100)}` : "–"
             }
+
+            StyledText { // which window is being shown
+                Layout.alignment: Qt.AlignVCenter
+                visible: gauge.label.length > 0
+                color: Appearance.colors.colSubtext
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                text: gauge.label
+            }
         }
     }
 
@@ -83,6 +92,7 @@ MouseArea {
         UsageGauge { // Click the module to switch between the two windows
             iconName: root.showingWeekly ? "calendar_month" : "auto_awesome"
             percentage: (root.showingWeekly ? ClaudeUsage.sevenDay : ClaudeUsage.fiveHour) / 100
+            label: root.showingWeekly ? "7d" : "5h"
         }
     }
 

--- a/dots/.config/quickshell/ii/services/ClaudeUsage.qml
+++ b/dots/.config/quickshell/ii/services/ClaudeUsage.qml
@@ -1,0 +1,139 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs
+import qs.services
+import qs.modules.common
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+/**
+ * Claude subscription usage (Pro / Max).
+ *
+ * Reads the OAuth access token from ~/.claude/.credentials.json (kept fresh by
+ * Claude Code) and polls https://api.anthropic.com/api/oauth/usage — the same
+ * data Claude Code's /usage command shows. Only active when
+ * Config.options.bar.claudeUsage.enable is true.
+ *
+ * Requires `jq` and `curl` (already used elsewhere in the shell).
+ */
+Singleton {
+    id: root
+
+    readonly property bool enabled: Config.options.bar.claudeUsage.enable
+    readonly property int fetchInterval: Config.options.bar.claudeUsage.fetchInterval * 60 * 1000
+
+    property bool available: false
+    property string lastError: ""
+    property string subscriptionType: "" // "pro" | "max" | ...
+
+    // Utilization percentages (0-100); -1 means "not reported by the API"
+    property real fiveHour: 0
+    property real sevenDay: 0
+    property real sevenDayOpus: -1
+    property real sevenDaySonnet: -1
+
+    // Reset timestamps (epoch ms; 0 if unknown)
+    property double fiveHourReset: 0
+    property double sevenDayReset: 0
+
+    // Pay-as-you-go extra credits
+    property bool extraEnabled: false
+    property real extraUsedCredits: 0
+    property real extraMonthlyLimit: 0
+    property string extraCurrency: ""
+
+    function _pct(v) {
+        return (v === null || v === undefined) ? -1 : v;
+    }
+
+    function _parseIso(s) {
+        if (!s)
+            return 0;
+        const t = Date.parse(s);
+        return isNaN(t) ? 0 : t;
+    }
+
+    // Human "2h 5m" until the given epoch-ms. References DateTime.time so it
+    // recomputes on the clock tick.
+    function timeUntil(epochMs) {
+        DateTime.time; // reactivity dependency
+        if (!epochMs)
+            return "—";
+        let diff = Math.floor((epochMs - Date.now()) / 1000);
+        if (diff <= 0)
+            return Translation.tr("now");
+        const d = Math.floor(diff / 86400);
+        diff %= 86400;
+        const h = Math.floor(diff / 3600);
+        diff %= 3600;
+        const m = Math.floor(diff / 60);
+        let out = "";
+        if (d > 0)
+            out += `${d}d `;
+        if (h > 0)
+            out += `${h}h `;
+        out += `${m}m`;
+        return out.trim();
+    }
+
+    function refine(data) {
+        root.subscriptionType = data.subscriptionType ?? "";
+        root.fiveHour = data.five_hour?.utilization ?? 0;
+        root.sevenDay = data.seven_day?.utilization ?? 0;
+        root.sevenDayOpus = root._pct(data.seven_day_opus?.utilization);
+        root.sevenDaySonnet = root._pct(data.seven_day_sonnet?.utilization);
+        root.fiveHourReset = root._parseIso(data.five_hour?.resets_at);
+        root.sevenDayReset = root._parseIso(data.seven_day?.resets_at);
+        const ex = data.extra_usage;
+        root.extraEnabled = ex?.is_enabled ?? false;
+        root.extraUsedCredits = ex?.used_credits ?? 0;
+        root.extraMonthlyLimit = ex?.monthly_limit ?? 0;
+        root.extraCurrency = ex?.currency ?? "";
+        root.available = true;
+        root.lastError = "";
+    }
+
+    function getData() {
+        if (!root.enabled)
+            return;
+        fetcher.running = false;
+        fetcher.running = true;
+    }
+
+    Process {
+        id: fetcher
+        command: ["bash", "-c", "creds=\"$HOME/.claude/.credentials.json\"; " + "tok=$(jq -r '.claudeAiOauth.accessToken' \"$creds\" 2>/dev/null); " + "sub=$(jq -r '.claudeAiOauth.subscriptionType' \"$creds\" 2>/dev/null); " + "if [ -z \"$tok\" ] || [ \"$tok\" = null ]; then echo '{\"error\":\"no Claude token\"}'; exit 0; fi; " + "curl -s --max-time 10 " + "-H \"Authorization: Bearer $tok\" " + "-H \"anthropic-beta: oauth-2025-04-20\" " + "-H \"anthropic-version: 2023-06-01\" " + "https://api.anthropic.com/api/oauth/usage " + "| jq -c --arg sub \"$sub\" '. + {subscriptionType:$sub}'"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (text.trim().length === 0) {
+                    root.available = false;
+                    root.lastError = "empty response";
+                    return;
+                }
+                try {
+                    const d = JSON.parse(text);
+                    if (d.error) {
+                        root.available = false;
+                        root.lastError = String(d.error);
+                        return;
+                    }
+                    root.refine(d);
+                } catch (e) {
+                    root.available = false;
+                    root.lastError = e.message;
+                    console.error(`[ClaudeUsage] ${e.message}: ${text}`);
+                }
+            }
+        }
+    }
+
+    Timer {
+        running: root.enabled
+        repeat: true
+        interval: root.fetchInterval
+        triggeredOnStart: true
+        onTriggered: root.getData()
+    }
+}

--- a/dots/.config/quickshell/ii/services/ClaudeUsage.qml
+++ b/dots/.config/quickshell/ii/services/ClaudeUsage.qml
@@ -110,6 +110,7 @@ Singleton {
                 if (text.trim().length === 0) {
                     root.available = false;
                     root.lastError = "empty response";
+                    retryTimer.restart();
                     return;
                 }
                 try {
@@ -117,12 +118,14 @@ Singleton {
                     if (d.error) {
                         root.available = false;
                         root.lastError = String(d.error);
+                        retryTimer.restart();
                         return;
                     }
                     root.refine(d);
                 } catch (e) {
                     root.available = false;
                     root.lastError = e.message;
+                    retryTimer.restart();
                     console.error(`[ClaudeUsage] ${e.message}: ${text}`);
                 }
             }
@@ -135,5 +138,15 @@ Singleton {
         interval: root.fetchInterval
         triggeredOnStart: true
         onTriggered: root.getData()
+    }
+
+    // Quick retry while we don't have data yet (cold start / token mid-refresh /
+    // transient network), so a failed first fetch doesn't leave "Unavailable"
+    // showing until the next full interval.
+    Timer {
+        id: retryTimer
+        interval: 15000
+        repeat: false
+        onTriggered: if (root.enabled && !root.available) root.getData()
     }
 }


### PR DESCRIPTION
## Describe your changes

Adds a small bar module that shows your **Claude (Pro/Max) subscription usage** — handy for people who live in Claude Code and want to keep an eye on their limits without running `/usage`. Inspired by the macOS app CodexBar, but native to the shell.

It is **opt-in and purely additive**: gated behind `bar.claudeUsage.enable` (default `false`), shown next to the media widget. Nothing changes for existing users unless they enable it.

**What it looks like (when enabled):** two `Resources`-style gauges in the center group —
- ⟳ **5-hour session** utilization
- 📅 **7-day** utilization (toggle via `showWeekly`)

Gauges turn red past `warningThreshold`. Hovering shows a popup with per-model usage (Opus/Sonnet), reset countdowns, and pay-as-you-go extra credits. Left-click forces a refresh.

**How it gets data:** reads the OAuth access token from `~/.claude/.credentials.json` (kept fresh by Claude Code) and polls `https://api.anthropic.com/api/oauth/usage` — the exact data Claude Code's `/usage` command shows. Requires `jq` and `curl` (already used elsewhere in the shell). When no token is present or the request fails, the popup shows an "Unavailable" message and the gauges read `–`.

### Files
- `services/ClaudeUsage.qml` — singleton poller (only active when enabled)
- `modules/ii/bar/ClaudeUsageBar.qml` — the gauges + hover popup
- `modules/ii/bar/BarContent.qml` — renders it via a `Loader` gated on the toggle
- `modules/common/Config.qml` — `bar.claudeUsage { enable, showWeekly, warningThreshold, fetchInterval }`

### Config
```jsonc
"bar": {
  "claudeUsage": {
    "enable": true,
    "showWeekly": true,
    "warningThreshold": 90,
    "fetchInterval": 5   // minutes
  }
}
```

## Is it ready? Questions/feedback needed?

Ready for review. Tested live on Quickshell (Hyprland, Claude Max) — loads cleanly with the option on and off. Follows existing conventions (`ClippedFilledCircularProgress`, `StyledPopup`, `Translation.tr`, service-singleton + `Process`/`StdioCollector` like `Weather.qml`). Happy to adjust naming, default interval, icons, or placement.