### PR TITLE
Fix right sidebar corner trigger reopening after dismiss

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/screenCorners/ScreenCorners.qml
+++ b/dots/.config/quickshell/ii/modules/ii/screenCorners/ScreenCorners.qml
@@ -12,19 +12,52 @@ import Quickshell.Hyprland
 Scope {
     id: screenCorners
     readonly property Toplevel activeWindow: ToplevelManager.activeToplevel
-    property var actionForCorner: ({
-        [RoundCorner.CornerEnum.TopLeft]: () => GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen,
-        [RoundCorner.CornerEnum.BottomLeft]: () => GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen,
-        [RoundCorner.CornerEnum.TopRight]: () => GlobalStates.sidebarRightOpen = !GlobalStates.sidebarRightOpen,
-        [RoundCorner.CornerEnum.BottomRight]: () => GlobalStates.sidebarRightOpen = !GlobalStates.sidebarRightOpen
-    })
+
+    function isLeftCorner(corner) {
+        return corner === RoundCorner.CornerEnum.TopLeft || corner === RoundCorner.CornerEnum.BottomLeft;
+    }
+
+    function openSidebarForCorner(corner) {
+        if (isLeftCorner(corner))
+            GlobalStates.sidebarLeftOpen = true;
+        else
+            GlobalStates.sidebarRightOpen = true;
+    }
+
+    function toggleSidebarForCorner(corner) {
+        if (isLeftCorner(corner))
+            GlobalStates.sidebarLeftOpen = !GlobalStates.sidebarLeftOpen;
+        else
+            GlobalStates.sidebarRightOpen = !GlobalStates.sidebarRightOpen;
+    }
 
     component CornerPanelWindow: PanelWindow {
         id: cornerPanelWindow
         property var brightnessMonitor: Brightness.getMonitorForScreen(screen)
         property bool fullscreen
+        property bool cornerTriggerActive: false
+        property bool registeredAsFocusGrabPersistent: false
         visible: (Config.options.appearance.fakeScreenRounding === 1 || (Config.options.appearance.fakeScreenRounding === 2 && !fullscreen))
         property var corner
+
+        function updateFocusGrabPersistence() {
+            const shouldRegister = visible && cornerTriggerActive;
+            if (registeredAsFocusGrabPersistent === shouldRegister)
+                return;
+
+            registeredAsFocusGrabPersistent = shouldRegister;
+            if (shouldRegister)
+                GlobalFocusGrab.addPersistent(cornerPanelWindow);
+            else
+                GlobalFocusGrab.removePersistent(cornerPanelWindow);
+        }
+
+        onVisibleChanged: updateFocusGrabPersistence()
+        Component.onCompleted: updateFocusGrabPersistence()
+        Component.onDestruction: {
+            if (registeredAsFocusGrabPersistent)
+                GlobalFocusGrab.removePersistent(cornerPanelWindow);
+        }
 
         exclusionMode: ExclusionMode.Ignore
         mask: Region {
@@ -66,6 +99,12 @@ Scope {
                     if (cornerPanelWindow.fullscreen) return false;
                     return (Config.options.sidebar.cornerOpen.bottom == cornerWidget.isBottom);
                 }
+                function syncFocusGrabPersistence() {
+                    cornerPanelWindow.cornerTriggerActive = active;
+                    cornerPanelWindow.updateFocusGrabPersistence();
+                }
+                Component.onCompleted: syncFocusGrabPersistence()
+                onActiveChanged: syncFocusGrabPersistence()
                 anchors {
                     top: (cornerWidget.isTopLeft || cornerWidget.isTopRight) ? parent.top : undefined
                     bottom: (cornerWidget.isBottomLeft || cornerWidget.isBottomRight) ? parent.bottom : undefined
@@ -84,14 +123,14 @@ Scope {
                         const correctX = (cornerWidget.isRight && mouseArea.mouseX >= mouseArea.width - 2) || (cornerWidget.isLeft && mouseArea.mouseX <= 2);
                         const correctY = (cornerWidget.isTop && mouseArea.mouseY > verticalOffset || cornerWidget.isBottom && mouseArea.mouseY < mouseArea.height - verticalOffset);
                         if (correctX && correctY)
-                            screenCorners.actionForCorner[cornerPanelWindow.corner]();
+                            screenCorners.openSidebarForCorner(cornerPanelWindow.corner);
                     }
                     onEntered: {
                         if (Config.options.sidebar.cornerOpen.clickless)
-                            screenCorners.actionForCorner[cornerPanelWindow.corner]();
+                            screenCorners.openSidebarForCorner(cornerPanelWindow.corner);
                     }
                     onPressed: {
-                        screenCorners.actionForCorner[cornerPanelWindow.corner]();
+                        screenCorners.toggleSidebarForCorner(cornerPanelWindow.corner);
                     }
                     onScrollDown: {
                         if (!Config.options.sidebar.cornerOpen.valueScroll)


### PR DESCRIPTION
## Describe your changes

Fixes a right sidebar corner trigger issue where clicking the top-right corner area while the sidebar was already open could immediately retrigger the sidebar open animation.

The issue happened because the corner interaction could still fire after the sidebar had just been dismissed, causing sidebarRightOpen to go from true to false and back to true during the same interaction.

This change prevents the top-right corner trigger from reopening the right sidebar immediately after it has been dismissed, while keeping the expected corner/sidebar behavior intact.

## Is it ready? Questions/feedback needed?

Ready for review.

