### PR TITLE
feat: add Wi-Fi rescan button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 
 # Emacs auto backup file
 *~
+
+# test scripts
+/test

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/wifiNetworks/WifiDialog.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/wifiNetworks/WifiDialog.qml
@@ -11,8 +11,42 @@ WindowDialog {
     id: root
     backgroundHeight: 600
 
-    WindowDialogTitle {
-        text: Translation.tr("Connect to Wi-Fi")
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.leftMargin: 4
+        Layout.rightMargin: 4
+
+        WindowDialogTitle {
+            Layout.fillWidth: true
+            text: Translation.tr("Connect to Wi-Fi")
+        }
+
+        MouseArea {
+            Layout.alignment: Qt.AlignVCenter
+            implicitWidth: 36
+            implicitHeight: 36
+            cursorShape: Network.wifiScanning ? Qt.ArrowCursor : Qt.PointingHandCursor
+
+            enabled: !Network.wifiScanning
+            opacity: Network.wifiScanning ? 0.4 : 1
+
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 150
+                }
+            }
+
+            onClicked: {
+                Network.rescanWifi()
+            }
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "restart_alt"
+                iconSize: 20
+                color: Appearance.colors.colOnLayer0
+            }
+        }
     }
     WindowDialogSeparator {
         visible: !Network.wifiScanning

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/wifiNetworks/WifiDialog.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/wifiNetworks/WifiDialog.qml
@@ -21,11 +21,12 @@ WindowDialog {
             text: Translation.tr("Connect to Wi-Fi")
         }
 
-        MouseArea {
+        DialogButton {
+            id: rescanButton
             Layout.alignment: Qt.AlignVCenter
             implicitWidth: 36
             implicitHeight: 36
-            cursorShape: Network.wifiScanning ? Qt.ArrowCursor : Qt.PointingHandCursor
+            buttonText: ""
 
             enabled: !Network.wifiScanning
             opacity: Network.wifiScanning ? 0.4 : 1
@@ -36,15 +37,17 @@ WindowDialog {
                 }
             }
 
-            onClicked: {
-                Network.rescanWifi()
-            }
+            onClicked: Network.rescanWifi()
 
-            MaterialSymbol {
-                anchors.centerIn: parent
-                text: "restart_alt"
-                iconSize: 20
-                color: Appearance.colors.colOnLayer0
+            contentItem: Item {
+                anchors.fill: parent
+
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "restart_alt"
+                    iconSize: 20
+                    color: rescanButton.enabled ? rescanButton.colEnabled : rescanButton.colDisabled
+                }
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

Adds a Wi-Fi rescan button to manually refresh the available network list.

The button triggers a Wi-Fi rescan and provides visual feedback while scanning, making it temporarily disabled/less prominent until the scan finishes. This prevents repeated scan requests while one is already running.

## Is it ready? Questions/feedback needed?

Ready for review.
