### PR TITLE
fix: improve Bluetooth toggle behavior

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidBluetoothToggle.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidBluetoothToggle.qml
@@ -11,4 +11,11 @@ AndroidQuickToggleButton {
     id: root
     
     toggleModel: BluetoothToggle {}
+
+    mainAction: () => {
+        Quickshell.execDetached([
+            "bash", "-lc",
+            "rfkill list bluetooth | grep -q 'Soft blocked: yes' && rfkill unblock bluetooth || rfkill block bluetooth"
+        ])
+    }
 }


### PR DESCRIPTION
## Describe your changes

Improves the Bluetooth toggle so turning Bluetooth on also makes sure the adapter is enabled.

This fixes an issue on my system where the sidebar Bluetooth toggle did not turn Bluetooth back on correctly after it had been disabled at the adapter/radio level.

## Is it ready? Questions/feedback needed?

Ready for review.
