### PR TITLE
fix(songrec): grep pattern never matched real songrec JSON output

### DIFF
--- a/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
+++ b/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
@@ -46,7 +46,7 @@ SONGREC_PID=$!
 ( sleep "$TOTAL_DURATION" && kill "$SONGREC_PID" 2>/dev/null ) &
 
 while IFS= read -r line; do
-    if echo "$line" | grep -q '"matches": \['; then
+    if echo "$line" | grep -q '"track":'; then
         echo "$line"
         exit 0
     fi


### PR DESCRIPTION
## Describe your changes

`recognize-music.sh` matches recognition results with `grep -q '"matches": \['` (with a space after the colon), but `songrec listen --json` emits compact JSON with no space (`"matches":[`). The grep never matches, so the script always falls through to the unconditional `exit 0` at the bottom with empty stdout — even when songrec successfully recognizes the track. This means music recognition silently fails 100% of the time regardless of audio source/interval settings. Confirmed via `bash -x`: songrec correctly identifies tracks (e.g. Billie Jean - Michael Jackson) but the script never forwards the result. Fix: match on `"track":` instead, which is also more semantically correct since that's the key the QML side actually reads (`obj.track.title`).

## Is it ready? Questions/feedback needed?
Ready.
