### PR TITLE
Update three-finger pinch gesture action

### DIFF
--- a/dots/.config/hypr/hyprland/general.lua
+++ b/dots/.config/hypr/hyprland/general.lua
@@ -14,7 +14,7 @@ hl.gesture({
 hl.gesture({
     fingers = 3,
     direction = "pinch",
-    action = "fullscreen"
+    action = "float" -- to make the window floating instead of full screen
 })
 hl.gesture({
     fingers = 4,


### PR DESCRIPTION
Changed the action for a three-finger pinch gesture from fullscreen to floating.

## Describe your changes
Previously, whenever I pinched using 3 fingers, it would make the focused window float. However, after the recent update, the action mapped to that gesture changed to fullscreen. To fix this, I changed the value from ```'fullscreen'``` to ```'float'``` on line 17 in the file ```.config/hypr/hyprland/general.lua```.
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes