### PR TITLE
feat: AI Sidebar - stick-to-bottom auto-scroll for AI chat

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
@@ -15,6 +15,10 @@ ListView {
     property bool popin: true
     property bool animateAppearance: true
     property bool animateMovement: false
+    // Set false to snap contentY instantly instead of animating (e.g. for auto-follow)
+    property bool smoothScroll: true
+    // Duration of the contentY scroll animation; keep short for auto-follow
+    property int scrollDuration: Appearance.animation.scroll.duration
     // Accumulated scroll destination so wheel deltas stack while animating
     property real scrollTargetY: 0
 
@@ -52,10 +56,11 @@ ListView {
     }
 
     Behavior on contentY {
+        enabled: root.smoothScroll
         NumberAnimation {
             id: scrollAnim
             alwaysRunToEnd: true
-            duration: Appearance.animation.scroll.duration
+            duration: root.scrollDuration
             easing.type: Appearance.animation.scroll.type
             easing.bezierCurve: Appearance.animation.scroll.bezierCurve
         }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -364,15 +364,24 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 mouseScrollFactor: Config.options.interactions.scrolling.mouseScrollFactor * 1.4
 
                 property int lastResponseLength: 0
-                // onContentHeightChanged: {
-                //     if (atYEnd)
-                //         Qt.callLater(positionViewAtEnd);
-                // }
-                // onCountChanged: {
-                //     // Auto-scroll when new messages are added
-                //     if (atYEnd)
-                //         Qt.callLater(positionViewAtEnd);
-                // }
+
+                // Stick-to-bottom while streaming (like a claude-code style terminal)
+                property bool followBottom: true
+                // While following, use a short scroll animation to dampen erratic height changes
+                scrollDuration: followBottom ? 70 : Appearance.animation.scroll.duration
+
+                onContentHeightChanged: { // text grew during streaming
+                    if (followBottom)
+                        Qt.callLater(positionViewAtEnd);
+                }
+                onCountChanged: { // a new message was added
+                    if (followBottom)
+                        Qt.callLater(positionViewAtEnd);
+                }
+                // Decouple when a user gesture begins (flick/drag/wheel set moving).
+                onMovingChanged: if (moving) followBottom = false
+                // When the gesture ends, re-attach only if they came to rest at the bottom.
+                onMovementEnded: followBottom = atYEnd
 
                 add: null // Prevent function calls from being janky
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/ScrollToBottomButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/ScrollToBottomButton.qml
@@ -14,8 +14,15 @@ RippleButton {
         bottomMargin: 10
     }
 
-    opacity: !target.atYEnd ? 1 : 0
-    scale: !target.atYEnd ? 1 : 0.7
+    // Show only when the user scrolled away, not during auto-follow; key off followBottom
+    // (not raw distance, which the 70ms follow lags) and require a meaningful gap
+    property real showThreshold: Math.max(200, target.height * 0.3)
+    readonly property real distanceFromBottom: target.contentHeight - target.height - target.contentY
+    readonly property bool following: target.followBottom === true
+    readonly property bool shouldShow: !following && distanceFromBottom > showThreshold
+
+    opacity: shouldShow ? 1 : 0
+    scale: shouldShow ? 1 : 0.7
     visible: opacity > 0
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
@@ -34,6 +41,7 @@ RippleButton {
 
     downAction: () => {
         target.positionViewAtEnd()
+        if (target.followBottom !== undefined) target.followBottom = true // re-engage auto-follow
     }
 
     contentItem: Row {

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -24,7 +24,17 @@ Rectangle {
 
     anchors.left: parent?.left
     anchors.right: parent?.right
-    implicitHeight: columnLayout.implicitHeight + root.messagePadding * 2
+
+    // While streaming (!done), never let the bubble shrink: markdown reflow (esp. tables)
+    // transiently collapses height and jolts the auto-scroll. Floor it until done.
+    readonly property real naturalHeight: columnLayout.implicitHeight + root.messagePadding * 2
+    property real streamingHeightFloor: 0
+    implicitHeight: (messageData && !messageData.done) ? Math.max(naturalHeight, streamingHeightFloor) : naturalHeight
+    onNaturalHeightChanged: {
+        if (messageData && !messageData.done)
+            streamingHeightFloor = Math.max(streamingHeightFloor, naturalHeight);
+    }
+    onMessageDataChanged: streamingHeightFloor = 0 // reset if this delegate is reused for another message
 
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1


### PR DESCRIPTION
Hi End-4 team! 

This is my first PR on the project so I've made sure its just a small one. I've been using the AI sidebar quite a bit with Nemotron ultra training it on my specific setup so that editing configs and diagnosing issues becomes a bit easier. When using it I was often bothered by the lack of scroll behavior that I'm used to in claude code - which I use a lot for my day job. I wanted to add something similar to the sidebar and I noticed some commented out code where an attempt had already been made to implement similar behavior. I hope my (and Claude's) code is up to your standards and if there's anything that's noncompliant or could be made better please let me know! :3

## Describe your changes

The AI-chat sidebar now rides the bottom as a response streams in, stops following the moment the user scrolls up, and re-engages on return to the bottom.

- AiChat.qml: replace the disabled atYEnd-based auto-scroll with a followBottom flag driven by gesture signals (movingChanged/movementEnded), not raw contentY; 70ms scrollDuration while following.
- StyledListView.qml: add scrollDuration + smoothScroll gate on the contentY Behavior; defaults preserve existing behavior elsewhere.
- ScrollToBottomButton.qml: show only when !followBottom and far enough from the bottom; clicking re-engages follow.
- AiMessage.qml: monotonic streaming height floor while !done to prevent scroll jolts when markdown (e.g. tables) transiently collapses on reparse.

## Is it ready? Questions/feedback needed?

I did a little IT testing on my own device and it seemed robust but depending on how thorough you want to be it might warrant more.
