### PR TITLE
fix(wallpapers): derive defaultFolder from saved wallpaperPath

### DIFF
--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -19,7 +19,7 @@ Singleton {
     property string generateThumbnailsMagickScriptPath: `${FileUtils.trimFileProtocol(Directories.scriptPath)}/thumbnails/generate-thumbnails-magick.sh`
     property alias directory: folderModel.folder
     readonly property string effectiveDirectory: FileUtils.trimFileProtocol(folderModel.folder.toString())
-    property url defaultFolder: Qt.resolvedUrl(`${Directories.pictures}/Wallpapers`)
+    property url defaultFolder: Qt.resolvedUrl(FileUtils.parentDirectory(Config.options.background.wallpaperPath) || `${Directories.pictures}/Wallpapers`)
     property alias folderModel: folderModel // Expose for direct binding when needed
     property string searchQuery: ""
     readonly property list<string> extensions: [ // TODO: add videos


### PR DESCRIPTION
The defaultFolder was hardcoded to ~/Pictures/Wallpapers, causing randomFromCurrentFolder() to silently bail out (folderModel.count === 0) when that directory doesn't exist — e.g. when wallpapers are stored elsewhere such as ~/Wallpapers.

Now defaultFolder is derived from the parent directory of the persisted wallpaperPath in config.json, falling back to ~/Pictures/Wallpapers only when no wallpaper has been set yet (fresh install).

Ready and tested in my local


