### PR TITLE
booru: change directory to wallpapers

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Directories.qml
+++ b/dots/.config/quickshell/ii/modules/common/Directories.qml
@@ -27,8 +27,8 @@ Singleton {
     property string coverArt: FileUtils.trimFileProtocol(`${Directories.cache}/media/coverart`)
     property string tempImages: "/tmp/quickshell/media/images"
     property string booruPreviews: FileUtils.trimFileProtocol(`${Directories.cache}/media/boorus`)
-    property string booruDownloads: FileUtils.trimFileProtocol(Directories.pictures  + "/homework")
-    property string booruDownloadsNsfw: FileUtils.trimFileProtocol(Directories.pictures + "/homework/🌶️")
+    property string booruDownloads: FileUtils.trimFileProtocol(Directories.pictures  + "/Wallpapers")
+    property string booruDownloadsNsfw: FileUtils.trimFileProtocol(Directories.pictures + "/Wallpapers/🌶️")
     property string latexOutput: FileUtils.trimFileProtocol(`${Directories.cache}/media/latex`)
     property string shellConfig: FileUtils.trimFileProtocol(`${Directories.config}/illogical-impulse`)
     property string shellConfigName: "config.json"

--- a/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -202,8 +202,8 @@ MouseArea {
                             ...(Config.options.policies.weeb === 1 ? [
                                     {
                                         icon: "favorite",
-                                        name: "Homework",
-                                        path: `${Directories.pictures}/homework`
+                                        name: "Wallpapers",
+                                        path: `${Directories.pictures}/Wallpapers`
                                     }
                                 ] : []),]
                         delegate: RippleButton {


### PR DESCRIPTION
## Describe your changes

* Changes `homework` to `Wallpapers`

## Is it ready? Questions/feedback needed?
yes, but this would require the user, to rename the homework folder to Wallpapers in the future, i like things be sorted, i believe the homework name ain't that good. most booru websites have good qualities, meaning users use it for for wallpapers.
