### PR TITLE
fix(network): Prevent process re-entrancy crash on rapid wifi state changes (Random shell crash fix caused by network.qml)

### DIFF
--- a/dots/.config/quickshell/ii/services/Network.qml
+++ b/dots/.config/quickshell/ii/services/Network.qml
@@ -153,11 +153,35 @@ Singleton {
     }
 
     // Status update
+    // NOTE: debounced. nmcli monitor can emit several lines within the same
+    // second during wifi state changes (radio off/on, scan, associate, DHCP,
+    // connected). Previously each line called update() unconditionally,
+    // which could set running = true on a Process that was already running,
+    // racing its in-flight stdout callback teardown and crashing quickshell.
+    // Now a call that arrives while the previous batch is still in flight is
+    // deferred via pendingUpdate and re-run once every process has exited.
+    property bool pendingUpdate: false
+
     function update() {
+        if (updateConnectionType.running || wifiStatusProcess.running ||
+            updateNetworkName.running || updateNetworkStrength.running) {
+            pendingUpdate = true;
+            return;
+        }
         updateConnectionType.startCheck();
-        wifiStatusProcess.running = true
+        wifiStatusProcess.running = true;
         updateNetworkName.running = true;
         updateNetworkStrength.running = true;
+    }
+
+    function maybeRunPendingUpdate() {
+        if (!pendingUpdate)
+            return;
+        if (updateConnectionType.running || wifiStatusProcess.running ||
+            updateNetworkName.running || updateNetworkStrength.running)
+            return;
+        pendingUpdate = false;
+        update();
     }
 
     Process {
@@ -216,6 +240,7 @@ Singleton {
             root.wifiStatus = wifiStatus;
             root.ethernet = hasEthernet;
             root.wifi = hasWifi;
+            root.maybeRunPendingUpdate();
         }
     }
 
@@ -228,6 +253,9 @@ Singleton {
                 root.networkName = data;
             }
         }
+        onExited: (exitCode, exitStatus) => {
+            root.maybeRunPendingUpdate();
+        }
     }
 
     Process {
@@ -238,6 +266,9 @@ Singleton {
             onRead: data => {
                 root.networkStrength = parseInt(data);
             }
+        }
+        onExited: (exitCode, exitStatus) => {
+            root.maybeRunPendingUpdate();
         }
     }
 
@@ -252,6 +283,7 @@ Singleton {
         stdout: StdioCollector {
             onStreamFinished: {
                 root.wifiEnabled = text.trim() === "enabled";
+                root.maybeRunPendingUpdate();
             }
         }
     }

--- a/dots/.config/quickshell/ii/services/Network.qml
+++ b/dots/.config/quickshell/ii/services/Network.qml
@@ -240,8 +240,12 @@ Singleton {
             root.wifiStatus = wifiStatus;
             root.ethernet = hasEthernet;
             root.wifi = hasWifi;
-            root.maybeRunPendingUpdate();
         }
+        // onExited never fires if nmcli fails to *launch* (e.g. missing binary/PATH
+        // issue) - Quickshell's Process only emits runningChanged in that case.
+        // running is the one signal guaranteed to fire either way, so use it to
+        // release the pendingUpdate guard instead of relying on onExited alone.
+        onRunningChanged: if (!running) root.maybeRunPendingUpdate()
     }
 
     Process {
@@ -253,9 +257,7 @@ Singleton {
                 root.networkName = data;
             }
         }
-        onExited: (exitCode, exitStatus) => {
-            root.maybeRunPendingUpdate();
-        }
+        onRunningChanged: if (!running) root.maybeRunPendingUpdate()
     }
 
     Process {
@@ -267,9 +269,7 @@ Singleton {
                 root.networkStrength = parseInt(data);
             }
         }
-        onExited: (exitCode, exitStatus) => {
-            root.maybeRunPendingUpdate();
-        }
+        onRunningChanged: if (!running) root.maybeRunPendingUpdate()
     }
 
     Process {
@@ -283,9 +283,9 @@ Singleton {
         stdout: StdioCollector {
             onStreamFinished: {
                 root.wifiEnabled = text.trim() === "enabled";
-                root.maybeRunPendingUpdate();
             }
         }
+        onRunningChanged: if (!running) root.maybeRunPendingUpdate()
     }
 
     Process {


### PR DESCRIPTION
## Describe your changes

Shell was crashing randomly whenever I tried to connect to wifi. After investigating, I found that `Network.qml` sends several requests without waiting for the previous one to finish, and that was crashing the shell.

Specifically: `nmcli monitor` emits several lines in quick succession during wifi state changes (radio toggle, scan, associate, DHCP, connected). Each line called `update()` unconditionally, which could set `running = true` on a `Process` still in flight, racing its teardown and crashing quickshell.

This PR guards `update()` to defer via a `pendingUpdate` flag when any of the four processes are still running, and drains exactly one deferred update once all have exited, via `maybeRunPendingUpdate()`.

## Is it ready? Questions/feedback needed?

Yes, ready for review. Reproduced the crash by rapidly toggling wifi on/off and reconnecting; no crashes after the fix across repeated attempts.

