### PR TITLE
feat(bar): Tailscale exit node selector util button

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -257,6 +257,7 @@ Singleton {
                     property bool showDarkModeToggle: true
                     property bool showPerformanceProfileToggle: false
                     property bool showScreenRecord: false
+                    property bool showTailscale: false
                 }
                 property JsonObject workspaces: JsonObject {
                     property bool monochromeIcons: true

--- a/dots/.config/quickshell/ii/modules/ii/bar/TailscaleButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/TailscaleButton.qml
@@ -1,0 +1,254 @@
+pragma ComponentBehavior: Bound
+
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Hyprland
+
+Item {
+    id: root
+    implicitWidth: button.implicitWidth
+    implicitHeight: button.implicitHeight
+
+    readonly property bool active: Tailscale.exitNodeActive
+    readonly property bool menuOpen: menuLoader.active
+
+    function openMenu() {
+        Tailscale.refresh();
+        menuLoader.active = true;
+    }
+    function closeMenu() {
+        focusGrab.active = false;
+        menuLoader.active = false;
+    }
+    function toggleMenu() {
+        if (menuLoader.active)
+            closeMenu();
+        else
+            openMenu();
+    }
+
+    CircleUtilButton {
+        id: button
+        anchors.centerIn: parent
+        toggled: root.menuOpen
+        onClicked: root.toggleMenu()
+
+        MaterialSymbol {
+            horizontalAlignment: Qt.AlignHCenter
+            fill: root.active ? 1 : 0
+            text: !Tailscale.running ? "vpn_key_off" : root.active ? "vpn_lock" : "vpn_key"
+            iconSize: Appearance.font.pixelSize.large
+            color: root.active ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnLayer2
+
+            StyledToolTip {
+                extraVisibleCondition: button.hovered && !root.menuOpen
+                text: !Tailscale.running ? Translation.tr("Tailscale off") : root.active ? Translation.tr("Exit node: %1").arg(Tailscale.currentExitNodeName) : Translation.tr("No exit node")
+            }
+        }
+    }
+
+    HyprlandFocusGrab {
+        id: focusGrab
+        active: false
+        windows: [menuLoader.item]
+        onCleared: root.closeMenu()
+    }
+
+    // A selectable row: radio state + icon + label/sublabel + online dot.
+    component ExitNodeRow: RippleButton {
+        id: rowButton
+        property bool selected: false
+        property string label: ""
+        property string sublabel: ""
+        property bool online: true
+        property string symbol: "lan"
+
+        Layout.fillWidth: true
+        implicitHeight: 40
+        buttonRadius: Appearance.rounding.verysmall
+        colBackground: ColorUtils.transparentize(Appearance.colors.colLayer1, 1)
+
+        contentItem: RowLayout {
+            anchors {
+                verticalCenter: parent.verticalCenter
+                left: parent.left
+                right: parent.right
+                leftMargin: 8
+                rightMargin: 10
+            }
+            spacing: 8
+
+            MaterialSymbol {
+                iconSize: 20
+                text: rowButton.selected ? "radio_button_checked" : "radio_button_unchecked"
+                color: rowButton.selected ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+            }
+
+            MaterialSymbol {
+                iconSize: 18
+                fill: rowButton.selected ? 1 : 0
+                text: rowButton.symbol
+                color: Appearance.colors.colOnLayer0
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                StyledText {
+                    Layout.fillWidth: true
+                    elide: Text.ElideRight
+                    text: rowButton.label
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colOnLayer0
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    visible: rowButton.sublabel.length > 0
+                    elide: Text.ElideRight
+                    text: rowButton.sublabel
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                }
+            }
+
+            Rectangle {
+                visible: rowButton.sublabel.length > 0
+                implicitWidth: 8
+                implicitHeight: 8
+                radius: 4
+                color: rowButton.online ? Appearance.colors.colOnLayer0 : Appearance.colors.colSubtext
+                opacity: rowButton.online ? 1 : 0.35
+            }
+        }
+    }
+
+    Loader {
+        id: menuLoader
+        active: false
+
+        sourceComponent: PopupWindow {
+            id: menuWindow
+            color: "transparent"
+            visible: true
+
+            readonly property real elevation: Appearance.sizes.elevationMargin
+
+            anchor {
+                window: root.QsWindow.window
+                item: root
+                gravity: (!Config.options.bar.vertical && !Config.options.bar.bottom) ? Edges.Bottom : Edges.Top
+                edges: (!Config.options.bar.vertical && !Config.options.bar.bottom) ? Edges.Bottom : Edges.Top
+            }
+
+            implicitWidth: menuBackground.implicitWidth + elevation * 2
+            implicitHeight: menuBackground.implicitHeight + elevation * 2
+
+            Component.onCompleted: focusGrab.active = true
+
+            StyledRectangularShadow {
+                target: menuBackground
+            }
+
+            Rectangle {
+                id: menuBackground
+                readonly property real padding: 6
+                anchors.centerIn: parent
+                implicitWidth: Math.max(240, contentColumn.implicitWidth + padding * 2)
+                implicitHeight: contentColumn.implicitHeight + padding * 2
+                color: Appearance.colors.colLayer0
+                radius: Appearance.rounding.small
+                border.width: 1
+                border.color: Appearance.colors.colLayer0Border
+
+                ColumnLayout {
+                    id: contentColumn
+                    anchors.centerIn: parent
+                    width: menuBackground.width - menuBackground.padding * 2
+                    spacing: 2
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.margins: 8
+                        Layout.bottomMargin: 4
+                        spacing: 8
+
+                        MaterialSymbol {
+                            iconSize: 20
+                            fill: 1
+                            text: "vpn_lock"
+                            color: Appearance.colors.colOnLayer0
+                        }
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: Translation.tr("Exit node")
+                            font.pixelSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnLayer0
+                        }
+                        RippleButton {
+                            implicitWidth: 26
+                            implicitHeight: 26
+                            buttonRadius: Appearance.rounding.full
+                            releaseAction: () => Tailscale.refresh()
+                            contentItem: MaterialSymbol {
+                                anchors.centerIn: parent
+                                iconSize: 18
+                                text: "refresh"
+                                color: Appearance.colors.colOnLayer0
+                            }
+                            StyledToolTip {
+                                text: Translation.tr("Refresh")
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        implicitHeight: 1
+                        color: Appearance.colors.colLayer0Border
+                    }
+
+                    ExitNodeRow {
+                        selected: !Tailscale.exitNodeActive
+                        label: Translation.tr("None (direct)")
+                        symbol: "public_off"
+                        releaseAction: () => {
+                            Tailscale.clearExitNode();
+                            root.closeMenu();
+                        }
+                    }
+
+                    Repeater {
+                        model: Tailscale.exitNodes
+                        delegate: ExitNodeRow {
+                            required property var modelData
+                            selected: modelData.selected
+                            label: modelData.name
+                            sublabel: modelData.ip
+                            online: modelData.online
+                            symbol: "lan"
+                            releaseAction: () => {
+                                Tailscale.setExitNode(modelData.ip);
+                                root.closeMenu();
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        visible: Tailscale.exitNodes.length === 0
+                        Layout.fillWidth: true
+                        Layout.margins: 8
+                        wrapMode: Text.WordWrap
+                        text: Tailscale.available ? Translation.tr("No exit nodes available") : Tailscale.lastError.length > 0 ? Translation.tr("Unavailable: %1").arg(Tailscale.lastError) : Translation.tr("Tailscale unavailable")
+                        color: Appearance.colors.colSubtext
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/bar/UtilButtons.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/UtilButtons.qml
@@ -123,6 +123,14 @@ Item {
         }
 
         Loader {
+            active: Config.options.bar.utilButtons.showTailscale
+            visible: Config.options.bar.utilButtons.showTailscale
+            sourceComponent: TailscaleButton {
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+
+        Loader {
             active: Config.options.bar.utilButtons.showPerformanceProfileToggle
             visible: Config.options.bar.utilButtons.showPerformanceProfileToggle
             sourceComponent: CircleUtilButton {

--- a/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
@@ -235,6 +235,14 @@ ContentPage {
                     Config.options.bar.utilButtons.showScreenRecord = checked;
                 }
             }
+            ConfigSwitch {
+                buttonIcon: "vpn_lock"
+                text: Translation.tr("Tailscale exit node")
+                checked: Config.options.bar.utilButtons.showTailscale
+                onCheckedChanged: {
+                    Config.options.bar.utilButtons.showTailscale = checked;
+                }
+            }
         }
     }
 

--- a/dots/.config/quickshell/ii/services/Tailscale.qml
+++ b/dots/.config/quickshell/ii/services/Tailscale.qml
@@ -1,0 +1,143 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+/**
+ * Tailscale exit-node state and control.
+ *
+ * Polls `tailscale status --json` and exposes the peers that offer to be an
+ * exit node, plus which one (if any) is currently selected. Selecting a node
+ * runs `tailscale set --exit-node=…`; on machines where the user is not the
+ * Tailscale operator this fails, so it falls back to `pkexec` (a polkit
+ * prompt). Run `sudo tailscale set --operator=$USER` once to skip the prompt.
+ */
+Singleton {
+    id: root
+
+    readonly property int fetchInterval: 5000 // 5 seconds
+
+    property bool available: false // CLI present and responded
+    property bool running: false // BackendState === "Running"
+    property string currentExitNodeId: "" // peer ID of active exit node, "" if none
+    property string lastError: ""
+    // list of { id, name, ip, online, selected }
+    property var exitNodes: []
+
+    readonly property bool exitNodeActive: root.currentExitNodeId.length > 0
+    readonly property string currentExitNodeName: {
+        for (let i = 0; i < root.exitNodes.length; i++)
+            if (root.exitNodes[i].selected)
+                return root.exitNodes[i].name;
+        return "";
+    }
+
+    function refresh() {
+        fetcher.running = false;
+        fetcher.running = true;
+    }
+
+    // Prefer the IPv4 address (cleaner for `--exit-node=`), fall back to first.
+    function _ip4(ips) {
+        if (!ips || ips.length === 0)
+            return "";
+        for (let i = 0; i < ips.length; i++) {
+            const bare = ips[i].split("/")[0];
+            if (bare.indexOf(":") === -1)
+                return bare;
+        }
+        return ips[0].split("/")[0];
+    }
+
+    function refine(data) {
+        root.running = (data.BackendState === "Running");
+        const exitId = data.ExitNodeStatus?.ID ?? "";
+        const nodes = [];
+        const peers = data.Peer ?? {};
+        for (const key in peers) {
+            const p = peers[key];
+            if (!p.ExitNodeOption)
+                continue;
+            nodes.push({
+                id: p.ID ?? "",
+                name: p.HostName ?? "?",
+                ip: root._ip4(p.TailscaleIPs),
+                online: p.Online ?? false,
+                selected: (p.ExitNode === true) || (exitId.length > 0 && p.ID === exitId)
+            });
+        }
+        // Online first, then alphabetical.
+        nodes.sort((a, b) => {
+            if (a.online !== b.online)
+                return a.online ? -1 : 1;
+            return a.name.localeCompare(b.name);
+        });
+        root.exitNodes = nodes;
+        root.currentExitNodeId = exitId;
+        root.available = true;
+        root.lastError = "";
+    }
+
+    function _run(exitArg) {
+        // Try as operator; fall back to polkit if access is denied.
+        const base = `tailscale set --exit-node=${exitArg}`;
+        setter.command = ["bash", "-c", `${base} 2>/dev/null || pkexec ${base}`];
+        setter.running = false;
+        setter.running = true;
+    }
+
+    function setExitNode(ip) {
+        root._run(`${ip} --exit-node-allow-lan-access=true`);
+    }
+
+    function clearExitNode() {
+        root._run("");
+    }
+
+    Process {
+        id: fetcher
+        command: ["tailscale", "status", "--json"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const t = text.trim();
+                if (t.length === 0) {
+                    root.available = false;
+                    root.lastError = "no response";
+                    return;
+                }
+                try {
+                    root.refine(JSON.parse(t));
+                } catch (e) {
+                    root.available = false;
+                    root.lastError = e.message;
+                    console.error(`[Tailscale] ${e.message}: ${t}`);
+                }
+            }
+        }
+        stderr: StdioCollector {
+            onStreamFinished: {
+                if (text.trim().length > 0) {
+                    root.available = false;
+                    root.lastError = text.trim();
+                }
+            }
+        }
+    }
+
+    Process {
+        id: setter
+        // Re-read state as soon as a change lands.
+        onExited: root.refresh()
+    }
+
+    Timer {
+        running: true
+        repeat: true
+        interval: root.fetchInterval
+        triggeredOnStart: true
+        onTriggered: root.refresh()
+    }
+}


### PR DESCRIPTION
## What

Adds an **opt-in** utility button to the bar for selecting a [Tailscale](https://tailscale.com) exit node — a one-click way to route traffic through (or stop routing through) an exit node without dropping to a terminal.

Clicking the button opens a popup listing every peer that advertises itself as an exit node (online nodes first), with the current selection marked by a radio indicator and an online/offline dot. Pick one to route through it, or **None (direct)** to stop using an exit node. A refresh button re-polls on demand.

The bar icon reflects live state:
| State | Icon |
|-------|------|
| Exit node active | `vpn_lock` (filled) |
| No exit node | `vpn_key` |
| Tailscale not running | `vpn_key_off` |

A tooltip shows the active node's name.

## How

- **`services/Tailscale.qml`** — singleton that polls `tailscale status --json` every 5s and exposes the exit-node peers plus `setExitNode()` / `clearExitNode()`. Selection runs `tailscale set --exit-node=…`; if the user isn't the Tailscale operator (so the plain command is denied) it falls back to `pkexec` (a polkit prompt). Running `sudo tailscale set --operator=$USER` once makes it seamless.
- **`modules/ii/bar/TailscaleButton.qml`** — the bar button and its popup menu (dismisses on outside click via `HyprlandFocusGrab`, consistent with the tray menu).
- Wired into `UtilButtons.qml`, gated by `bar.utilButtons.showTailscale` (**default `false`** — nothing changes for existing users), with a matching toggle in the bar settings page.

## Notes

- Fully additive and off by default; no behavior change unless the user enables the toggle.
- No new dependencies beyond the `tailscale` CLI (and `pkexec`, already present on most setups, only used as a privilege fallback).
- Follows existing conventions: `Singleton` + `Process`/`StdioCollector` polling like other services, `CircleUtilButton` for the button, `Translation.tr` for all strings.