### PR TITLE
fix(hypr): session lock not triggering via SUPER+L and idle timeout

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -1,17 +1,17 @@
-$lock_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lock")' & pidof qs quickshell hyprlock || hyprlock
+$lock_cmd = qs -c ${qsConfig:-ii} ipc call lock activate || pidof hyprlock || hyprlock
 # $lock_cmd = pidof hyprlock || hyprlock
 $suspend_cmd = systemctl suspend || loginctl suspend
 
 general {
     lock_cmd = $lock_cmd
-    before_sleep_cmd = loginctl lock-session
-    after_sleep_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lockFocus")'
+    before_sleep_cmd = $lock_cmd
+    after_sleep_cmd = qs -c ${qsConfig:-ii} ipc call lock focus
     inhibit_sleep = 3
 }
 
 listener {
     timeout = 300 # 5mins
-    on-timeout = loginctl lock-session
+    on-timeout = $lock_cmd
 }
 
 listener {

--- a/dots/.config/hypr/hyprland/execs.lua
+++ b/dots/.config/hypr/hyprland/execs.lua
@@ -8,7 +8,7 @@ hl.on("hyprland.start", function ()
 
     -- Core components (authentication, lock screen, notification daemon)
     hl.exec_cmd("gnome-keyring-daemon --start --components=secrets")
-    hl.exec_cmd("hypridle")
+    hl.exec_cmd("pidof hypridle || hypridle")
     hl.exec_cmd("dbus-update-activation-environment --all")
     hl.exec_cmd("sleep 1 && dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP") -- Some fix idk
 

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -332,7 +332,8 @@ hl.bind("SUPER + ALT + Equal",
     hl.dsp.exec_cmd("notify-send 'Urgent notification' 'Ah hell no' -u critical -a 'Hyprland keybind'")) -- # [hidden]
 
 --##! Session
-hl.bind("SUPER + L", hl.dsp.exec_cmd("loginctl lock-session"), { description = "Session: Lock" })
+hl.bind("SUPER + L", hl.dsp.exec_cmd(qsIpcCall .. " lock activate || pidof hyprlock || hyprlock"), { description = "Session: Lock" })
+-- hl.bind("switch:on:Lid Switch", hl.dsp.exec_cmd(qsIpcCall .. " lock activate || pidof hyprlock || hyprlock"), { locked = true }) -- # [hidden] Lock when laptop lid is closed, uncomment to enable
 hl.bind("SUPER + SHIFT + L", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"),
     { locked = true, description = "Session: Sleep" }) -- Sleep
 -- hl.bind("switch:on:Lid Switch", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"), {locked = true} ) -- # [hidden] Suspend when laptop lid is closed, uncomment if for whatever reason it's not the default behavior


### PR DESCRIPTION
## Describe your changes

<!-- ONE FEATURE PER PULL REQUEST ONLY -->

Fixes the lock screen not activating when using `SUPER+L`, after the idle timeout, or before the system goes to sleep.

Closes #3391. Related to #3341.

While investigating this, I found that both `loginctl lock-session` and `hyprctl dispatch global quickshell:lock` don't reliably trigger the QuickShell lock screen. The `global` dispatch also throws the following Lua parse error:

```text
error: [string "return hl.dispatch(global quickshell:lock)"]:1: ')' expected near 'quickshell'
```

The working approach is to use the QuickShell IPC:

```sh
qs -c $qsConfig ipc call lock activate
```

### hypridle.conf

* Updated `$lock_cmd` to use `qs ipc call lock activate`, with `hyprlock` as a fallback.
* Replaced `loginctl lock-session` in both `before_sleep_cmd` and the 5min idle timeout with `$lock_cmd`.
* Changed `after_sleep_cmd` to use `qs ipc call lock focus`.

### hyprland/keybinds.lua

* Updated the `SUPER+L` binding to use the same QuickShell IPC command (with `hyprlock` as a fallback) instead of `loginctl lock-session`.
* Added a commented out `switch:on:Lid Switch` lock binding to match the existing commented lid suspend binding.

### hyprland/execs.lua

* Guarded `hypridle` startup with `pidof hypridle ||` to prevent duplicate instances after a Hyprland reload.

## Is it ready? Questions/feedback needed?

Tested and Ready for review.

Tested by running `qs -c ii ipc call lock activate` to verify the lock screen activates correctly, and by reloading Hyprland and restarting `hypridle` to confirm the updated configuration is picked up.
