### PR TITLE
feat(ai): OpenAI-format function calling + stable streaming scroll

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/StyledListView.qml
@@ -15,6 +15,10 @@ ListView {
     property bool popin: true
     property bool animateAppearance: true
     property bool animateMovement: false
+    // When false, contentY changes apply instantly (no scroll easing). Used for
+    // streaming auto-follow: animating every token-driven height change fights
+    // itself and looks janky, whereas instant pinning is smooth.
+    property bool animateContentY: true
     // Accumulated scroll destination so wheel deltas stack while animating
     property real scrollTargetY: 0
 
@@ -52,6 +56,7 @@ ListView {
     }
 
     Behavior on contentY {
+        enabled: root.animateContentY
         NumberAnimation {
             id: scrollAnim
             alwaysRunToEnd: true

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -30,6 +30,7 @@ Item {
         messageInputField.forceActiveFocus();
         if (event.modifiers === Qt.NoModifier) {
             if (event.key === Qt.Key_PageUp) {
+                messageListView.autoFollow = false; // reading intent beats streaming pin
                 messageListView.contentY = Math.max(0, messageListView.contentY - messageListView.height / 2);
                 event.accepted = true;
             } else if (event.key === Qt.Key_PageDown) {
@@ -363,16 +364,51 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 touchpadScrollFactor: Config.options.interactions.scrolling.touchpadScrollFactor * 1.4
                 mouseScrollFactor: Config.options.interactions.scrolling.mouseScrollFactor * 1.4
 
+                // Keep the streaming text comfortably above the very bottom edge
+                // ("preheat" the generation zone) instead of jammed against input.
+                bottomMargin: 12
+
                 property int lastResponseLength: 0
-                // onContentHeightChanged: {
-                //     if (atYEnd)
-                //         Qt.callLater(positionViewAtEnd);
-                // }
-                // onCountChanged: {
-                //     // Auto-scroll when new messages are added
-                //     if (atYEnd)
-                //         Qt.callLater(positionViewAtEnd);
-                // }
+
+                // --- Streaming auto-follow (smooth) ---
+                // Pin to the bottom INSTANTLY (no scroll easing) as the response
+                // grows, but only while the user is already at the bottom. If they
+                // scroll up, follow disengages; when they return to the bottom (or
+                // hit the scroll-to-bottom button) it re-engages. Instant pinning
+                // avoids the jank of animating every token-driven height change.
+                property bool autoFollow: true
+                property bool pinning: false
+                property bool pinQueued: false
+                // Hysteresis band (px from the true bottom). Asymmetric on purpose:
+                //  - RE-ENGAGE only when the user lands (near) exactly at the bottom,
+                //    so scrolling up to read never gets magnetically yanked back down.
+                //  - the wide old 40px band was the "magnetism": any downward scroll
+                //    passing within 40px snapped follow back on mid-gesture.
+                readonly property real followReengagePx: 6
+                function pinBottom() {
+                    pinQueued = false;
+                    if (!autoFollow) return;               // user scrolled away since queued
+                    const maxY = Math.max(0, contentHeight - height);
+                    if (contentY >= maxY - 1) return;      // already at end → no redundant pin (kills shake)
+                    pinning = true;
+                    animateContentY = false;               // instant, bypass scroll easing
+                    contentY = maxY;
+                    animateContentY = true;
+                    pinning = false;
+                }
+                // User grabbing/flicking the list disengages follow immediately.
+                onDraggingChanged: if (dragging) autoFollow = false
+                onContentHeightChanged: {
+                    // Coalesce the burst of height changes streaming produces into
+                    // one pin per event loop, instead of one per token.
+                    if (autoFollow && !pinQueued) { pinQueued = true; Qt.callLater(pinBottom); }
+                }
+                onContentYChanged: {
+                    if (pinning) return;                   // ignore our own pin
+                    const maxY = Math.max(0, contentHeight - height);
+                    if (contentY < maxY - followReengagePx) autoFollow = false;   // moved up → let go
+                    else if (contentY >= maxY - 1) autoFollow = true;             // landed at bottom → follow
+                }
 
                 add: null // Prevent function calls from being janky
 
@@ -390,6 +426,22 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                         Ai.messageByID[modelData];
                     }
                     messageInputField: root.inputField
+                }
+            }
+
+            MouseArea {
+                // Wheel-intent watcher. Position-based disengage (onContentYChanged)
+                // loses the race while streaming: at gesture start contentY is still
+                // inside the bottom band, so a queued pin yanks the view back down.
+                // Catch the INTENT instead: any upward wheel kills autoFollow before
+                // the pin can fire. Event is not accepted → scrolling itself still
+                // goes through the normal path (custom fast-scroll or Flickable).
+                z: 1
+                anchors.fill: messageListView
+                acceptedButtons: Qt.NoButton
+                onWheel: function(wheelEvent) {
+                    if (wheelEvent.angleDelta.y > 0) messageListView.autoFollow = false;
+                    wheelEvent.accepted = false;
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -801,8 +801,11 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 ApiInputBoxIndicator {
                     // Model indicator
                     icon: "api"
-                    text: Ai.getModel().name
-                    tooltipText: Translation.tr("Current model: %1\nSet it with %2model MODEL").arg(Ai.getModel().name).arg(root.commandPrefix)
+                    // Optional-chain: local ollama models are added to Ai.models
+                    // asynchronously, so this binding evaluates against an
+                    // incomplete map on every reload (was a warn burst on each reload).
+                    text: Ai.getModel()?.name ?? "…"
+                    tooltipText: Translation.tr("Current model: %1\nSet it with %2model MODEL").arg(Ai.getModel()?.name ?? "…").arg(root.commandPrefix)
                 }
 
                 ApiInputBoxIndicator {

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/ScrollToBottomButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/ScrollToBottomButton.qml
@@ -33,6 +33,10 @@ RippleButton {
     buttonRadius: Appearance.rounding.verysmall
 
     downAction: () => {
+        // Re-engage streaming auto-follow (if the target supports it), then scroll
+        // to the end — so subsequent generated text keeps pinning to the bottom
+        // instead of the view "pulling up" away from it.
+        if (target.autoFollow !== undefined) target.autoFollow = true
         target.positionViewAtEnd()
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -20,7 +20,33 @@ Rectangle {
     property bool renderMarkdown: true
     property bool editing: false
 
-    property list<var> messageBlocks: StringUtils.splitMarkdownBlocks(root.messageData?.content)
+    // Streaming re-split happens on EVERY token; feeding those fresh objects
+    // straight into ScriptModel destroyed and recreated every segment delegate
+    // per token — heights collapsed to 0 and re-expanded, which is what shook
+    // the list and yanked it toward the top. Split: a stable SKELETON
+    // (type/lang/idx, object identity preserved while structure is unchanged)
+    // drives the model, while the growing text flows to existing delegates
+    // through liveBlocks bindings.
+    property list<var> liveBlocks: StringUtils.splitMarkdownBlocks(root.messageData?.content)
+    readonly property var _blockSkeletonCache: ({ arr: [] })  // mutated, not reassigned — no binding dependency
+    property list<var> messageBlocks: {
+        const fresh = root.liveBlocks;
+        const cached = _blockSkeletonCache.arr;
+        let structureHeld = fresh.length >= cached.length;
+        if (structureHeld) {
+            for (let i = 0; i < cached.length; i++) {
+                if (cached[i].type !== fresh[i].type || cached[i].lang !== fresh[i].lang) {
+                    structureHeld = false;
+                    break;
+                }
+            }
+        }
+        if (!structureHeld) cached.length = 0;
+        for (let i = cached.length; i < fresh.length; i++) {
+            cached.push({ type: fresh[i].type, lang: fresh[i].lang, idx: i });
+        }
+        return cached.slice();
+    }
 
     anchors.left: parent?.left
     anchors.right: parent?.right
@@ -297,7 +323,7 @@ Rectangle {
                         editing: root.editing
                         renderMarkdown: root.renderMarkdown
                         enableMouseSelection: root.enableMouseSelection
-                        segmentContent: modelData.content
+                        segmentContent: root.liveBlocks[modelData.idx]?.content ?? ""
                         segmentLang: modelData.lang
                         messageData: root.messageData
                     } }
@@ -305,16 +331,16 @@ Rectangle {
                         editing: root.editing
                         renderMarkdown: root.renderMarkdown
                         enableMouseSelection: root.enableMouseSelection
-                        segmentContent: modelData.content
+                        segmentContent: root.liveBlocks[modelData.idx]?.content ?? ""
                         messageData: root.messageData
                         done: root.messageData?.done ?? false
-                        completed: modelData.completed ?? false
+                        completed: root.liveBlocks[modelData.idx]?.completed ?? false
                     } }
                     DelegateChoice { roleValue: "text"; MessageTextBlock {
                         editing: root.editing
                         renderMarkdown: root.renderMarkdown
                         enableMouseSelection: root.enableMouseSelection
-                        segmentContent: modelData.content
+                        segmentContent: root.liveBlocks[modelData.idx]?.content ?? ""
                         messageData: root.messageData
                         done: root.messageData?.done ?? false
                         forceDisableChunkSplitting: root.messageData?.content.includes("```") ?? true

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -20,7 +20,18 @@ ColumnLayout {
     property var segmentLang: "txt"
     property var messageData: {}
     property bool isCommandRequest: segmentLang === "command"
-    property var displayLang: (isCommandRequest ? "bash" : segmentLang)
+    // Normalise the language for syntax highlighting:
+    // - command requests -> bash
+    // - shell aliases (sh/shell/console/terminal/zsh/fish) -> bash
+    // - empty/unspecified ("" or the internal "txt" default) -> bash (shell assistant; commands dominate)
+    // - explicit prose tags (text/plaintext/plain) are respected as-is, NOT forced to bash
+    property var displayLang: {
+        if (isCommandRequest) return "bash";
+        const raw = (segmentLang || "").toString().toLowerCase().trim();
+        const shellAliases = ["", "txt", "sh", "shell", "console", "terminal", "bash", "zsh", "fish"];
+        if (shellAliases.includes(raw)) return "bash";
+        return segmentLang;
+    }
 
     property real codeBlockBackgroundRounding: Appearance.rounding.small
     property real codeBlockHeaderPadding: 3
@@ -56,7 +67,12 @@ ColumnLayout {
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 color: Appearance.colors.colOnLayer2
-                text: root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain"
+                text: {
+                    if (root.isCommandRequest) return Translation.tr("Command");
+                    if (!root.displayLang) return "plain";
+                    const def = Repository.definitionForName(root.displayLang);
+                    return (def && def.name) ? def.name : root.displayLang;
+                }
             }
 
             Item { Layout.fillWidth: true }
@@ -178,38 +194,22 @@ ColumnLayout {
                     // Layout.fillHeight: true
                     implicitWidth: parent.width
                     implicitHeight: codeTextArea.implicitHeight + 1
-                    contentWidth: codeTextArea.width - 1
+                    // Wrap code to the viewport width instead of scrolling
+                    // horizontally: a horizontal flickable stole the vertical mouse
+                    // wheel (the chat couldn't scroll while hovering a code block),
+                    // and long lines were clipped off the right edge.
+                    contentWidth: availableWidth
                     // contentHeight: codeTextArea.contentHeight
                     clip: true
                     ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-                    
-                    ScrollBar.horizontal: ScrollBar {
-                        anchors.bottom: parent.bottom
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        padding: 5
-                        policy: ScrollBar.AsNeeded
-                        opacity: visualSize == 1 ? 0 : 1
-                        visible: opacity > 0
-
-                        Behavior on opacity {
-                            NumberAnimation {
-                                duration: Appearance.animation.elementMoveFast.duration
-                                easing.type: Appearance.animation.elementMoveFast.type
-                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
-                            }
-                        }
-                        
-                        contentItem: Rectangle {
-                            implicitHeight: 6
-                            radius: Appearance.rounding.small
-                            color: Appearance.colors.colLayer2Active
-                        }
-                    }
+                    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
                     TextArea { // Code
                         id: codeTextArea
                         Layout.fillWidth: true
+                        // Bound width + wrap so long lines fold to the viewport
+                        // (no horizontal scroll → vertical wheel reaches the chat).
+                        width: codeScrollView.availableWidth
                         readOnly: !editing
                         selectByMouse: enableMouseSelection || editing
                         renderType: Text.NativeRendering
@@ -218,7 +218,7 @@ ColumnLayout {
                         font.pixelSize: Appearance.font.pixelSize.small
                         selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
                         selectionColor: Appearance.colors.colSecondaryContainer
-                        // wrapMode: TextEdit.Wrap
+                        wrapMode: TextEdit.Wrap
                         color: messageData.thinking ? Appearance.colors.colSubtext : Appearance.colors.colOnLayer1
 
                         text: segmentContent
@@ -243,7 +243,7 @@ ColumnLayout {
                             id: highlighter
                             textEdit: codeTextArea
                             repository: Repository
-                            definition: Repository.definitionForName(root.displayLang || "plaintext")
+                            definition: Repository.definitionForName(root.displayLang || "bash")
                             theme: Appearance.syntaxHighlightingTheme
                         }
                     }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
@@ -155,7 +155,7 @@ ColumnLayout {
             renderType: Text.NativeRendering
             font.family: Appearance.font.family.reading
             font.hintingPreference: Font.PreferNoHinting // Prevent weird bold text
-            font.pixelSize: Appearance.font.pixelSize.small
+            font.pixelSize: Appearance.font.pixelSize.larger
             selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
             selectionColor: Appearance.colors.colSecondaryContainer
             wrapMode: TextEdit.Wrap

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -786,17 +786,57 @@ Singleton {
         property string shellCommand: ""
         property AiMessageData message
         property string baseMessageContent: ""
+        property bool sawStderr: false
+        property bool truncated: false
+        // Append captured output (stdout or stderr) to the function response so
+        // the model can see it. Without this, stderr was discarded and a failing
+        // command looked like empty output — the model would then blindly retry
+        // the same command. Surfacing stderr lets the model see "command not
+        // found" / errors and adapt instead.
+        function appendOutput(text) {
+            // Cap what the model has to read: 8k chars, then one explicit
+            // truncation marker so it knows the output continued (and doesn't
+            // overclaim from a partial view).
+            if (commandExecutionProc.message.functionResponse.length >= 8000) {
+                if (commandExecutionProc.truncated) return;
+                commandExecutionProc.truncated = true;
+                text = "[[ output truncated at 8000 chars — the command produced more; do not assume anything about the rest ]]";
+            }
+            commandExecutionProc.message.functionResponse += text + "\n\n";
+            const updatedContent = commandExecutionProc.baseMessageContent + `\n\n<think>\n<tt>${commandExecutionProc.message.functionResponse}</tt>\n</think>`;
+            commandExecutionProc.message.rawContent = updatedContent;
+            commandExecutionProc.message.content = updatedContent;
+        }
         command: ["bash", "-c", shellCommand]
         stdout: SplitParser {
+            onRead: (output) => commandExecutionProc.appendOutput(output)
+        }
+        stderr: SplitParser {
             onRead: (output) => {
-                commandExecutionProc.message.functionResponse += output + "\n\n";
-                const updatedContent = commandExecutionProc.baseMessageContent + `\n\n<think>\n<tt>${commandExecutionProc.message.functionResponse}</tt>\n</think>`;
-                commandExecutionProc.message.rawContent = updatedContent;
-                commandExecutionProc.message.content = updatedContent;
+                commandExecutionProc.sawStderr = true;
+                commandExecutionProc.appendOutput("[stderr] " + output);
+            }
+        }
+        onRunningChanged: {
+            if (running) {
+                sawStderr = false; // reset per execution
+                truncated = false;
             }
         }
         onExited: (exitCode, exitStatus) => {
-            commandExecutionProc.message.functionResponse += `[[ Command exited with code ${exitCode} (${exitStatus}) ]]\n`;
+            // Command output is data, not instructions: wrap it in an untrusted
+            // envelope before the model reads it, with inner closing tags
+            // defanged so output can't break out of the envelope.
+            commandExecutionProc.message.functionResponse =
+                "<untrusted_output>\n"
+                + commandExecutionProc.message.functionResponse.split("</untrusted_output>").join("</untrusted-output>")
+                + "\n</untrusted_output>\n";
+            // Make failure explicit and actionable so the model doesn't retry blindly.
+            if (exitCode !== 0) {
+                commandExecutionProc.message.functionResponse += `[[ Command FAILED with exit code ${exitCode} (${exitStatus})${exitCode === 127 ? " — command not found; check the name/PATH, do NOT re-run it unchanged" : ""}. Do not repeat this exact command; report the failure or try a different approach. ]]\n`;
+            } else {
+                commandExecutionProc.message.functionResponse += `[[ Command exited with code ${exitCode} (${exitStatus}) ]]\n`;
+            }
             requester.makeRequest(); // Continue
         }
     }

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -236,7 +236,7 @@ Singleton {
             "none": [],
         }
     }
-    property list<var> availableTools: Object.keys(root.tools[models[currentModelId]?.api_format])
+    property list<var> availableTools: Object.keys(root.tools[models[currentModelId]?.api_format] ?? {})
     property var toolDescriptions: {
         "functions": Translation.tr("Commands, edit configs, search.\nTakes an extra turn to switch to search mode if that's needed"),
         "search": Translation.tr("Gives the model search capabilities (immediately)"),
@@ -486,9 +486,15 @@ Singleton {
 
     function setModel(modelId, feedback = true, setPersistentState = true) {
         if (!modelId) modelId = ""
-        modelId = modelId.toLowerCase()
-        if (modelList.indexOf(modelId) !== -1) {
-            const model = models[modelId]
+        // Resolve the real key case-insensitively. Keys come from safeModelName(),
+        // which preserves case, so Ollama quant tags register as e.g.
+        // `qwen2.5_14b-instruct-q3_K_M` (uppercase K_M). A lowercased request
+        // (`...q3_k_m`) would miss and dump the whole model catalog as
+        // "Invalid model. Supported:". Match lowercase-vs-real, keep the real key.
+        const wantedId = modelId.toLowerCase()
+        const resolvedId = modelList.find(id => String(id).toLowerCase() === wantedId)
+        if (resolvedId !== undefined) {
+            const model = models[resolvedId]
             // See if policy prevents online models
             if (Config.options.policies.ai === 2 && !model.endpoint.includes("localhost")) {
                 root.addMessage(
@@ -497,7 +503,7 @@ Singleton {
                 );
                 return;
             }
-            if (setPersistentState) Persistent.states.ai.model = modelId;
+            if (setPersistentState) Persistent.states.ai.model = resolvedId;
             if (feedback) root.addMessage(Translation.tr("Model set to %1").arg(model.name), root.interfaceRole);
             if (model.requires_key) {
                 // If key not there show advice

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -11,9 +11,10 @@ import qs.services.ai
 
 /**
  * Basic service to handle LLM chats. Supports Google's and OpenAI's API formats.
- * Supports Gemini and OpenAI models.
- * Limitations:
- * - For now functions only work with Gemini API format
+ * Supports Gemini and OpenAI models (incl. local Ollama / OpenRouter).
+ * Function calling works for both the Gemini format and the OpenAI format
+ * (streamed tool_calls are assembled in OpenAiApiStrategy), so local models
+ * can use tools too.
  */
 Singleton {
     id: root

--- a/dots/.config/quickshell/ii/services/ai/OpenAiApiStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/OpenAiApiStrategy.qml
@@ -2,24 +2,88 @@ import QtQuick
 
 ApiStrategy {
     property bool isReasoning: false
-    
+    // Accumulates streamed tool-call fragments by index. OpenAI-compatible APIs
+    // (incl. Ollama, OpenRouter) stream a tool call across several SSE chunks:
+    // the first carries id + function.name, later chunks append function.arguments.
+    // We assemble them and emit a {functionCall} result so the shared
+    // Ai.qml -> handleFunctionCall flow runs — same contract as the Gemini path.
+    // This is what makes function calling work for local/OpenAI-format models.
+    property var toolCallAcc: ({})
+
     function buildEndpoint(model: AiModel): string {
         // console.log("[AI] Endpoint: " + model.endpoint);
         return model.endpoint;
     }
 
+    // Recover the model's actual tool call from the injected display marker
+    // `[[ Function: name({json}) ]]`. The marker is the durable record of the
+    // call — it lives in rawContent, so it survives chat save/load, whereas
+    // message.functionCall does not.
+    function extractToolCall(rawContent) {
+        const m = /\[\[ Function: (\w+)\(([\s\S]*?)\) \]\]/.exec(rawContent || "");
+        if (!m) return null;
+        let args = m[2].trim();
+        try { JSON.parse(args); } catch (e) { args = "{}"; }
+        return { name: m[1], arguments: args };
+    }
+
+    // Remove ALL runtime-injected scaffolding from assistant display text so the
+    // history the model reads is clean prose + structured tool_calls (below),
+    // never a copyable card. Without this a weak 7B few-shots itself: it sees its
+    // own past turn rendered as `[[ Function: … ]]` / a ```command```  fence and
+    // reproduces that AS TEXT on the next command instead of emitting a real
+    // tool call — the fence then renders like a request but has no
+    // functionPending, so no Approve button appears (the "second command" bug).
+    function stripScaffolding(content) {
+        return (content || "")
+            .replace(/\s*<think>[\s\S]*?<\/think>\s*/g, " ")
+            .replace(/```command\n[\s\S]*?```/g, "")
+            .replace(/\[\[ Function:[\s\S]*?\]\]/g, "")
+            .replace(/\[\[ Output of[^\]]*\]\]/g, "")
+            .replace(/\*\*Command execution request\*\*[^\n]*\n?/g, "")
+            .replace(/\n{3,}/g, "\n\n")
+            .trim();
+    }
+
     function buildRequestData(model: AiModel, messages, systemPrompt: string, temperature: real, tools: list<var>, filePath: string) {
+        // Build history with PROPER OpenAI tool semantics: an assistant turn that
+        // called a tool carries a structured `tool_calls`, and its result comes
+        // back as a `role:"tool"` message keyed by tool_call_id. Flattening tool
+        // use into text markers (the old behavior) is exactly what taught the
+        // model to imitate the marker instead of calling the tool.
+        const history = [{ role: "system", content: systemPrompt }];
+        let callSeq = 0;
+        let lastToolCallId = null;
+        for (let i = 0; i < messages.length; i++) {
+            const message = messages[i];
+            if (message.role === "assistant") {
+                const tc = extractToolCall(message.rawContent);
+                const text = stripScaffolding(message.rawContent);
+                if (tc) {
+                    const id = `call_${callSeq++}`;
+                    lastToolCallId = id;
+                    history.push({
+                        role: "assistant",
+                        content: text,
+                        tool_calls: [{ id: id, type: "function", function: { name: tc.name, arguments: tc.arguments } }],
+                    });
+                } else {
+                    history.push({ role: "assistant", content: text });
+                }
+            } else if (message.role === "user" && message.functionName && lastToolCallId) {
+                // Function/command result — the model's tool observation.
+                const out = (message.functionResponse && message.functionResponse.length > 0)
+                    ? message.functionResponse
+                    : stripScaffolding(message.rawContent);
+                history.push({ role: "tool", tool_call_id: lastToolCallId, content: out });
+                lastToolCallId = null;
+            } else {
+                history.push({ role: message.role, content: message.rawContent });
+            }
+        }
         let baseData = {
             "model": model.model,
-            "messages": [
-                {role: "system", content: systemPrompt},
-                ...messages.map(message => {
-                    return {
-                        "role": message.role,
-                        "content": message.rawContent,
-                    }
-                }),
-            ],
+            "messages": history,
             "stream": true,
             "tools": tools,
             "temperature": temperature,
@@ -31,6 +95,38 @@ ApiStrategy {
         return `-H "Authorization: Bearer \$\{${apiKeyEnvVarName}\}"`;
     }
 
+    function hasPendingToolCall() {
+        return Object.keys(toolCallAcc).length > 0;
+    }
+
+    // Assemble the first accumulated tool call, render it into the message (same
+    // visible marker as Gemini), reset the accumulator, and return the contract
+    // result that Ai.qml turns into handleFunctionCall().
+    function emitToolCall(message) {
+        const keys = Object.keys(toolCallAcc);
+        if (keys.length === 0) return { finished: true };
+        const tc = toolCallAcc[keys[0]];
+        let args = {};
+        try {
+            args = (tc.args && tc.args.length > 0) ? JSON.parse(tc.args) : {};
+        } catch (e) {
+            // Arguments not valid JSON (truncated / model glitch): surface raw so
+            // the user sees what happened instead of a silent no-op.
+            const warn = `\n\n[[ Tool call ${tc.name}: could not parse arguments: ${tc.args} ]]\n`;
+            message.rawContent += warn;
+            message.content += warn;
+            toolCallAcc = ({});
+            return { finished: true };
+        }
+        const newContent = `\n\n[[ Function: ${tc.name}(${JSON.stringify(args, null, 2)}) ]]\n`;
+        message.rawContent += newContent;
+        message.content += newContent;
+        message.functionName = tc.name;
+        message.functionCall = tc.name;
+        toolCallAcc = ({}); // reset for the next turn
+        return { functionCall: { name: tc.name, args: args }, finished: true };
+    }
+
     function parseResponseLine(line, message) {
         // Remove 'data: ' prefix if present and trim whitespace
         let cleanData = line.trim();
@@ -39,13 +135,15 @@ ApiStrategy {
         }
 
         // console.log("[AI] OpenAI: Data:", cleanData);
-        
+
         // Handle special cases
         if (!cleanData || cleanData.startsWith(":")) return {};
         if (cleanData === "[DONE]") {
+            // Flush a tool call that finished without an explicit finish_reason chunk.
+            if (hasPendingToolCall()) return emitToolCall(message);
             return { finished: true };
         }
-        
+
         // Real stuff
         try {
             const dataJson = JSON.parse(cleanData);
@@ -58,10 +156,24 @@ ApiStrategy {
                 return { finished: true };
             }
 
+            const choice = dataJson.choices ? dataJson.choices[0] : undefined;
+            const delta = choice?.delta;
+            const finishReason = choice?.finish_reason;
+
+            // Accumulate streamed tool-call fragments (by index)
+            if (delta?.tool_calls) {
+                for (const tc of delta.tool_calls) {
+                    const idx = tc.index ?? 0;
+                    if (!toolCallAcc[idx]) toolCallAcc[idx] = { name: "", args: "" };
+                    if (tc.function?.name) toolCallAcc[idx].name = tc.function.name;
+                    if (tc.function?.arguments) toolCallAcc[idx].args += tc.function.arguments;
+                }
+            }
+
             let newContent = "";
 
-            const responseContent = dataJson.choices[0]?.delta?.content || dataJson.message?.content;
-            const responseReasoning = dataJson.choices[0]?.delta?.reasoning || dataJson.choices[0]?.delta?.reasoning_content;
+            const responseContent = delta?.content || dataJson.message?.content;
+            const responseReasoning = delta?.reasoning || delta?.reasoning_content;
 
             if (responseContent && responseContent.length > 0) {
                 if (isReasoning) {
@@ -84,6 +196,11 @@ ApiStrategy {
             message.content += newContent;
             message.rawContent += newContent;
 
+            // A finished tool call: emit it so Ai.qml runs handleFunctionCall.
+            if ((finishReason === "tool_calls" || finishReason) && hasPendingToolCall()) {
+                return emitToolCall(message);
+            }
+
             // Usage metadata
             if (dataJson.usage) {
                 return {
@@ -91,30 +208,35 @@ ApiStrategy {
                         input: dataJson.usage.prompt_tokens ?? -1,
                         output: dataJson.usage.completion_tokens ?? -1,
                         total: dataJson.usage.total_tokens ?? -1
-                    }
+                    },
+                    finished: !!finishReason
                 };
             }
 
-            if (dataJson.done) {
+            if (dataJson.done || finishReason) {
+                if (hasPendingToolCall()) return emitToolCall(message);
                 return { finished: true };
             }
-            
+
         } catch (e) {
             console.log("[AI] OpenAI: Could not parse line: ", e);
             message.rawContent += line;
             message.content += line;
         }
-        
+
         return {};
     }
-    
+
     function onRequestFinished(message) {
-        // OpenAI format doesn't need special finish handling
+        // Safety net: flush any tool call assembled but not yet emitted (e.g. the
+        // stream ended without a [DONE] / finish_reason line).
+        if (hasPendingToolCall()) return emitToolCall(message);
         return {};
     }
-    
+
     function reset() {
         isReasoning = false;
+        toolCallAcc = ({});
     }
 
 }


### PR DESCRIPTION
Two tracks in four reviewable commits. They meet in daily use: function calling is what makes the sidebar genuinely useful with local models, and the scroll fixes are what make watching it stream bearable.

## Function calling for the OpenAI API format

Tools are already declared for the OpenAI format in `Ai.qml`, but `OpenAiApiStrategy` never assembled them from the stream — the file header says it: *"For now functions only work with Gemini API format"*. So local Ollama / OpenRouter models could never call tools.

- Streamed `tool_calls` arrive across several SSE chunks: the first carries `id` + `function.name`, later ones append `function.arguments`. The strategy now accumulates the fragments by index and emits the finished call through the same contract the Gemini path uses (`handleFunctionCall`), flushing on `finish_reason`, `[DONE]`, or request end.
- Request history is rebuilt with proper OpenAI tool semantics: an assistant turn that called a tool carries structured `tool_calls`, and its result goes back as `role:"tool"` keyed by `tool_call_id`. Before, tool use was flattened into display text — and smaller local models then *imitate* the rendered marker as plain text on the next turn instead of emitting a real call. The fake fence renders like a command request but never gets an Approve button. Easy to repro once tool calls work at all: qwen2.5:7b, two commands in one chat.

## Stable streaming layout + auto-follow scrolling

The markdown re-split ran on every token and fed fresh block objects into the ScriptModel, destroying and recreating every segment delegate per token — heights collapsed to 0 and re-expanded, which is what shook the list and yanked it toward the top. Fixed at the source: a stable block skeleton (type/lang/idx) keeps delegate identity while the structure is unchanged, and the growing text flows to the existing delegates through bindings.

On top of that, auto-follow (the commented-out `positionViewAtEnd` attempt in the tree): pin to the bottom instantly (no easing) once per event loop, disengage on drag / upward wheel / PageUp, re-engage only when the user lands back at the true bottom or hits the scroll-to-bottom button. The wheel disengage is intent-based deliberately — a position check loses the race against a queued pin mid-stream.

This overlaps with #3493 in intent, and I'm happy to converge there. The differences that mattered in my use: this removes the delegate churn that causes the shake (rather than flooring bubble height while streaming), and it disengages on wheel input directly — `moving` is never set by the custom wheel handler in `StyledListView` (it assigns `contentY` programmatically), so a gesture-based check can't see mouse-wheel scrolling.

## Command output handling

stderr of an executed command was discarded, so a failing command looked like empty output and the model would blindly retry it. Captured now (tagged `[stderr]`), with failure explicit in the exit marker (and a hint on exit 127). Output the model reads is capped at 8k chars with an explicit truncation marker, and wrapped in an `<untrusted_output>` envelope with inner closing tags defanged — command output is data the model reads, not instructions.

## Smaller fixes

- Code blocks wrap to the viewport instead of scrolling horizontally — the horizontal flickable stole the vertical wheel (the chat couldn't scroll while hovering a code block) and clipped long lines.
- Highlight-language normalisation (`sh`/`shell`/`console`/`zsh`/… → bash; explicit prose tags respected), and a "Command" header label on command requests.
- `/model`: resolve the key case-insensitively — Ollama quant tags like `q3_K_M` were unselectable and dumped the whole model catalog as "Invalid model".
- Null-safe `availableTools` and model indicator: local ollama models register asynchronously, so these bindings briefly evaluate against an incomplete map on every reload (was a warn burst).
- Message reading font `small` → `larger`.

## Tested

Daily driving on Arch + Hyprland against local Ollama (qwen2.5:7b, qwen3:8b): multi-turn chats with repeated `run_shell_command` calls, the approve flow, failing commands, long outputs. The Gemini strategy path is untouched. I haven't run non-Ollama OpenAI-format providers; the assembly follows the OpenAI streaming shape (fragments keyed by `index`), so provider variations should land in the accumulator the same way — if one doesn't, the strategy degrades to exactly the current behavior (no tool call emitted).
