### PR TITLE
Fix broken ls command

### DIFF
--- a/dots/.config/fish/config.fish
+++ b/dots/.config/fish/config.fish
@@ -25,7 +25,7 @@ if status is-interactive
     alias pamcan pacman
     alias q 'qs -c ii'
     if test "$TERM" != "linux"
-        alias ls 'eza --icons'
+        alias ls 'eza --icons=auto'
     end
     if test "$TERM" = "xterm-kitty"
         alias ssh 'kitten ssh'


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

After the recent change of `eza` command line arguments parser (https://github.com/eza-community/eza/pull/1447), `eza --icons /` command is interpreted as `eza --icons=/`.

Because of this, `ls <dir>` command does not seem to work properly, when `eza: ^0.23.5` is present in the system.

<img width="455" height="70" alt="image" src="https://github.com/user-attachments/assets/e8826629-b1bd-4872-9182-2e8d565497d9" />

Simply specifying `--icons=auto` fixes this issue.

## Is it ready? Questions/feedback needed?

It is ready.

To reproduce this bug, update your system.


