### PR TITLE
feat(bar): Show icon in "Keep system awake" mode

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -302,6 +302,19 @@ Item { // Bar content region
                             id: notificationUnreadCount
                         }
                     }
+                    Revealer {
+                        reveal: Idle.inhibit
+                        Layout.fillHeight: true
+                        Layout.rightMargin: reveal ? indicatorsRowLayout.realSpacing : 0
+                        Behavior on Layout.rightMargin {
+                            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                        }
+                        MaterialSymbol {
+                            text: "coffee"
+                            iconSize: Appearance.font.pixelSize.larger
+                            color: rightSidebarButton.colText
+                        }
+                    }
                     MaterialSymbol {
                         text: Network.materialSymbol
                         iconSize: Appearance.font.pixelSize.larger


### PR DESCRIPTION
## Describe your changes

An indicator icon is added when the "Keep system awake" function is turned on.

<img width="157" height="40" alt="image" src="https://github.com/user-attachments/assets/b95ad58e-903e-471a-9c27-f3a23c193348" />


https://github.com/user-attachments/assets/b4007cdc-216d-4b05-9983-b729ff586009




## Is it ready? Questions/feedback needed?

Ready, no questions/feedback needed
