### PR TITLE
fix(qs): translator action buttons

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/translator/TextCanvas.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/translator/TextCanvas.qml
@@ -14,7 +14,7 @@ Rectangle {
     property var inputTextArea: isInput ? inputLoader.item : undefined
     readonly property string displayedText: isInput ? inputLoader.item.text : 
         root.text.length > 0 ? outputLoader.item.text : ""
-    default property alias actionButtons: actions.data
+    default property alias actionButtons: actions.groupData
     Layout.fillWidth: true
     implicitHeight: Math.max(150, inputColumn.implicitHeight)
     color: Appearance.colors.colLayer2


### PR DESCRIPTION
## Describe your changes

Fix https://github.com/end-4/dots-hyprland/issues/3444

## Is it ready? Questions/feedback needed?

Yes, alias to `actions.groupData`

Image after fix:
<img width="431" height="199" alt="image" src="https://github.com/user-attachments/assets/8228b569-cd38-47c1-a077-a319e9b26b01" />
<img width="431" height="206" alt="image" src="https://github.com/user-attachments/assets/85987bc1-5390-455b-8aeb-c0e2244cf1d9" />


