### PR TITLE
fix(ii): keep todo items clear of add-task FAB

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/todo/TaskList.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/todo/TaskList.qml
@@ -19,6 +19,7 @@ Item {
     StyledListView {
         id: listView
         anchors.fill: parent
+        bottomMargin: root.listBottomPadding
         spacing: root.todoListItemSpacing
         animateAppearance: false
         model: ScriptModel {


### PR DESCRIPTION
## Describe your changes

The todo list's floating add (+) button overlapped the done/delete buttons of the last items when there were 4+ entries, making them unclickable unless you create another item first.

`TaskList.qml` already defined a `listBottomPadding` property but it never applied to the `StyledListView`.

## Is it ready? Questions/feedback needed?

Yes

Before
<img width="428" height="361" alt="image" src="https://github.com/user-attachments/assets/91de5a9a-7ec5-4474-b3c1-1ef8b529fe88" />

After
<img width="423" height="360" alt="image" src="https://github.com/user-attachments/assets/831073d8-4aea-4ef3-ab85-5f95560b293a" />
