### PR TITLE
fix(fish): update eza alias syntax for newer versions for prevent err…

### DIFF
--- a/dots/.config/fish/config.fish
+++ b/dots/.config/fish/config.fish
@@ -25,7 +25,7 @@ if status is-interactive
     alias pamcan pacman
     alias q 'qs -c ii'
     if test "$TERM" != "linux"
-        alias ls 'eza --icons'
+        alias ls 'eza --icons=always'
     end
     if test "$TERM" = "xterm-kitty"
         alias ssh 'kitten ssh'


### PR DESCRIPTION
### Description
In recent versions of `eza`, the `--icons` flag requires an explicit argument (`always`, `auto`, or `never`). Running `ls` with the previous alias (`eza --icons`) caused an error whenever a path argument (like `/` or `./Desktop/`) was provided, as `eza` incorrectly parsed the path as a value for the `--icons` flag.

This PR updates the Fish alias to use `--icons=always`, resolving the following error:
`error: invalid value '/' for '--icons [<WHEN>]'`

### Changes
* Changed `alias ls 'eza --icons'` to `alias ls 'eza --icons=always'` in `dots/.config/fish/config.fish`.
