### PR TITLE
fix(ii): make quickshell tmp dir per-user via XDG_RUNTIME_DIR

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Directories.qml
+++ b/dots/.config/quickshell/ii/modules/common/Directories.qml
@@ -23,9 +23,15 @@ Singleton {
     // Other dirs used by the shell, without "file://"
     property string assetsPath: Quickshell.shellPath("assets")
     property string scriptPath: Quickshell.shellPath("scripts")
+    // Per-user runtime dir for transient files. Using a shared "/tmp/quickshell"
+    // breaks on multi-user machines: whoever logs in first owns the dir and
+    // locks every other user out (grim/magick get "Permission denied", so
+    // screenshots never write and the clipboard keeps stale/empty content).
+    // XDG_RUNTIME_DIR (/run/user/$UID) is private per-user and auto-cleaned.
+    readonly property string runtimeTmp: (Quickshell.env("XDG_RUNTIME_DIR") || "/tmp") + "/quickshell"
     property string favicons: FileUtils.trimFileProtocol(`${Directories.cache}/media/favicons`)
     property string coverArt: FileUtils.trimFileProtocol(`${Directories.cache}/media/coverart`)
-    property string tempImages: "/tmp/quickshell/media/images"
+    property string tempImages: `${runtimeTmp}/media/images`
     property string booruPreviews: FileUtils.trimFileProtocol(`${Directories.cache}/media/boorus`)
     property string booruDownloads: FileUtils.trimFileProtocol(Directories.pictures  + "/homework")
     property string booruDownloadsNsfw: FileUtils.trimFileProtocol(Directories.pictures + "/homework/🌶️")
@@ -39,8 +45,8 @@ Singleton {
     property string notificationsPath: FileUtils.trimFileProtocol(`${Directories.cache}/notifications/notifications.json`)
     property string generatedMaterialThemePath: FileUtils.trimFileProtocol(`${Directories.state}/user/generated/colors.json`)
     property string generatedWallpaperCategoryPath: FileUtils.trimFileProtocol(`${Directories.state}/user/generated/wallpaper/category.txt`)
-    property string cliphistDecode: FileUtils.trimFileProtocol(`/tmp/quickshell/media/cliphist`)
-    property string screenshotTemp: "/tmp/quickshell/media/screenshot"
+    property string cliphistDecode: FileUtils.trimFileProtocol(`${runtimeTmp}/media/cliphist`)
+    property string screenshotTemp: `${runtimeTmp}/media/screenshot`
     property string wallpaperSwitchScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/colors/switchwall.sh`)
     property string defaultAiPrompts: Quickshell.shellPath("defaults/ai/prompts")
     property string userAiPrompts: FileUtils.trimFileProtocol(`${Directories.shellConfig}/ai/prompts`)

--- a/dots/.config/quickshell/ii/scripts/ai/gemini-categorize-wallpaper.sh
+++ b/dots/.config/quickshell/ii/scripts/ai/gemini-categorize-wallpaper.sh
@@ -11,7 +11,7 @@ SOURCE_IMG_PATH="$1"
 MODEL="${2:-${GEMINI_WALLPAPER_MODEL:-gemini-2.5-flash}}" # We use the flash variant so it's fast
 WALLPAPER_NAME="$(basename "$SOURCE_IMG_PATH")"
 PROMPT="${3:-${GEMINI_WALLPAPER_PROMPT:-Categorize the wallpaper. Its file name is $WALLPAPER_NAME}}"
-RESIZED_IMG_PATH="/tmp/quickshell/ai/wallpaper.jpg"
+RESIZED_IMG_PATH="${XDG_RUNTIME_DIR:-/tmp}/quickshell/ai/wallpaper.jpg"
 
 # Resize image for speed
 mkdir -p "$(dirname "$RESIZED_IMG_PATH")"

--- a/dots/.config/quickshell/ii/scripts/images/find_regions.py
+++ b/dots/.config/quickshell/ii/scripts/images/find_regions.py
@@ -4,9 +4,11 @@ import argparse
 import cv2
 import json
 import numpy as np
+import os
 import sys
 
-DEFAULT_IMAGE_PATH = '/tmp/quickshell/media/screenshot/image'
+DEFAULT_IMAGE_PATH = os.path.join(
+    os.environ.get('XDG_RUNTIME_DIR', '/tmp'), 'quickshell/media/screenshot/image')
 
 def iou(boxA, boxB):
     # Compute intersection over union for two boxes

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -320,7 +320,7 @@ Singleton {
         }
     }
 
-    property string requestScriptFilePath: "/tmp/quickshell/ai/request.sh"
+    property string requestScriptFilePath: `${Directories.runtimeTmp}/ai/request.sh`
     property string pendingFilePath: ""
 
     Component.onCompleted: {

--- a/dots/.config/quickshell/ii/services/Brightness.qml
+++ b/dots/.config/quickshell/ii/services/Brightness.qml
@@ -186,7 +186,7 @@ Singleton {
     // Anti-flashbang
     property int workspaceAnimationDelay: 500
     property int contentSwitchDelay: 30
-    property string screenshotDir: "/tmp/quickshell/brightness/antiflashbang"
+    property string screenshotDir: `${Directories.runtimeTmp}/brightness/antiflashbang`
     function brightnessMultiplierForLightness(x: real): real {
         // I hand picked some values and fitted an exponential curve for this
         // 6.600135 + 216.360356 * e^(-0.0811129189x)

--- a/dots/.config/quickshell/ii/services/ai/GeminiApiStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/GeminiApiStrategy.qml
@@ -207,8 +207,9 @@ ApiStrategy {
         content += `IMAGE_PATH='${CF.StringUtils.shellSingleQuoteEscape(trimmedFilePath)}'\n`;
         content += `${fileMimeTypeVarName}=$(file -b --mime-type "$IMAGE_PATH")\n`;
         content += 'NUM_BYTES=$(wc -c < "${IMAGE_PATH}")\n';
-        content += 'tmp_header_file="/tmp/quickshell/ai/upload-header.tmp"\n';
-        content += 'tmp_file_info_file="/tmp/quickshell/ai/file-info.json.tmp"\n';
+        content += 'tmp_header_file="${XDG_RUNTIME_DIR:-/tmp}/quickshell/ai/upload-header.tmp"\n';
+        content += 'tmp_file_info_file="${XDG_RUNTIME_DIR:-/tmp}/quickshell/ai/file-info.json.tmp"\n';
+        content += 'mkdir -p "$(dirname "$tmp_header_file")"\n';
 
         // Initial resumable request defining metadata.
         // The upload url is in the response headers dump them to a file.


### PR DESCRIPTION
## Describe your changes

Quickshell writes its temporary files to a hardcoded `/tmp/quickshell`. This path is
the same for every user. On a machine with more than one user account, the first user
to log in becomes the owner of that folder, and every other user is then locked out of
it.

When that happens, taking a screenshot fails silently:

1. `mkdir -p` succeeds, because the folder already exists.
2. `grim` fails with "Permission denied" and never saves the new capture.
3. The crop step still runs, and copies whatever old image the other user left behind.

So the region snip looks like it worked, but the clipboard holds an old screenshot or
nothing at all. Left click (copy) pastes the wrong image, and right click (edit) opens
the wrong image in swappy. The cliphist thumbnails and the AI / brightness temp files
break in the same way.

This PR points all of those paths to `$XDG_RUNTIME_DIR/quickshell` (`/run/user/$UID`)
instead. That folder is private to each user (mode 0700), lives on tmpfs, and is
cleaned up automatically on logout, which is exactly what these files need.
`Directories.runtimeTmp` is the single source of truth for the QML side, and the shell
scripts read `$XDG_RUNTIME_DIR` at runtime.

About the "one feature per pull request" rule: this is one fix for one root cause. The
6 files all have the same bug (the shared path), so splitting them would leave the
problem half fixed. Happy to split it if you prefer.

About the fallback: `XDG_RUNTIME_DIR` is always set in practice, because the Wayland
socket lives inside it and a Wayland client cannot start without it. The `/tmp`
fallback is only a defensive default.

## Is it ready? Questions/feedback needed?

Ready. Tested on the machine where the bug happened (two user accounts, uid 1000 and
1001):

- `grim` now saves the capture instead of failing.
- The clipboard checksum matches a freshly cropped image, not the stale one.
- Right click opens swappy with the correct image.
- `find_regions.py` still returns valid JSON.
- No new QML warnings after the config reloads.

I could not exercise the AI and anti-flashbang paths at runtime (anti-flashbang is
disabled in my config, and the AI request needs an API key). They read the same
`Directories.runtimeTmp` property, which is confirmed working.