### PR TITLE
feat(qs): display list of all installed applications and the recently used apps

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -481,7 +481,6 @@ Singleton {
                 property bool sloppy: false // Uses levenshtein distance based scoring instead of fuzzy sort. Very weird.
                 property JsonObject prefix: JsonObject {
                     property bool showDefaultActionsWithoutPrefix: true
-                    property string allApps: "@"// all applications
                     property string action: "/"
                     property string app: ">"
                     property string clipboard: ";"

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -481,6 +481,7 @@ Singleton {
                 property bool sloppy: false // Uses levenshtein distance based scoring instead of fuzzy sort. Very weird.
                 property JsonObject prefix: JsonObject {
                     property bool showDefaultActionsWithoutPrefix: true
+                    property string allApps: "@"// all applications
                     property string action: "/"
                     property string app: ">"
                     property string clipboard: ";"

--- a/dots/.config/quickshell/ii/modules/common/models/LauncherSearchResult.qml
+++ b/dots/.config/quickshell/ii/modules/common/models/LauncherSearchResult.qml
@@ -29,4 +29,6 @@ QtObject {
 
     // Extra stuff to allow for more flexibility
     property string category: type
+    //all applications
+    property bool isSeparator: false
 }

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
@@ -81,12 +81,11 @@ RowLayout {
         onTextChanged: LauncherSearch.query = text
 
         onAccepted: {
-            if (appResults.count > 0) {
-                // Get the first visible delegate and trigger its click
-                let firstItem = appResults.itemAtIndex(0);
-                if (firstItem && firstItem.clicked) {
-                    firstItem.clicked();
-                }
+            const idx = appResults.currentIndex >= 0 ? appResults.currentIndex : 0;
+            const entry = resultModel.values?.[idx];
+            if (entry && !entry.isSeparator && entry.execute) {
+                GlobalStates.overviewOpen = false;
+                entry.execute();
             }
         }
 
@@ -96,6 +95,22 @@ RowLayout {
                 const tabbedText = LauncherSearch.results[0].name;
                 LauncherSearch.query = tabbedText;
                 searchInput.text = tabbedText;
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Down) {
+                const values = resultModel.values ?? [];
+                let next = appResults.currentIndex + 1;
+                while (next < values.length && values[next]?.isSeparator)
+                    next++;
+                if (next < values.length)
+                    appResults.currentIndex = next;
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Up) {
+                const values = resultModel.values ?? [];
+                let prev = appResults.currentIndex - 1;
+                while (prev >= 0 && values[prev]?.isSeparator)
+                    prev--;
+                if (prev >= 0)
+                    appResults.currentIndex = prev;
                 event.accepted = true;
             }
         }

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
@@ -40,8 +40,6 @@ RippleButton {
     property int buttonHorizontalPadding: 10
     property int buttonVerticalPadding: 6
     property bool keyboardDown: false
-    // readonly property bool selected: (root.hovered || root.focus)
-    // readonly property bool selected: (root.hovered || root.focus || ListView.isCurrentItem)
     property bool forcedSelected: false
     readonly property bool selected: (root.hovered || root.focus || root.forcedSelected)
 

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
@@ -40,7 +40,10 @@ RippleButton {
     property int buttonHorizontalPadding: 10
     property int buttonVerticalPadding: 6
     property bool keyboardDown: false
-    readonly property bool selected: (root.hovered || root.focus)
+    // readonly property bool selected: (root.hovered || root.focus)
+    // readonly property bool selected: (root.hovered || root.focus || ListView.isCurrentItem)
+    property bool forcedSelected: false
+    readonly property bool selected: (root.hovered || root.focus || root.forcedSelected)
 
     implicitHeight: rowLayout.implicitHeight + root.buttonVerticalPadding * 2
     implicitWidth: rowLayout.implicitWidth + root.buttonHorizontalPadding * 2
@@ -158,6 +161,7 @@ RippleButton {
                 source: Quickshell.iconPath(root.iconName, "image-missing")
                 width: 35
                 height: 35
+                Component.onCompleted: console.log("[icon debug]", root.itemName, "iconName:", root.iconName, "resolved:", source)
             }
         }
 

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchListSeparator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchListSeparator.qml
@@ -1,0 +1,35 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+    property string letter: ""
+
+    // Not focusable/clickable - purely a section label between app groups
+    focus: false
+    activeFocusOnTab: false
+
+    implicitHeight: letterText.implicitHeight + topPadding + bottomPadding
+    property int horizontalMargin: 10
+    property int buttonHorizontalPadding: 10
+    property int topPadding: 10
+    property int bottomPadding: 2
+
+    StyledText {
+        id: letterText
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+            leftMargin: root.horizontalMargin + root.buttonHorizontalPadding
+            rightMargin: root.horizontalMargin + root.buttonHorizontalPadding
+            topMargin: root.topPadding
+        }
+        text: root.letter.toUpperCase()
+        font.pixelSize: Appearance.font.pixelSize.smaller
+        font.weight: Font.DemiBold
+        color: Appearance.colors.colSubtext
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -25,7 +25,11 @@ Item { // Wrapper
     implicitHeight: searchWidgetContent.implicitHeight + searchBar.verticalPadding * 2 + Appearance.sizes.elevationMargin * 2
 
     function focusFirstItem() {
-        appResults.currentIndex = 0;
+        let idx = 0;
+        const values = appResults.model?.values ?? [];
+        while (idx < values.length && values[idx]?.isSeparator)
+            idx++;
+        appResults.currentIndex = idx;
     }
 
     function focusSearchInput() {
@@ -118,111 +122,164 @@ Item { // Wrapper
             enabled: GlobalStates.overviewOpen && root.showResults
             animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
         }
-
+        
         ColumnLayout {
-            id: columnLayout
-            anchors {
-                top: parent.top
-                horizontalCenter: parent.horizontalCenter
-            }
-            spacing: 0
-
-            // clip: true
-            layer.enabled: true
-            layer.effect: OpacityMask {
-                maskSource: Rectangle {
-                    width: searchWidgetContent.width
-                    height: searchWidgetContent.width
-                    radius: searchWidgetContent.radius
-                }
-            }
-
-            SearchBar {
-                id: searchBar
-                property real verticalPadding: 4
-                Layout.fillWidth: true
-                Layout.leftMargin: 10
-                Layout.rightMargin: 4
-                Layout.topMargin: verticalPadding
-                Layout.bottomMargin: verticalPadding
-                Synchronizer on searchingText {
-                    property alias source: root.searchingText
-                }
-            }
-
-            Rectangle {
-                // Separator
-                visible: root.showResults
-                Layout.fillWidth: true
-                height: 1
-                color: Appearance.colors.colOutlineVariant
-            }
-
-            ListView { // App results
-                id: appResults
-                visible: root.showResults
-                Layout.fillWidth: true
-                implicitHeight: Math.min(600, appResults.contentHeight + topMargin + bottomMargin)
-                clip: true
-                topMargin: 10
-                bottomMargin: 10
-                spacing: 2
-                KeyNavigation.up: searchBar
-                highlightMoveDuration: 100
-
-                onFocusChanged: {
-                    if (focus)
-                        appResults.currentIndex = 1;
-                }
-
-                Connections {
-                    target: root
-                    function onSearchingTextChanged() {
-                        if (appResults.count > 0)
-                            appResults.currentIndex = 0;
+                    id: columnLayout
+                    anchors {
+                        top: parent.top
+                        horizontalCenter: parent.horizontalCenter
                     }
-                }
+                    spacing: 0
 
-                Timer {
-                    id: debounceTimer
-                    interval: root.typingDebounceInterval
-                    onTriggered: {
-                        resultModel.values = LauncherSearch.results ?? [];
+                    // clip: true
+                    layer.enabled: true
+                    layer.effect: OpacityMask {
+                        maskSource: Rectangle {
+                            width: searchWidgetContent.width
+                            height: searchWidgetContent.width
+                            radius: searchWidgetContent.radius
+                        }
                     }
-                }
 
-                Connections {
-                    target: LauncherSearch
-                    function onResultsChanged() {
-                        resultModel.values = LauncherSearch.results.slice(0, root.typingResultLimit);
-                        root.focusFirstItem();
-                        debounceTimer.restart();
+                    SearchBar {
+                        id: searchBar
+                        property real verticalPadding: 4
+                        Layout.fillWidth: true
+                        Layout.leftMargin: 10
+                        Layout.rightMargin: 4
+                        Layout.topMargin: verticalPadding
+                        Layout.bottomMargin: verticalPadding
+                        Synchronizer on searchingText {
+                            property alias source: root.searchingText
+                        }
                     }
-                }
 
-                model: ScriptModel {
-                    id: resultModel
-                    objectProp: "key"
-                }
+                    Rectangle {
+                        // Separator
+                        visible: root.showResults
+                        Layout.fillWidth: true
+                        height: 1
+                        color: Appearance.colors.colOutlineVariant
+                    }
 
-                delegate: SearchItem {
-                    id: searchItem
-                    // The selectable item for each search result
-                    required property var modelData
-                    anchors.left: parent?.left
-                    anchors.right: parent?.right
-                    entry: modelData
-                    query: StringUtils.cleanOnePrefix(root.searchingText, [Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch])
+                    ListView { // App results
+                        id: appResults
+                        visible: root.showResults
+                        Layout.fillWidth: true
+                        implicitHeight: Math.min(600, appResults.contentHeight + topMargin + bottomMargin)
+                        clip: true
+                        topMargin: 10
+                        bottomMargin: 10
+                        spacing: 2
+                        KeyNavigation.up: searchBar
+                        highlightMoveDuration: 100
 
-                    Keys.onPressed: event => {
-                        if (event.key === Qt.Key_Tab) {
-                            if (LauncherSearch.results.length === 0)
+                        onFocusChanged: {
+                            if (focus)
+                                appResults.currentIndex = 1;
+                        }
+
+                        // Skip over separator (letter header) rows when the current
+                        // index lands on one, in whichever direction we were moving.
+                        property int previousIndex: -1
+                        onCurrentIndexChanged: {
+                            const values = resultModel.values ?? [];
+                            if (currentIndex < 0 || currentIndex >= values.length) {
+                                previousIndex = currentIndex;
                                 return;
-                            const tabbedText = searchItem.modelData.name;
-                            LauncherSearch.query = tabbedText;
-                            searchBar.searchInput.text = tabbedText;
-                            event.accepted = true;
-                            root.focusSearchInput();
+                            }
+                            if (values[currentIndex]?.isSeparator) {
+                                const direction = currentIndex >= previousIndex ? 1 : -1;
+                                let next = currentIndex + direction;
+                                while (next >= 0 && next < values.length && values[next]?.isSeparator)
+                                    next += direction;
+                                if (next >= 0 && next < values.length) {
+                                    previousIndex = next;
+                                    currentIndex = next;
+                                    return;
+                                }
+                            }
+                            previousIndex = currentIndex;
+                        }
+
+                        Connections {
+                            target: root
+                            function onSearchingTextChanged() {
+                                if (appResults.count > 0)
+                                    appResults.currentIndex = 0;
+                            }
+                        }
+
+                        Timer {
+                            id: debounceTimer
+                            interval: root.typingDebounceInterval
+                            onTriggered: {
+                                resultModel.values = LauncherSearch.results ?? [];
+                            }
+                        }
+
+                        Connections {
+                            target: LauncherSearch
+                            function onResultsChanged() {
+                                // Don't cap results to typingResultLimit when browsing the
+                                // full alphabetical app list (the "@all" special query) -
+                                // the whole point there is to see everything, not just 15.
+                                const isAllAppsMode = root.searchingText === (Config.options.search.prefix.allApps + "all");
+                                resultModel.values = isAllAppsMode ? LauncherSearch.results : LauncherSearch.results.slice(0, root.typingResultLimit);
+                                root.focusFirstItem();
+                                debounceTimer.restart();
+                            }
+                        }
+
+                        model: ScriptModel {
+                            id: resultModel
+                            objectProp: "key"
+                        }
+
+                        delegate: Item {
+                            id: delegateItem
+                            required property var modelData
+                            width: appResults.width
+                            implicitHeight: contentLoader.item ? contentLoader.item.implicitHeight : 0
+                            height: implicitHeight
+
+                            Loader {
+                                id: contentLoader
+                                anchors.left: parent.left
+                                anchors.right: parent.right
+                                sourceComponent: delegateItem.modelData.isSeparator ? separatorComponent : searchItemComponent
+                            }
+
+                            Component {
+                                id: separatorComponent
+                                SearchListSeparator {
+                                    anchors.left: parent?.left
+                                    anchors.right: parent?.right
+                                    letter: delegateItem.modelData.name
+                                }
+                            }
+
+                            Component {
+                                id: searchItemComponent
+                                SearchItem {
+                                    id: searchItem
+                            anchors.left: parent?.left
+                            anchors.right: parent?.right
+                            entry: delegateItem.modelData
+                            forcedSelected: delegateItem.ListView.isCurrentItem
+                            query: StringUtils.cleanOnePrefix(root.searchingText, [Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.allApps, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch])
+
+                            Keys.onPressed: event => {
+                                if (event.key === Qt.Key_Tab) {
+                                    if (LauncherSearch.results.length === 0)
+                                        return;
+                                    const tabbedText = searchItem.entry.name;
+                                    LauncherSearch.query = tabbedText;
+                                    searchBar.searchInput.text = tabbedText;
+                                    event.accepted = true;
+                                    root.focusSearchInput();
+                                }
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -221,10 +221,7 @@ Item { // Wrapper
                         Connections {
                             target: LauncherSearch
                             function onResultsChanged() {
-                                // Don't cap results to typingResultLimit when browsing the
-                                // full alphabetical app list (the "@all" special query) -
-                                // the whole point there is to see everything, not just 15.
-                                const isAllAppsMode = root.searchingText === (Config.options.search.prefix.allApps + "all");
+                                const isAllAppsMode = root.searchingText === Config.options.search.prefix.app;
                                 resultModel.values = isAllAppsMode ? LauncherSearch.results : LauncherSearch.results.slice(0, root.typingResultLimit);
                                 root.focusFirstItem();
                                 debounceTimer.restart();
@@ -267,7 +264,8 @@ Item { // Wrapper
                             anchors.right: parent?.right
                             entry: delegateItem.modelData
                             forcedSelected: delegateItem.ListView.isCurrentItem
-                            query: StringUtils.cleanOnePrefix(root.searchingText, [Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.allApps, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch])
+                            query: StringUtils.cleanOnePrefix(root.searchingText, [Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch])
+
 
                             Keys.onPressed: event => {
                                 if (event.key === Qt.Key_Tab) {

--- a/dots/.config/quickshell/ii/services/AppSearch.qml
+++ b/dots/.config/quickshell/ii/services/AppSearch.qml
@@ -76,6 +76,9 @@ Singleton {
             return r.obj.entry
         });
     }
+    function listAllSorted() {
+        return [...list].sort((a, b) => a.name.localeCompare(b.name));
+    }
 
     function iconExists(iconName) {
         if (!iconName || iconName.length == 0) return false;

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -224,8 +224,7 @@ Singleton {
                     }
                 });
             }).filter(Boolean);
-        }else if (root.query === (Config.options.search.prefix.allApps + "all")) {
-            // Full alphabetical app list with letter separators, for the "@all" browse mode
+        }else if (root.query === Config.options.search.prefix.app) {
             const sortedApps = AppSearch.listAllSorted();
             let lastLetter = "";
             const output = [];

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -224,6 +224,41 @@ Singleton {
                     }
                 });
             }).filter(Boolean);
+        }else if (root.query === (Config.options.search.prefix.allApps + "all")) {
+            // Full alphabetical app list with letter separators, for the "@all" browse mode
+            const sortedApps = AppSearch.listAllSorted();
+            let lastLetter = "";
+            const output = [];
+            for (const entry of sortedApps) {
+                const firstLetter = (entry.name?.[0] ?? "").toUpperCase();
+                if (firstLetter !== lastLetter) {
+                    output.push(resultComp.createObject(null, {
+                        name: firstLetter,
+                        isSeparator: true
+                    }));
+                    lastLetter = firstLetter;
+                }
+                output.push(resultComp.createObject(null, {
+                    type: Translation.tr("App"),
+                    id: entry.id,
+                    name: entry.name,
+                    iconName: entry.icon,
+                    iconType: LauncherSearchResult.IconType.System,
+                    verb: Translation.tr("Open"),
+                    execute: () => {
+                        if (!entry.runInTerminal)
+                            entry.execute();
+                        else {
+                            Quickshell.execDetached(["bash", '-c', `${Config.options.apps.terminal} -e '${StringUtils.shellSingleQuoteEscape(entry.command.join(' '))}'`]);
+                        }
+                    },
+                    comment: entry.comment,
+                    runInTerminal: entry.runInTerminal,
+                    genericName: entry.genericName,
+                    keywords: entry.keywords
+                }));
+            }
+            return output;
         }
 
         ////////////////// Init ///////////////////
@@ -288,7 +323,12 @@ Singleton {
                 if (cleanedCommand.startsWith(Config.options.search.prefix.shellCommand)) {
                     cleanedCommand = cleanedCommand.slice(Config.options.search.prefix.shellCommand.length);
                 }
-                Quickshell.execDetached(["bash", "-c", root.query.startsWith('sudo') ? `${Config.options.apps.terminal} fish -C '${cleanedCommand}'` : cleanedCommand]);
+                //if you fish
+                // const heldCommand = `${cleanedCommand}; exec fish`;
+                // Quickshell.execDetached(["fish", "-c", `${Config.options.apps.terminal} -e fish -c '${StringUtils.shellSingleQuoteEscape(heldCommand)}'`]);
+                //default bash
+                const heldCommand = `${cleanedCommand}; exec bash`;
+                Quickshell.execDetached(["bash", "-c", `${Config.options.apps.terminal} -e bash -c '${StringUtils.shellSingleQuoteEscape(heldCommand)}'`]);
             }
         });
         const webSearchResultObject = resultComp.createObject(null, {

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -225,9 +225,57 @@ Singleton {
                 });
             }).filter(Boolean);
         }else if (root.query === Config.options.search.prefix.app) {
+            const output = [];
+
+            // Recent apps
+            const recentApps = RecentApps.topEntries(5);
+            if (recentApps.length > 0) {
+                output.push(resultComp.createObject(null, {
+                    name: Translation.tr("Recent"),
+                    isSeparator: true
+                }));
+                for (const entry of recentApps) {
+                    output.push(resultComp.createObject(null, {
+                        type: Translation.tr("Recent"),
+                        id: entry.id,
+                        name: entry.name,
+                        iconName: entry.icon,
+                        iconType: LauncherSearchResult.IconType.System,
+                        verb: Translation.tr("Open"),
+                        execute: () => {
+                            RecentApps.recordUsage(entry.id);
+                            if (!entry.runInTerminal)
+                                entry.execute();
+                            else {
+                                Quickshell.execDetached(["bash", '-c', `${Config.options.apps.terminal} -e '${StringUtils.shellSingleQuoteEscape(entry.command.join(' '))}'`]);
+                            }
+                        },
+                        comment: entry.comment,
+                        runInTerminal: entry.runInTerminal,
+                        genericName: entry.genericName,
+                        keywords: entry.keywords,
+                        actions: entry.actions.map(action => {
+                            return resultComp.createObject(null, {
+                                name: action.name,
+                                iconName: action.icon,
+                                iconType: LauncherSearchResult.IconType.System,
+                                execute: () => {
+                                    if (!action.runInTerminal)
+                                        action.execute();
+                                    else {
+                                        Quickshell.execDetached(["bash", '-c', `${Config.options.apps.terminal} -e '${StringUtils.shellSingleQuoteEscape(action.command.join(' '))}'`]);
+                                    }
+                                }
+                            });
+                        })
+                    }));
+                }
+            }
+
+            // Alphabetical list with letter separators
             const sortedApps = AppSearch.listAllSorted();
             let lastLetter = "";
-            const output = [];
+            
             for (const entry of sortedApps) {
                 const firstLetter = (entry.name?.[0] ?? "").toUpperCase();
                 if (firstLetter !== lastLetter) {
@@ -245,6 +293,7 @@ Singleton {
                     iconType: LauncherSearchResult.IconType.System,
                     verb: Translation.tr("Open"),
                     execute: () => {
+                        RecentApps.recordUsage(entry.id);
                         if (!entry.runInTerminal)
                             entry.execute();
                         else {
@@ -296,10 +345,10 @@ Singleton {
                 iconType: LauncherSearchResult.IconType.System,
                 verb: Translation.tr("Open"),
                 execute: () => {
+                    RecentApps.recordUsage(entry.id);
                     if (!entry.runInTerminal)
                         entry.execute();
                     else {
-                        // Probably needs more proper escaping, but this will do for now
                         Quickshell.execDetached(["bash", '-c', `${Config.options.apps.terminal} -e '${StringUtils.shellSingleQuoteEscape(entry.command.join(' '))}'`]);
                     }
                 },

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -227,7 +227,7 @@ Singleton {
         }else if (root.query === Config.options.search.prefix.app) {
             const output = [];
 
-            // Recent apps
+            // Recent apps, shown above the alphabetical list
             const recentApps = RecentApps.topEntries(5);
             if (recentApps.length > 0) {
                 output.push(resultComp.createObject(null, {
@@ -275,7 +275,6 @@ Singleton {
             // Alphabetical list with letter separators
             const sortedApps = AppSearch.listAllSorted();
             let lastLetter = "";
-            
             for (const entry of sortedApps) {
                 const firstLetter = (entry.name?.[0] ?? "").toUpperCase();
                 if (firstLetter !== lastLetter) {

--- a/dots/.config/quickshell/ii/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/ii/services/LauncherSearch.qml
@@ -255,7 +255,21 @@ Singleton {
                     comment: entry.comment,
                     runInTerminal: entry.runInTerminal,
                     genericName: entry.genericName,
-                    keywords: entry.keywords
+                    keywords: entry.keywords,
+                    actions: entry.actions.map(action => {
+                        return resultComp.createObject(null, {
+                            name: action.name,
+                            iconName: action.icon,
+                            iconType: LauncherSearchResult.IconType.System,
+                            execute: () => {
+                                if (!action.runInTerminal)
+                                    action.execute();
+                                else {
+                                    Quickshell.execDetached(["bash", '-c', `${Config.options.apps.terminal} -e '${StringUtils.shellSingleQuoteEscape(action.command.join(' '))}'`]);
+                                }
+                            }
+                        });
+                    })
                 }));
             }
             return output;

--- a/dots/.config/quickshell/ii/services/RecentApps.qml
+++ b/dots/.config/quickshell/ii/services/RecentApps.qml
@@ -1,0 +1,68 @@
+pragma Singleton
+
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+/**
+ * Tracks recently launched apps (by DesktopEntry id) and persists them
+ * to disk, similar to how Config.qml persists shell options.
+ */
+Singleton {
+    id: root
+
+    property int maxStored: 20
+    property int readWriteDelay: 50 // milliseconds
+
+    // Resolves stored ids back to real DesktopEntry objects via AppSearch.list,
+    // silently dropping any that no longer exist (e.g. app was uninstalled).
+    function topEntries(count) {
+        const ids = dataAdapter.recent.map(r => r.id);
+        const resolved = [];
+        for (const id of ids) {
+            const entry = AppSearch.list.find(a => a.id === id);
+            if (entry)
+                resolved.push(entry);
+            if (resolved.length >= count)
+                break;
+        }
+        return resolved;
+    }
+
+    function recordUsage(id) {
+        if (!id)
+            return;
+        const list = dataAdapter.recent.filter(r => r.id !== id);
+        list.unshift({
+            id: id,
+            lastUsed: Date.now()
+        });
+        dataAdapter.recent = list.slice(0, root.maxStored);
+    }
+
+    Timer {
+        id: fileWriteTimer
+        interval: root.readWriteDelay
+        repeat: false
+        onTriggered: fileView.writeAdapter()
+    }
+
+    FileView {
+        id: fileView
+        path: Directories.recentAppsPath
+        watchChanges: true
+        onAdapterUpdated: fileWriteTimer.restart()
+        onLoadFailed: error => {
+            if (error == FileViewError.FileNotFound) {
+                writeAdapter();
+            }
+        }
+
+        JsonAdapter {
+            id: dataAdapter
+            property list<var> recent: []
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes
## `>` search — browse all installed apps

**Problem:** Earlier there was no orderly way to show full list of installed apps.

**Behavior added:**
- Typing `>` shows every installed app, sorted alphabetically, with a
  letter separator row before each new starting letter (e.g. "A", "B", "C"...).
- And a recent application section.

# In Action

https://github.com/user-attachments/assets/35a77920-74ee-40ae-a90e-2decc63ed1d3






<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes, ready to use. Need feedback.