### PR TITLE
fedora: add quickshell deps to feddeps.toml

### DIFF
--- a/sdata/dist-fedora/feddeps.toml
+++ b/sdata/dist-fedora/feddeps.toml
@@ -134,6 +134,34 @@ packages = [
 ]
 install_opts = ["--setopt=install_weak_deps=False"]
 
+[groups.quickshell]
+packages = [
+  "qt6-qtdeclarative",
+  "qt6-qtbase",
+  "jemalloc",
+  "qt6-qtsvg",
+  "pipewire-libs",
+  "libxcb",
+  "wayland-devel",
+  "qt6-qtwayland",
+  "qt5-qtwayland",
+  "libdrm",
+  "breakpad",
+  "kf6-kirigami",
+  "libunwind-devel",
+  # NOTE: Below are custom dependencies of illogical-impulse
+  "qt6-qt5compat",
+  "qt6-qtimageformats",
+  "qt6-qtpositioning",
+  "qt6-qtquicktimeline",
+  "qt6-qtsensors",
+  "qt6-qttools",
+  "qt6-qttranslations",
+  "qt6-qtvirtualkeyboard",
+  "kdialog",
+  "kf6-syntax-highlighting"
+]
+
 [groups.illogical-impulse]
 packages = [
     "quickshell-git",


### PR DESCRIPTION
## Describe your changes

Adds manual installation to script since Quickshell breaks everything (so fixes #3516)
its also necessary to merge end-4/ii-package-builds#5 then

## Is it ready? Questions/feedback needed?


