### PR TITLE
Set max audio in incrementVolume function to 1.5

### DIFF
--- a/dots/.config/quickshell/ii/services/Audio.qml
+++ b/dots/.config/quickshell/ii/services/Audio.qml
@@ -60,7 +60,7 @@ Singleton {
     function incrementVolume() {
         const currentVolume = Audio.value;
         const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
-        Audio.sink.audio.volume = Math.min(1, Audio.sink.audio.volume + step);
+        Audio.sink.audio.volume = Math.min(1.5, Audio.sink.audio.volume + step);
     }
     
     function decrementVolume() {


### PR DESCRIPTION
## Describe your changes
In qs.services.Audio, I changed the incrementVolume() function's maximum volume to be 150, similar to the keybind

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
... i changed like 1 number