### PR TITLE
feat(sidebar): add Manjaro distro icon support

### DIFF
--- a/dots/.config/quickshell/ii/assets/icons/manjaro-symbolic.svg
+++ b/dots/.config/quickshell/ii/assets/icons/manjaro-symbolic.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="200"
+   height="200"
+   viewBox="0 0 200 200">
+  <g transform="translate(222.41168,-236.90015)">
+    <rect width="58.534939" height="200" x="-80.946617" y="236.90016" />
+    <rect width="58.534939" height="129.26881" x="-151.68127" y="307.63138" />
+    <path transform="translate(-222.41168,236.90015)"
+          d="M 0 0 L 0 200 L 58.535156 200 L 58.535156 58.535156 L 129.26562 58.535156 L 129.26562 0 L 58.535156 0 L 20.765625 0 L 0 0 z " />
+  </g>
+</svg>

--- a/dots/.config/quickshell/ii/services/SystemInfo.qml
+++ b/dots/.config/quickshell/ii/services/SystemInfo.qml
@@ -60,6 +60,7 @@ Singleton {
             switch (distroId) {
                 case "artix":
                 case "arch": distroIcon = "arch-symbolic"; break;
+                case "manjaro": distroIcon = "manjaro-symbolic"; break;
                 case "endeavouros": distroIcon = "endeavouros-symbolic"; break;
                 case "cachyos": distroIcon = "cachyos-symbolic"; break;
                 case "nixos": distroIcon = "nixos-symbolic"; break;


### PR DESCRIPTION
## Describe your changes

Add `manjaro-symbolic.svg` (from font-logos, Unlicense) and map the `manjaro` distro ID to it in `SystemInfo.qml` so the **sidebar displays the Manjaro logo** instead of the generic Linux icon.

| Before | After |
|-----------|---------|
| <img width="148" height="48" alt="image" src="https://github.com/user-attachments/assets/2127cb4f-c789-45b6-a826-8d3b54cdfcca" /> | <img width="148" height="49" alt="image" src="https://github.com/user-attachments/assets/e29427ef-074d-4d13-b783-125530cf397e" /> |

## Is it ready? Questions/feedback needed?

Ready, no questions/feedback needed.