### PR TITLE
feat(clipboard): Clear clipboard buttons

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
@@ -40,6 +40,7 @@ RippleButton {
     property int buttonHorizontalPadding: 10
     property int buttonVerticalPadding: 6
     property bool keyboardDown: false
+    property bool clearBtnHasFocus: false
     readonly property bool selected: (root.hovered || root.focus)
 
     implicitHeight: rowLayout.implicitHeight + root.buttonVerticalPadding * 2

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchItem.qml
@@ -41,7 +41,7 @@ RippleButton {
     property int buttonVerticalPadding: 6
     property bool keyboardDown: false
     property bool clearBtnHasFocus: false
-    readonly property bool selected: (root.hovered || root.focus)
+    readonly property bool selected: (root.hovered || root.focus) && !root.clearBtnHasFocus
 
     implicitHeight: rowLayout.implicitHeight + root.buttonVerticalPadding * 2
     implicitWidth: rowLayout.implicitWidth + root.buttonHorizontalPadding * 2

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -222,18 +222,6 @@ Item { // Wrapper
                     }
                     KeyNavigation.right: clearClipboardBtn
                     KeyNavigation.down: appResults
-                    Keys.onPressed: event => {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            clearResultsBtn.down = true;
-                            clearResultsBtn.clicked();
-                            event.accepted = true;
-                        }
-                    }
-                    Keys.onReleased: event => {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            clearResultsBtn.down = false;
-                        }
-                    }
                 }
                 Button {
                     id: clearClipboardBtn
@@ -259,20 +247,8 @@ Item { // Wrapper
                         Cliphist.wipe();
                         root.focusSearchInput();
                     }
-                    KeyNavigation.left: root.clipboardSearching ? clearResultsBtn : undefined
+                    KeyNavigation.left: root.clipboardSearching ? clearResultsBtn : searchBar
                     KeyNavigation.down: appResults
-                    Keys.onPressed: event => {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            clearClipboardBtn.down = true;
-                            clearClipboardBtn.clicked();
-                            event.accepted = true;
-                        }
-                    }
-                    Keys.onReleased: event => {
-                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            clearClipboardBtn.down = false;
-                        }
-                    }
                 }
             }
 
@@ -326,7 +302,7 @@ Item { // Wrapper
 
                 onFocusChanged: {
                     if (focus)
-                        appResults.currentIndex = 1;
+                        appResults.currentIndex = 0;
                 }
 
                 Connections {

--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchWidget.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import Qt.labs.synchronizer
 import Qt5Compat.GraphicalEffects
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
 
@@ -18,6 +19,8 @@ Item { // Wrapper
     readonly property string xdgConfigHome: Directories.config
     readonly property int typingDebounceInterval: 200
     readonly property int typingResultLimit: 15 // Should be enough to cover the whole view
+    readonly property bool clearBtnHasFocus: clearClipboardBtn.activeFocus || clearResultsBtn.activeFocus
+    readonly property bool clipboardSearching: root.searchingText.startsWith(Config.options.search.prefix.clipboard) && root.searchingText.length > Config.options.search.prefix.clipboard.length
 
     property string searchingText: LauncherSearch.query
     property bool showResults: searchingText != ""
@@ -51,6 +54,22 @@ Item { // Wrapper
         // Prevent Esc and Backspace from registering
         if (event.key === Qt.Key_Escape)
             return;
+
+        // Handle Down arrow: navigate to Clear results/Clear all button or list
+        if (event.key === Qt.Key_Down) {
+            const isClipboard = root.searchingText.startsWith(Config.options.search.prefix.clipboard);
+            if (isClipboard) {
+                if (root.clipboardSearching && !clearResultsBtn.activeFocus) {
+                    clearResultsBtn.forceActiveFocus();
+                    event.accepted = true;
+                    return;
+                } else if (!clearClipboardBtn.activeFocus) {
+                    clearClipboardBtn.forceActiveFocus();
+                    event.accepted = true;
+                    return;
+                }
+            }
+        }
 
         // Handle Backspace: focus and delete character if not focused
         if (event.key === Qt.Key_Backspace) {
@@ -158,6 +177,141 @@ Item { // Wrapper
                 color: Appearance.colors.colOutlineVariant
             }
 
+            RowLayout {
+                visible: root.showResults && root.searchingText.startsWith(Config.options.search.prefix.clipboard)
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 10
+                Layout.topMargin: 6
+                Layout.bottomMargin: 2
+
+                StyledText {
+                    text: Translation.tr("Clipboard")
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colSubtext
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                Button {
+                    id: clearResultsBtn
+                    visible: root.clipboardSearching
+                    implicitHeight: 28
+                    hoverEnabled: true
+                    contentItem: StyledText {
+                        text: Translation.tr("Clear results")
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: clearResultsBtn.focus ? Appearance.colors.colOnPrimaryContainer : Appearance.colors.colPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        radius: Appearance.rounding.small
+                        color: clearResultsBtn.down ? Appearance.colors.colPrimaryContainerActive : (clearResultsBtn.hovered ? Appearance.colors.colPrimaryContainer : ColorUtils.transparentize(Appearance.colors.colPrimaryContainer, 1))
+                        border.width: clearResultsBtn.focus ? 2 : 0
+                        border.color: Appearance.colors.colSecondary
+                        Behavior on color {
+                            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+                        }
+                    }
+                    onClicked: {
+                        const searchString = StringUtils.cleanPrefix(root.searchingText, Config.options.search.prefix.clipboard);
+                        const matches = Cliphist.fuzzyQuery(searchString);
+                        Cliphist.deleteEntries(matches);
+                        root.focusSearchInput();
+                    }
+                    KeyNavigation.right: clearClipboardBtn
+                    KeyNavigation.down: appResults
+                    Keys.onPressed: event => {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            clearResultsBtn.down = true;
+                            clearResultsBtn.clicked();
+                            event.accepted = true;
+                        }
+                    }
+                    Keys.onReleased: event => {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            clearResultsBtn.down = false;
+                        }
+                    }
+                }
+                Button {
+                    id: clearClipboardBtn
+                    implicitHeight: 28
+                    hoverEnabled: true
+                    contentItem: StyledText {
+                        text: Translation.tr("Clear all")
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: clearClipboardBtn.focus ? Appearance.colors.colOnPrimaryContainer : Appearance.colors.colPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        radius: Appearance.rounding.small
+                        color: clearClipboardBtn.down ? Appearance.colors.colPrimaryContainerActive : (clearClipboardBtn.hovered ? Appearance.colors.colPrimaryContainer : ColorUtils.transparentize(Appearance.colors.colPrimaryContainer, 1))
+                        border.width: clearClipboardBtn.focus ? 2 : 0
+                        border.color: Appearance.colors.colSecondary
+                        Behavior on color {
+                            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+                        }
+                    }
+                    onClicked: {
+                        Cliphist.wipe();
+                        root.focusSearchInput();
+                    }
+                    KeyNavigation.left: root.clipboardSearching ? clearResultsBtn : undefined
+                    KeyNavigation.down: appResults
+                    Keys.onPressed: event => {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            clearClipboardBtn.down = true;
+                            clearClipboardBtn.clicked();
+                            event.accepted = true;
+                        }
+                    }
+                    Keys.onReleased: event => {
+                        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                            clearClipboardBtn.down = false;
+                        }
+                    }
+                }
+            }
+
+            Item {
+                visible: root.showResults && root.searchingText.startsWith(Config.options.search.prefix.clipboard) && appResults.count === 0
+                Layout.fillWidth: true
+                implicitHeight: 120
+
+                readonly property bool hasEntries: Cliphist.entries.length > 0
+                readonly property bool isSearching: hasEntries && root.clipboardSearching
+
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    spacing: 5
+
+                    MaterialSymbol {
+                        Layout.alignment: Qt.AlignHCenter
+                        iconSize: 48
+                        color: Appearance.m3colors.m3outline
+                        text: parent.parent.isSearching ? "search_off" : "content_paste"
+                    }
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        font.pixelSize: Appearance.font.pixelSize.normal
+                        font.weight: Font.DemiBold
+                        color: Appearance.m3colors.m3outline
+                        horizontalAlignment: Text.AlignHCenter
+                        text: parent.parent.isSearching ? Translation.tr("No results found") : Translation.tr("Clipboard is empty")
+                    }
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        font.pixelSize: Appearance.font.pixelSize.small
+                        color: Appearance.m3colors.m3outline
+                        horizontalAlignment: Text.AlignHCenter
+                        text: parent.parent.isSearching ? Translation.tr("Try a different search") : Translation.tr("Copy something to see it here")
+                    }
+                }
+            }
+
             ListView { // App results
                 id: appResults
                 visible: root.showResults
@@ -209,9 +363,11 @@ Item { // Wrapper
                     id: searchItem
                     // The selectable item for each search result
                     required property var modelData
+                    required property int index
                     anchors.left: parent?.left
                     anchors.right: parent?.right
                     entry: modelData
+                    clearBtnHasFocus: root.clearBtnHasFocus
                     query: StringUtils.cleanOnePrefix(root.searchingText, [Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch])
 
                     Keys.onPressed: event => {
@@ -223,6 +379,21 @@ Item { // Wrapper
                             searchBar.searchInput.text = tabbedText;
                             event.accepted = true;
                             root.focusSearchInput();
+                        } else if (event.key === Qt.Key_Up && searchItem.index === 0) {
+                            const isClipboard = root.searchingText.startsWith(Config.options.search.prefix.clipboard);
+                            if (isClipboard) {
+                                if (root.clipboardSearching) {
+                                    clearResultsBtn.forceActiveFocus();
+                                } else {
+                                    clearClipboardBtn.forceActiveFocus();
+                                }
+                                event.accepted = true;
+                            }
+                        } else if (event.key === Qt.Key_Down) {
+                            const listView = searchItem.ListView.view;
+                            if (searchItem.index === listView.count - 1) {
+                                event.accepted = true;
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/ii/services/Cliphist.qml
+++ b/dots/.config/quickshell/ii/services/Cliphist.qml
@@ -98,6 +98,18 @@ Singleton {
         deleteProc.deleteEntry(entry);
     }
 
+    function deleteEntries(entries) {
+        if (entries.length === 0) return;
+        if (root.cliphistBinary.includes("cliphist")) {
+            const escaped = entries.map(e => StringUtils.shellSingleQuoteEscape(e)).join("\\n");
+            Quickshell.execDetached(["bash", "-c", `printf '${escaped}' | ${root.cliphistBinary} delete`]);
+        } else {
+            entries.forEach(e => deleteEntry(e));
+            return;
+        }
+        delayedUpdateTimer.restart();
+    }
+
     Process {
         id: wipeProc
         command: [root.cliphistBinary, "wipe"]

--- a/dots/.config/quickshell/ii/services/Cliphist.qml
+++ b/dots/.config/quickshell/ii/services/Cliphist.qml
@@ -104,8 +104,8 @@ Singleton {
             const escaped = entries.map(e => StringUtils.shellSingleQuoteEscape(e)).join("\\n");
             Quickshell.execDetached(["bash", "-c", `printf '${escaped}' | ${root.cliphistBinary} delete`]);
         } else {
-            entries.forEach(e => deleteEntry(e));
-            return;
+            const escaped = entries.map(e => StringUtils.shellSingleQuoteEscape(e)).join("'\\n'");
+            Quickshell.execDetached(["bash", "-c", `printf '%b' '${escaped}' | while IFS= read -r entry; do [ -n "$entry" ] && echo "$entry" | ${root.cliphistBinary} delete; done`]);
         }
         delayedUpdateTimer.restart();
     }


### PR DESCRIPTION
## Describe your changes

I added **buttons to wipe the clipboard and search results** in the **Quickshell overview**.

<img width="531" height="710" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/09138be0-c8a6-4637-9cf8-5ca781ed7926" />

The Clipboard widget allows users to manage and preview their clipping history. It includes a search filter to refine the information displayed.

Currently, when you perform a specific search and want to clear only the filtered results (or the entire list), there's no direct way to do so from the interface. This forces you to delete items one by one or manually clear the search box, impacting the user experience and workflow efficiency.

To address this, **two new buttons were added to the Clipboard interface**:

- **Clear Results**: Removes from the list only the items that match the currently active search filter.
- **Clear All**: Clears all items from the clipboard, regardless of whether a filter is active or not.


By allowing you to clear only visible results with `Clear results`, you can quickly segment and discard filtered output or commands without losing the rest of your history or current work context from the clipboard. Additionally, `Clear all` offers a quick shortcut to completely clear the clipboard directly within the same widget.


https://github.com/user-attachments/assets/f9971c56-c1c6-4991-944a-cf9c798fabf5



<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Ready, the changes have already been tested locally and the state's behavior is as expected. I would like to receive feedback, especially on the visual layout and accessibility of the new buttons in the UI.

### Related

Contributes to [Improve Clipboard](https://github.com/end-4/dots-hyprland/issues/2666)