### PR TITLE
feat(dock): Add visual feedback when launching apps from the dock

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -332,6 +332,7 @@ Singleton {
                 property list<string> pinnedApps: [ // IDs of pinned entries
                     "org.kde.dolphin", "kitty",]
                 property list<string> ignoredAppRegexes: []
+                property int launchAnimation: DockLaunchAnims.AnimType.Bounce
             }
 
             property JsonObject interactions: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/DockLaunchAnims.qml
+++ b/dots/.config/quickshell/ii/modules/common/DockLaunchAnims.qml
@@ -1,0 +1,5 @@
+import QtQuick
+
+QtObject {
+    enum AnimType { None, Bounce, Pulse, Pop, Wobble }
+}

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockAppButton.qml
@@ -62,6 +62,7 @@ DockButton {
     }
 
     onClicked: {
+        launchAnims.play(Config.options.dock.launchAnimation);
         if (appToplevel.toplevels.length === 0) {
             root.desktopEntry?.execute();
             return;
@@ -91,6 +92,9 @@ DockButton {
                     verticalCenter: parent.verticalCenter
                 }
                 active: !root.isSeparator
+                scale: launchAnims.scale
+                rotation: launchAnims.rot
+                transformOrigin: Item.Center
                 sourceComponent: IconImage {
                     source: Quickshell.iconPath(AppSearch.guessIcon(appToplevel.appId), "image-missing")
                     implicitSize: root.iconSize
@@ -136,5 +140,9 @@ DockButton {
                 }
             }
         }
+    }
+
+    DockLaunchAnimations {
+        id: launchAnims
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockLaunchAnimations.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockLaunchAnimations.qml
@@ -1,0 +1,115 @@
+import qs.modules.common
+import QtQuick
+
+Item {
+    id: root
+
+    property real scale: 1.0
+    property real rot: 0.0
+
+    function play(type) {
+        if (type === DockLaunchAnims.AnimType.None) return;
+        if (type === DockLaunchAnims.AnimType.Bounce) animBounce.restart();
+        else if (type === DockLaunchAnims.AnimType.Pulse) animPulse.restart();
+        else if (type === DockLaunchAnims.AnimType.Pop) animPop.restart();
+        else if (type === DockLaunchAnims.AnimType.Wobble) animWobble.restart();
+    }
+
+    SequentialAnimation {
+        id: animPop
+        PropertyAction { target: root; property: "scale"; value: 0.0 }
+        
+        NumberAnimation {
+            target: root
+            property: "scale"
+            from: 0.0
+            to: 1.0
+            duration: 350
+            easing.type: Easing.OutBack 
+        }
+    }
+
+    SequentialAnimation {
+        id: animBounce
+        
+        NumberAnimation {
+            target: root
+            property: "scale"
+            from: 1.0; to: 0.82
+            duration: 100
+            easing.type: Easing.InQuad
+        }
+        
+        NumberAnimation {
+            target: root
+            property: "scale"
+            from: 0.82; to: 1.0
+            duration: 400
+            easing.type: Easing.OutBounce 
+        }
+    }
+
+    SequentialAnimation {
+        id: animPulse
+        NumberAnimation {
+            target: root
+            property: "scale"
+            from: 1.0; to: 1.2
+            duration: 120
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.emphasizedDecel
+        }
+        NumberAnimation {
+            target: root
+            property: "scale"
+            from: 1.2; to: 1.0
+            duration: 350 // Regreso lento para suavidad
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+    }
+
+    SequentialAnimation {
+        id: animWobble
+        NumberAnimation {
+            target: root
+            property: "rot"
+            from: 0; to: -10
+            duration: 60
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.emphasizedDecel
+        }
+        NumberAnimation {
+            target: root
+            property: "rot"
+            from: -10; to: 10
+            duration: 80
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+        NumberAnimation {
+            target: root
+            property: "rot"
+            from: 10; to: -5
+            duration: 70
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+        NumberAnimation {
+            target: root
+            property: "rot"
+            from: -5; to: 5
+            duration: 60
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+        NumberAnimation {
+            target: root
+            property: "rot"
+            from: 5; to: 0
+            duration: 80
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -139,6 +139,23 @@ ContentPage {
                 Config.options.dock.monochromeIcons = checked;
             }
         }
+
+        ContentSubsection {
+            title: Translation.tr("Launch animation")
+            ConfigSelectionArray {
+                currentValue: Config.options.dock.launchAnimation
+                onSelected: newValue => {
+                    Config.options.dock.launchAnimation = newValue;
+                }
+                options: [
+                    { displayName: Translation.tr("None"), icon: "block", value: DockLaunchAnims.AnimType.None },
+                    { displayName: Translation.tr("Bounce"), icon: "swap_vert", value: DockLaunchAnims.AnimType.Bounce },
+                    { displayName: Translation.tr("Pulse"), icon: "open_in_new", value: DockLaunchAnims.AnimType.Pulse },
+                    { displayName: Translation.tr("Pop"), icon: "adjust", value: DockLaunchAnims.AnimType.Pop },
+                    { displayName: Translation.tr("Wobble"), icon: "360", value: DockLaunchAnims.AnimType.Wobble }
+                ]
+            }
+        }
     }
 
     ContentSection {


### PR DESCRIPTION
## Describe your changes

This PR introduces **launch animations for apps in the dock**, significantly improving the user experience (UX) by providing immediate **visual feedback after clicking**.

[ pr.webm](https://github.com/user-attachments/assets/64961428-ae5a-4f0d-bff9-508ac863e767)


Currently, when interacting with apps in the Dock, there is no visual effect to confirm that the action has been successfully registered. This can cause uncertainty for the user as to whether the click worked, especially when the app takes a while to appear.

To address this and add dynamism to the interface, a layer of visual feedback has been added that makes the **interaction much smoother and more reliable**.

### Changes Introduced

* **Launch visual effect:** An animation that plays immediately upon clicking any app icon in the dock.
* **New settings section:** The path `Settings > Interface > Dock > Launch animation` has been added so users can customize their experience.
   <img width="500" height="96" alt="image" src="https://github.com/user-attachments/assets/9844ecf8-5fd6-4808-ba86-7ecb061e9bbb" />
* **Variety of options:** Four preset animations are included (along with the option to disable them):
  * `Bounce`
  * `Pulse`
  * `Pop`
  * `Wobble`
  * `None`


> *Note: For the design of the effects, I drew inspiration from the [Tailwind Animations](https://tailwind-animations.com/#animation-collection-heading) collection; several of these visually striking animations could be adopted*

## Is it ready? Questions/feedback needed?

The development is practically **complete and functional**. However, **I'm opening this PR to get your feedback**:

1. **What do you think of the visual presentation and the pacing of the animations?**
2. **Is there any technical or design reason why you think we should discard or modify any of the implemented options?**