### PR TITLE
Wrap Claude CLI in ai chat

### DIFF
--- a/dots/.config/hypr/hyprland/env.lua
+++ b/dots/.config/hypr/hyprland/env.lua
@@ -6,6 +6,8 @@ hl.env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
 -- Applications
 local xdg_data_dirs_old = os.getenv("XDG_DATA_DIRS") or ""
 hl.env("XDG_DATA_DIRS", home_dir .. "/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share:" .. xdg_data_dirs_old)
+local path_old = os.getenv("PATH") or ""
+hl.env("PATH", home_dir .. "/.local/bin:" .. path_old)
 
 -- Themes
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")

--- a/dots/.config/quickshell/ii/modules/common/Directories.qml
+++ b/dots/.config/quickshell/ii/modules/common/Directories.qml
@@ -46,6 +46,7 @@ Singleton {
     property string userAiPrompts: FileUtils.trimFileProtocol(`${Directories.shellConfig}/ai/prompts`)
     property string userActions: FileUtils.trimFileProtocol(`${Directories.shellConfig}/actions`)
     property string aiChats: FileUtils.trimFileProtocol(`${Directories.state}/user/ai/chats`)
+    property string claudeModelListCachePath: FileUtils.trimFileProtocol(`${Directories.state}/user/ai/claude_models.json`)
     property string aiTranslationScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/ai/gemini-translate.sh`)
     property string recordScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/videos/record.sh`)
     property string userAvatarPathAccountsService: FileUtils.trimFileProtocol(`/var/lib/AccountsService/icons/${SystemInfo.username}`)

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -51,7 +51,7 @@ Singleton {
      * @returns {Array<{type: "text" | "think" | "code", content: string, lang?: string, completed?: boolean}>}
      */
     function splitMarkdownBlocks(markdown) {
-        const regex = /```(\w+)?\n([\s\S]*?)```|<think>([\s\S]*?)<\/think>/g;
+        const regex = /```([\w:-]+)?\n([\s\S]*?)```|<think>([\s\S]*?)<\/think>/g;
         /**
          * @type {{type: "text" | "think" | "code"; content: string; lang: string | undefined; completed: boolean | undefined}[]}
          */
@@ -119,7 +119,7 @@ Singleton {
                     });
                 }
                 // Try to detect language after ```
-                const codeLangMatch = text.slice(codeStart + 3).match(/^(\w+)?\n/);
+                const codeLangMatch = text.slice(codeStart + 3).match(/^([\w:-]+)?\n/);
                 let lang = "";
                 let codeContentStart = codeStart + 3;
                 if (codeLangMatch) {

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -283,6 +283,32 @@ Singleton {
     }
 
     /**
+     * Duration as the units that carry information, largest first: 2d, 3h / 4h, 50m / 1m, 30s.
+     * Seconds are dropped once the total runs to hours, where they say nothing; pass
+     * includeSeconds false for a duration that is only ever read in minutes, like an uptime.
+     * @param { number } seconds
+     * @param { boolean } [includeSeconds]
+     * @returns { string }
+     */
+    function friendlyDurationForSeconds(seconds, includeSeconds = true) {
+        if (isNaN(seconds) || seconds < 0)
+            return includeSeconds ? "0s" : "0m";
+        seconds = Math.floor(seconds);
+        const parts = [];
+        const days = Math.floor(seconds / 86400);
+        const hours = Math.floor((seconds % 86400) / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        if (days > 0) parts.push(`${days}d`);
+        if (hours > 0) parts.push(`${hours}h`);
+        if (minutes > 0) parts.push(`${minutes}m`);
+        if (includeSeconds && days === 0 && hours === 0 && seconds % 60 > 0) {
+            parts.push(`${seconds % 60}s`);
+        }
+        if (parts.length === 0) parts.push(includeSeconds ? `${seconds}s` : "0m");
+        return parts.join(", ");
+    }
+
+    /**
      * Escapes HTML special characters in a string.
      * @param { string } str
      * @returns { string }

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -46,6 +46,42 @@ Singleton {
     }
 
     /**
+     * Applies a transform to the nth command fence. Empty-bodied fences are skipped so
+     * the ordinal counts the same fences splitMarkdownBlocks emits.
+     * @param { string } content
+     * @param { number } ordinal
+     * @param { (fence: string) => string } transform
+     * @returns { string }
+     */
+    function editCommandFence(content, ordinal, transform) {
+        if (ordinal < 0) return content;
+        let seen = 0;
+        return content.replace(/```command(?::[\w-]+)*\n([\s\S]*?)```/g,
+            (fence, body) => body.trim().length === 0 ? fence
+                : (seen++ === ordinal) ? transform(fence) : fence);
+    }
+
+    /**
+     * Lifecycle states a command fence's info string can end with, as command:<name>:<state>.
+     */
+    readonly property var commandFenceStates: ["pending", "running", "done", "failed", "denied", "answered"]
+
+    /**
+     * Swaps a command fence's state token, keeping whatever tool name it already carries
+     * so states replace each other instead of stacking.
+     * @param { string } fence
+     * @param { string } state
+     * @returns { string }
+     */
+    function withCommandFenceState(fence, state) {
+        return fence.replace(/^```command((?::[\w-]+)*)/, (full, flags) => {
+            const name = flags.split(":").filter(s => s.length > 0)
+                .find(s => !root.commandFenceStates.includes(s));
+            return "```command" + (name ? ":" + name : "") + ":" + state;
+        });
+    }
+
+    /**
      * Splits markdown blocks into three different types: text, think, and code.
      * @param { string } markdown
      * @returns {Array<{type: "text" | "think" | "code", content: string, lang?: string, completed?: boolean}>}

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -135,6 +135,53 @@ Singleton {
     }
 
     /**
+     * Closes the open strings and brackets of truncated JSON.
+     * @param { string } s
+     * @returns { string | null } null when the string is cut mid-escape
+     */
+    function closeJson(s) {
+        let stack = [];
+        let inStr = false;
+        for (let i = 0; i < s.length; i++) {
+            const c = s[i];
+            if (inStr) {
+                if (c === '\\') {
+                    if (i + 1 >= s.length) return null;
+                    i++;
+                    continue;
+                }
+                if (c === '"') inStr = false;
+                continue;
+            }
+            if (c === '"') inStr = true;
+            else if (c === '{' || c === '[') stack.push(c);
+            else if (c === '}' || c === ']') stack.pop();
+        }
+        let out = s;
+        if (inStr) out += '"';
+        out = out.replace(/,\s*$/, "");
+        for (let i = stack.length - 1; i >= 0; i--) {
+            out += stack[i] === '{' ? '}' : ']';
+        }
+        return out;
+    }
+
+    /**
+     * Parses JSON that may still be streaming, chopping back past dangling keys, colons
+     * and partial literals until closing the remainder succeeds.
+     * @param { string } s
+     * @returns { any } null when no prefix parses
+     */
+    function parsePartialJson(s) {
+        for (let end = s.length; end > 0 && end > s.length - 64; end--) {
+            const closed = root.closeJson(s.slice(0, end));
+            if (closed === null) continue;
+            try { return JSON.parse(closed); } catch (e) {}
+        }
+        return null;
+    }
+
+    /**
      * Returns the original string with backslashes escaped
      * @param { string } str
      * @returns { string }

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -85,6 +85,25 @@ Singleton {
     readonly property var commandFenceStates: ["streaming", "pending", "running", "done", "failed", "denied", "answered"]
 
     /**
+     * Divides a command fence's body into the command and the output of the run. Output lives
+     * in the fence rather than beside it so it survives saving and reloading the chat, which
+     * keeps nothing but the message text.
+     */
+    readonly property string commandOutputSeparator: "\u001e"
+
+    /**
+     * @param { string } body
+     * @returns { {command: string, output: string} }
+     */
+    function splitCommandFenceBody(body) {
+        const parts = String(body ?? "").split(root.commandOutputSeparator);
+        return {
+            command: parts[0].replace(/\n$/, ""),
+            output: parts.slice(1).join("").replace(/^\n/, "").replace(/\s+$/, "")
+        };
+    }
+
+    /**
      * Swaps a command fence's state token, keeping whatever tool name it already carries
      * so states replace each other instead of stacking.
      * @param { string } fence

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -87,110 +87,50 @@ Singleton {
      * @returns {Array<{type: "text" | "think" | "code", content: string, lang?: string, completed?: boolean}>}
      */
     function splitMarkdownBlocks(markdown) {
-        // A still-streaming thought must not let code fences inside it match as
-        // code blocks: everything from an unclosed <think> onward is one
-        // incomplete think block, and only the text before it is parsed normally
-        let openThink = -1;
-        let searchFrom = 0;
-        while (true) {
-            const start = markdown.indexOf('<think>', searchFrom);
-            if (start === -1) break;
-            const close = markdown.indexOf('</think>', start);
-            if (close === -1) {
-                openThink = start;
-                break;
-            }
-            searchFrom = close + 8;
-        }
-        let openThinkContent = null;
-        if (openThink !== -1) {
-            openThinkContent = markdown.slice(openThink + 7);
-            markdown = markdown.slice(0, openThink);
-        }
-        const regex = /```([\w:-]+)?\n([\s\S]*?)```|<think>([\s\S]*?)<\/think>/g;
         /**
          * @type {{type: "text" | "think" | "code"; content: string; lang: string | undefined; completed: boolean | undefined}[]}
          */
-        let result = [];
-        let lastIndex = 0;
-        let match;
-        while ((match = regex.exec(markdown)) !== null) {
-            if (match.index > lastIndex) {
-                const text = markdown.slice(lastIndex, match.index);
-                if (text.trim()) {
-                    result.push({
-                        type: "text",
-                        content: text
-                    });
+        const result = [];
+        let pos = 0;
+        let textStart = 0;
+        const pushText = end => {
+            const text = markdown.slice(textStart, end);
+            if (text.trim()) result.push({ type: "text", content: text });
+        };
+        while (pos < markdown.length) {
+            const think = markdown.indexOf("<think>", pos);
+            const fence = markdown.indexOf("```", pos);
+            if (think === -1 && fence === -1) break;
+            // Whichever of the two opens first owns everything up to its own terminator, and
+            // its body is never scanned. A construct with no terminator runs to the end and
+            // is reported incomplete
+            if (fence === -1 || (think !== -1 && think < fence)) {
+                pushText(think);
+                const close = markdown.indexOf("</think>", think + 7);
+                const content = markdown.slice(think + 7, close === -1 ? markdown.length : close);
+                if (content.trim()) {
+                    result.push({ type: "think", content: content, completed: close !== -1 });
                 }
-            }
-            if (match[0].startsWith('```')) {
-                if (match[2] && match[2].trim()) {
-                    result.push({
-                        type: "code",
-                        lang: match[1] || "",
-                        content: match[2],
-                        completed: true
-                    });
-                }
-            } else if (match[0].startsWith('<think>')) {
-                if (match[3] && match[3].trim()) {
-                    result.push({
-                        type: "think",
-                        content: match[3],
-                        completed: true
-                    });
-                }
-            }
-            lastIndex = regex.lastIndex;
-        }
-        // Handle any remaining text after the last match; the pre-pass already
-        // took any unclosed <think>, so only an unfinished code block can remain
-        if (lastIndex < markdown.length) {
-            const text = markdown.slice(lastIndex);
-            const codeStart = text.indexOf('```');
-            if (codeStart !== -1) {
-                const beforeCode = text.slice(0, codeStart);
-                if (beforeCode.trim()) {
-                    result.push({
-                        type: "text",
-                        content: beforeCode
-                    });
-                }
-                // Try to detect language after ```
-                const codeLangMatch = text.slice(codeStart + 3).match(/^([\w:-]+)?\n/);
-                let lang = "";
-                let codeContentStart = codeStart + 3;
-                if (codeLangMatch) {
-                    lang = codeLangMatch[1] || "";
-                    codeContentStart += codeLangMatch[0].length;
-                } else if (text[codeStart + 3] === '\n') {
-                    codeContentStart += 1;
-                }
-                const codeContent = text.slice(codeContentStart);
-                if (codeContent.trim()) {
+                pos = close === -1 ? markdown.length : close + 8;
+            } else {
+                pushText(fence);
+                const langMatch = markdown.slice(fence + 3).match(/^([\w:-]+)?\n/);
+                const contentStart = fence + 3 + (langMatch?.[0].length ?? 0);
+                const close = markdown.indexOf("```", contentStart);
+                const content = markdown.slice(contentStart, close === -1 ? markdown.length : close);
+                if (content.trim()) {
                     result.push({
                         type: "code",
-                        lang,
-                        content: codeContent,
-                        completed: false
+                        lang: langMatch?.[1] ?? "",
+                        content: content,
+                        completed: close !== -1
                     });
                 }
-            } else if (text.trim()) {
-                result.push({
-                    type: "text",
-                    content: text
-                });
+                pos = close === -1 ? markdown.length : close + 3;
             }
+            textStart = pos;
         }
-        if (openThinkContent !== null && openThinkContent.trim()) {
-            result.push({
-                type: "think",
-                content: openThinkContent,
-                completed: false
-            });
-        }
-        // console.log(JSON.stringify(result, null, 2));
+        pushText(markdown.length);
         return result;
     }
 

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -82,7 +82,7 @@ Singleton {
     /**
      * Lifecycle states a command fence's info string can end with, as command:<name>:<state>.
      */
-    readonly property var commandFenceStates: ["pending", "running", "done", "failed", "denied", "answered"]
+    readonly property var commandFenceStates: ["streaming", "pending", "running", "done", "failed", "denied", "answered"]
 
     /**
      * Swaps a command fence's state token, keeping whatever tool name it already carries

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -51,6 +51,26 @@ Singleton {
      * @returns {Array<{type: "text" | "think" | "code", content: string, lang?: string, completed?: boolean}>}
      */
     function splitMarkdownBlocks(markdown) {
+        // A still-streaming thought must not let code fences inside it match as
+        // code blocks: everything from an unclosed <think> onward is one
+        // incomplete think block, and only the text before it is parsed normally
+        let openThink = -1;
+        let searchFrom = 0;
+        while (true) {
+            const start = markdown.indexOf('<think>', searchFrom);
+            if (start === -1) break;
+            const close = markdown.indexOf('</think>', start);
+            if (close === -1) {
+                openThink = start;
+                break;
+            }
+            searchFrom = close + 8;
+        }
+        let openThinkContent = null;
+        if (openThink !== -1) {
+            openThinkContent = markdown.slice(openThink + 7);
+            markdown = markdown.slice(0, openThink);
+        }
         const regex = /```([\w:-]+)?\n([\s\S]*?)```|<think>([\s\S]*?)<\/think>/g;
         /**
          * @type {{type: "text" | "think" | "code"; content: string; lang: string | undefined; completed: boolean | undefined}[]}
@@ -88,29 +108,12 @@ Singleton {
             }
             lastIndex = regex.lastIndex;
         }
-        // Handle any remaining text after the last match
+        // Handle any remaining text after the last match; the pre-pass already
+        // took any unclosed <think>, so only an unfinished code block can remain
         if (lastIndex < markdown.length) {
             const text = markdown.slice(lastIndex);
-            // Check for unfinished <think> block
-            const thinkStart = text.indexOf('<think>');
             const codeStart = text.indexOf('```');
-            if (thinkStart !== -1 && (codeStart === -1 || thinkStart < codeStart)) {
-                const beforeThink = text.slice(0, thinkStart);
-                if (beforeThink.trim()) {
-                    result.push({
-                        type: "text",
-                        content: beforeThink
-                    });
-                }
-                const thinkContent = text.slice(thinkStart + 7);
-                if (thinkContent.trim()) {
-                    result.push({
-                        type: "think",
-                        content: thinkContent,
-                        completed: false
-                    });
-                }
-            } else if (codeStart !== -1) {
+            if (codeStart !== -1) {
                 const beforeCode = text.slice(0, codeStart);
                 if (beforeCode.trim()) {
                     result.push({
@@ -143,6 +146,13 @@ Singleton {
                     content: text
                 });
             }
+        }
+        if (openThinkContent !== null && openThinkContent.trim()) {
+            result.push({
+                type: "think",
+                content: openThinkContent,
+                completed: false
+            });
         }
         // console.log(JSON.stringify(result, null, 2));
         return result;

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -46,8 +46,25 @@ Singleton {
     }
 
     /**
-     * Applies a transform to the nth command fence. Empty-bodied fences are skipped so
-     * the ordinal counts the same fences splitMarkdownBlocks emits.
+     * Whether a block from splitMarkdownBlocks is a command fence
+     * @param { {lang?: string} } block
+     * @returns { boolean }
+     */
+    function isCommandFence(block) {
+        return block.lang?.split(":")[0] === "command";
+    }
+
+    /**
+     * All command markdown blocks in string
+     * @param { string } content
+     * @returns { Array<{content: string, lang: string, start: number, end: number}> }
+     */
+    function commandFences(content) {
+        return root.splitMarkdownBlocks(content).filter(block => root.isCommandFence(block));
+    }
+
+    /**
+     * Applies a transform to the nth command fence, passing it the whole fence text.
      * @param { string } content
      * @param { number } ordinal
      * @param { (fence: string) => string } transform
@@ -55,10 +72,11 @@ Singleton {
      */
     function editCommandFence(content, ordinal, transform) {
         if (ordinal < 0) return content;
-        let seen = 0;
-        return content.replace(/```command(?::[\w-]+)*\n([\s\S]*?)```/g,
-            (fence, body) => body.trim().length === 0 ? fence
-                : (seen++ === ordinal) ? transform(fence) : fence);
+        const fence = root.commandFences(content)[ordinal];
+        if (!fence) return content;
+        return content.slice(0, fence.start)
+            + transform(content.slice(fence.start, fence.end))
+            + content.slice(fence.end);
     }
 
     /**
@@ -95,7 +113,7 @@ Singleton {
         let textStart = 0;
         const pushText = end => {
             const text = markdown.slice(textStart, end);
-            if (text.trim()) result.push({ type: "text", content: text });
+            if (text.trim()) result.push({ type: "text", content: text, start: textStart, end: end });
         };
         while (pos < markdown.length) {
             const think = markdown.indexOf("<think>", pos);
@@ -107,26 +125,34 @@ Singleton {
             if (fence === -1 || (think !== -1 && think < fence)) {
                 pushText(think);
                 const close = markdown.indexOf("</think>", think + 7);
+                pos = close === -1 ? markdown.length : close + 8;
                 const content = markdown.slice(think + 7, close === -1 ? markdown.length : close);
                 if (content.trim()) {
-                    result.push({ type: "think", content: content, completed: close !== -1 });
+                    result.push({
+                        type: "think",
+                        content: content,
+                        completed: close !== -1,
+                        start: think,
+                        end: pos
+                    });
                 }
-                pos = close === -1 ? markdown.length : close + 8;
             } else {
                 pushText(fence);
                 const langMatch = markdown.slice(fence + 3).match(/^([\w:-]+)?\n/);
                 const contentStart = fence + 3 + (langMatch?.[0].length ?? 0);
                 const close = markdown.indexOf("```", contentStart);
+                pos = close === -1 ? markdown.length : close + 3;
                 const content = markdown.slice(contentStart, close === -1 ? markdown.length : close);
                 if (content.trim()) {
                     result.push({
                         type: "code",
                         lang: langMatch?.[1] ?? "",
                         content: content,
-                        completed: close !== -1
+                        completed: close !== -1,
+                        start: fence,
+                        end: pos
                     });
                 }
-                pos = close === -1 ? markdown.length : close + 3;
             }
             textStart = pos;
         }

--- a/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
+++ b/dots/.config/quickshell/ii/modules/common/functions/StringUtils.qml
@@ -104,6 +104,22 @@ Singleton {
     }
 
     /**
+     * Character offset each line of the text starts at. Lets a caller ask a laid-out text item
+     * where a given line ended up, without splitting the text a second way.
+     * @param { string } text
+     * @returns { list<int> }
+     */
+    function lineStartOffsets(text) {
+        const lines = String(text ?? "").replace(/\n$/, "").split("\n");
+        let offset = 0;
+        return lines.map(line => {
+            const start = offset;
+            offset += line.length + 1;
+            return start;
+        });
+    }
+
+    /**
      * Swaps a command fence's state token, keeping whatever tool name it already carries
      * so states replace each other instead of stacking.
      * @param { string } fence

--- a/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
@@ -3,21 +3,24 @@ import QtQuick
 import QtQuick.Layouts
 
 /**
- * Clipping window for content that collapses to nothing. Anchor the content to an edge, not
- * filling, and set contentHeight to its own height. Bottom anchor slides it away; top anchor
- * suits content that also grows while expanded, which a bottom anchor pushes out of view.
+ * Clipping window for content that collapses to nothing, or to a peek of itself. Anchor the
+ * content to an edge, not filling, and set contentHeight to its own height. Bottom anchor
+ * slides it away; top anchor suits content that also grows while expanded, which a bottom
+ * anchor pushes out of view, and is the one that can show a peek.
  */
 Item {
     id: root
     property bool collapsed: false
     property real contentHeight: 0
+    // How much stays visible while collapsed
+    property real collapsedHeight: 0
     property var animation: Appearance?.animation.elementMoveFast
     // Off while content is still arriving, so growth isn't animated as a collapse
     property bool animated: true
 
     Layout.fillWidth: true
     clip: true
-    implicitHeight: root.collapsed ? 0 : root.contentHeight
+    implicitHeight: root.collapsed ? root.collapsedHeight : root.contentHeight
 
     Behavior on implicitHeight {
         enabled: root.animated

--- a/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
@@ -3,11 +3,9 @@ import QtQuick
 import QtQuick.Layouts
 
 /**
- * Clipping window for content that collapses to nothing.
- *
- * Anchor the content to this item's bottom, so collapsing slides it out of view instead of
- * squashing it, which would re-wrap text on the way. Set contentHeight to the content's own
- * natural height; measuring it here would fight the anchor.
+ * Clipping window for content that collapses to nothing. Anchor the content to this item's
+ * bottom so it slides out of view rather than being squashed, which would re-wrap text, and
+ * set contentHeight to the content's own height; measuring it here would fight that anchor.
  */
 Item {
     id: root

--- a/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
@@ -1,0 +1,32 @@
+import qs.modules.common
+import QtQuick
+import QtQuick.Layouts
+
+/**
+ * Clipping window for content that collapses to nothing.
+ *
+ * Anchor the content to this item's bottom, so collapsing slides it out of view instead of
+ * squashing it, which would re-wrap text on the way. Set contentHeight to the content's own
+ * natural height; measuring it here would fight the anchor.
+ */
+Item {
+    id: root
+    property bool collapsed: false
+    property real contentHeight: 0
+    property var animation: Appearance?.animation.elementMoveFast
+    // Off while content is still arriving, so growth isn't animated as a collapse
+    property bool animated: true
+
+    Layout.fillWidth: true
+    clip: true
+    implicitHeight: root.collapsed ? 0 : root.contentHeight
+
+    Behavior on implicitHeight {
+        enabled: root.animated
+        NumberAnimation {
+            duration: root.animation.duration
+            easing.type: root.animation.type
+            easing.bezierCurve: root.animation.bezierCurve
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/CollapsibleContent.qml
@@ -3,9 +3,9 @@ import QtQuick
 import QtQuick.Layouts
 
 /**
- * Clipping window for content that collapses to nothing. Anchor the content to this item's
- * bottom so it slides out of view rather than being squashed, which would re-wrap text, and
- * set contentHeight to the content's own height; measuring it here would fight that anchor.
+ * Clipping window for content that collapses to nothing. Anchor the content to an edge, not
+ * filling, and set contentHeight to its own height. Bottom anchor slides it away; top anchor
+ * suits content that also grows while expanded, which a bottom anchor pushes out of view.
  */
 Item {
     id: root

--- a/dots/.config/quickshell/ii/modules/common/widgets/ExpandButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/ExpandButton.qml
@@ -3,8 +3,8 @@ import qs.modules.common.functions
 import QtQuick
 
 /**
- * Chevron that points down when collapsed and up when expanded. Toggling is the caller's job,
- * so the same click can be handled by a surrounding header too.
+ * Chevron pointing down when collapsed, up when expanded. The caller owns the toggle, so a
+ * surrounding header can handle the same click.
  */
 RippleButton {
     id: root

--- a/dots/.config/quickshell/ii/modules/common/widgets/ExpandButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/ExpandButton.qml
@@ -1,0 +1,34 @@
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+
+/**
+ * Chevron that points down when collapsed and up when expanded. Toggling is the caller's job,
+ * so the same click can be handled by a surrounding header too.
+ */
+RippleButton {
+    id: root
+    property bool expanded: false
+    // Set from the surrounding header's MouseArea so the whole bar lights up as one control
+    property bool headerHovered: false
+
+    implicitWidth: 22
+    implicitHeight: 22
+    colBackground: root.headerHovered ? Appearance.colors.colLayer2Hover
+        : ColorUtils.transparentize(Appearance.colors.colLayer2, 1)
+    colBackgroundHover: Appearance.colors.colLayer2Hover
+    colRipple: Appearance.colors.colLayer2Active
+
+    contentItem: MaterialSymbol {
+        anchors.centerIn: parent
+        text: "keyboard_arrow_down"
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        iconSize: Appearance.font.pixelSize.normal
+        color: Appearance.colors.colOnLayer2
+        rotation: root.expanded ? 180 : 0
+        Behavior on rotation {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -7,6 +7,7 @@ import qs.modules.ii.sidebarLeft.aiChat
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 import Qt5Compat.GraphicalEffects
 import Quickshell
 import Quickshell.Io
@@ -374,6 +375,10 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 spacing: 10
                 popin: false
                 topMargin: statusBg.implicitHeight + statusBg.anchors.topMargin * 2
+
+                // A drag inside a text field is a selection, not a scroll; the field
+                // would otherwise lose the mouse grab to this list mid-selection
+                interactive: !(Window.activeFocusItem instanceof TextInput)
 
                 touchpadScrollFactor: Config.options.interactions.scrolling.touchpadScrollFactor * 1.4
                 mouseScrollFactor: Config.options.interactions.scrolling.mouseScrollFactor * 1.4

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -328,8 +328,13 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                         statusText: ""
                         description: Ai.currentModelHasApiKey ? Translation.tr("API key is set\nChange with /key YOUR_API_KEY") : Translation.tr("No API key\nSet it with /key YOUR_API_KEY")
                     }
-                    StatusSeparator {}
+                    StatusSeparator {
+                        visible: temperatureStatusItem.visible
+                    }
                     StatusItem {
+                        id: temperatureStatusItem
+                        // The Claude CLI does not expose temperature
+                        visible: Ai.getModel()?.api_format !== "claude-cli"
                         icon: "device_thermostat"
                         statusText: Ai.temperature.toFixed(1)
                         description: Translation.tr("Temperature\nChange with /temp VALUE")
@@ -683,9 +688,12 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                                 }
                                 event.accepted = false; // No image, let text pasting proceed
                             } else if (event.key === Qt.Key_Escape) {
-                                // Esc to detach file
+                                // Esc to detach file, else stop generation
                                 if (Ai.pendingFilePath.length > 0) {
                                     Ai.attachFile("");
+                                    event.accepted = true;
+                                } else if (Ai.busy) {
+                                    Ai.interrupt();
                                     event.accepted = true;
                                 } else {
                                     event.accepted = false;
@@ -694,20 +702,25 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                         }
                     }
                 }
-                RippleButton { // Send button
+                RippleButton { // Send/stop button
                     id: sendButton
+                    property bool stopMode: messageInputField.text.length === 0 && Ai.busy
                     Layout.alignment: Qt.AlignBottom
                     Layout.rightMargin: 5
                     implicitWidth: 40
                     implicitHeight: 40
                     buttonRadius: Appearance.rounding.small
-                    enabled: messageInputField.text.length > 0
+                    enabled: messageInputField.text.length > 0 || sendButton.stopMode
                     toggled: enabled
 
                     MouseArea {
                         anchors.fill: parent
                         cursorShape: sendButton.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                         onClicked: {
+                            if (sendButton.stopMode) {
+                                Ai.interrupt();
+                                return;
+                            }
                             const inputText = messageInputField.text;
                             root.handleInput(inputText);
                             messageInputField.clear();
@@ -719,7 +732,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                         horizontalAlignment: Text.AlignHCenter
                         iconSize: 22
                         color: sendButton.enabled ? Appearance.m3colors.m3onPrimary : Appearance.colors.colOnLayer2Disabled
-                        text: "arrow_upward"
+                        text: sendButton.stopMode ? "stop_circle" : "arrow_upward"
                     }
                 }
             }
@@ -749,12 +762,13 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 ApiInputBoxIndicator {
                     // Model indicator
                     icon: "api"
-                    text: Ai.getModel().name
-                    tooltipText: Translation.tr("Current model: %1\nSet it with %2model MODEL").arg(Ai.getModel().name).arg(root.commandPrefix)
+                    text: Ai.getModel()?.name ?? Translation.tr("No model")
+                    tooltipText: Translation.tr("Current model: %1\nSet it with %2model MODEL").arg(Ai.getModel()?.name ?? Translation.tr("None")).arg(root.commandPrefix)
                 }
 
                 ApiInputBoxIndicator {
-                    // Tool indicator
+                    // Tool indicator; the Claude CLI brings its own tools, so the setting has no effect there
+                    visible: Ai.getModel()?.api_format !== "claude-cli"
                     icon: "service_toolbox"
                     text: Ai.currentTool.charAt(0).toUpperCase() + Ai.currentTool.slice(1)
                     tooltipText: Translation.tr("Current tool: %1\nSet it with %2tool TOOL").arg(Ai.currentTool).arg(root.commandPrefix)

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/AiChat.qml
@@ -27,6 +27,10 @@ Item {
     }
 
     Keys.onPressed: event => {
+        // Don't yank focus out of another editable field (e.g. a question's
+        // free-text pill) — bare modifier presses bubble up here too
+        const focused = root.Window.activeFocusItem;
+        if (focused && focused !== messageInputField && focused.cursorVisible !== undefined) return;
         messageInputField.forceActiveFocus();
         if (event.modifiers === Qt.NoModifier) {
             if (event.key === Qt.Key_PageUp) {
@@ -355,6 +359,12 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 z: 1
                 target: messageListView
                 vertical: true
+            }
+
+            MouseArea { // Click on empty space to refocus the input (unfocuses question text pills)
+                anchors.fill: parent
+                z: -1
+                onPressed: root.inputField.forceActiveFocus()
             }
 
             StyledListView { // Message list

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/SidebarLeftContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/SidebarLeftContent.qml
@@ -4,6 +4,7 @@ import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 import Qt5Compat.GraphicalEffects
 import Qt.labs.synchronizer
 
@@ -72,6 +73,10 @@ Item {
                 anchors.fill: parent
                 spacing: 10
                 currentIndex: tabBar.currentIndex
+
+                // A horizontal drag inside a text field is a selection, not a tab
+                // switch; the field would otherwise lose the mouse grab to this view
+                interactive: !(Window.activeFocusItem instanceof TextInput)
 
                 clip: true
                 layer.enabled: true

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -20,11 +20,14 @@ Rectangle {
     property bool renderMarkdown: true
     property bool editing: false
 
+    // AskUserQuestion fences get their own delegate; other command fences render as code
     property list<var> messageBlocks: StringUtils.splitMarkdownBlocks(root.messageData?.content)
+        .map(block => (block.type === "code" && block.lang?.startsWith("command:AskUserQuestion"))
+            ? Object.assign({}, block, { type: "question" }) : block)
     // Block index of the command fence awaiting approval (messageData.pendingCommandIndex
     // counts command fences, not blocks)
     property int pendingCommandBlockIndex: messageBlocks
-        .map((block, i) => (block.type === "code" && block.lang?.split(":")[0] === "command") ? i : -1)
+        .map((block, i) => (block.lang?.split(":")[0] === "command") ? i : -1)
         .filter(i => i >= 0)[root.messageData?.pendingCommandIndex ?? -1] ?? -1
 
     anchors.left: parent?.left
@@ -286,6 +289,12 @@ Rectangle {
                         editing: root.editing
                         renderMarkdown: root.renderMarkdown
                         enableMouseSelection: root.enableMouseSelection
+                        segmentContent: modelData.content
+                        segmentLang: modelData.lang
+                        messageData: root.messageData
+                        isPendingCommand: index === root.pendingCommandBlockIndex
+                    } }
+                    DelegateChoice { roleValue: "question"; MessageQuestionBlock {
                         segmentContent: modelData.content
                         segmentLang: modelData.lang
                         messageData: root.messageData

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -21,8 +21,11 @@ Rectangle {
     property bool editing: false
 
     property list<var> messageBlocks: StringUtils.splitMarkdownBlocks(root.messageData?.content)
-    // Only the newest command block may answer the pending approval; older ones already got their verdict
-    property int lastCommandBlockIndex: messageBlocks.reduce((last, block, i) => (block.type === "code" && block.lang === "command") ? i : last, -1)
+    // Block index of the command fence awaiting approval (messageData.pendingCommandIndex
+    // counts command fences, not blocks)
+    property int pendingCommandBlockIndex: messageBlocks
+        .map((block, i) => (block.type === "code" && block.lang === "command") ? i : -1)
+        .filter(i => i >= 0)[root.messageData?.pendingCommandIndex ?? -1] ?? -1
 
     anchors.left: parent?.left
     anchors.right: parent?.right
@@ -302,7 +305,7 @@ Rectangle {
                         segmentContent: modelData.content
                         segmentLang: modelData.lang
                         messageData: root.messageData
-                        isLatestCommand: index === root.lastCommandBlockIndex
+                        isPendingCommand: index === root.pendingCommandBlockIndex
                     } }
                     DelegateChoice { roleValue: "think"; MessageThinkBlock {
                         editing: root.editing

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -21,6 +21,8 @@ Rectangle {
     property bool editing: false
 
     property list<var> messageBlocks: StringUtils.splitMarkdownBlocks(root.messageData?.content)
+    // Only the newest command block may answer the pending approval; older ones already got their verdict
+    property int lastCommandBlockIndex: messageBlocks.reduce((last, block, i) => (block.type === "code" && block.lang === "command") ? i : last, -1)
 
     anchors.left: parent?.left
     anchors.right: parent?.right
@@ -300,6 +302,7 @@ Rectangle {
                         segmentContent: modelData.content
                         segmentLang: modelData.lang
                         messageData: root.messageData
+                        isLatestCommand: index === root.lastCommandBlockIndex
                     } }
                     DelegateChoice { roleValue: "think"; MessageThinkBlock {
                         editing: root.editing

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -199,28 +199,8 @@ Rectangle {
                         }
                     }
 
-                    AiMessageControlButton {
-                        id: copyButton
-                        buttonIcon: activated ? "inventory" : "content_copy"
-
-                        onClicked: {
-                            Quickshell.clipboardText = root.messageData?.content
-                            copyButton.activated = true
-                            copyIconTimer.restart()
-                        }
-
-                        Timer {
-                            id: copyIconTimer
-                            interval: 1500
-                            repeat: false
-                            onTriggered: {
-                                copyButton.activated = false
-                            }
-                        }
-                        
-                        StyledToolTip {
-                            text: Translation.tr("Copy")
-                        }
+                    AiMessageCopyButton {
+                        copyText: root.messageData?.content ?? ""
                     }
                     AiMessageControlButton {
                         id: editButton

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -24,7 +24,7 @@ Rectangle {
     // Block index of the command fence awaiting approval (messageData.pendingCommandIndex
     // counts command fences, not blocks)
     property int pendingCommandBlockIndex: messageBlocks
-        .map((block, i) => (block.type === "code" && block.lang === "command") ? i : -1)
+        .map((block, i) => (block.type === "code" && block.lang?.split(":")[0] === "command") ? i : -1)
         .filter(i => i >= 0)[root.messageData?.pendingCommandIndex ?? -1] ?? -1
 
     anchors.left: parent?.left

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -27,7 +27,7 @@ Rectangle {
     // Block index of the command fence awaiting approval (messageData.pendingCommandIndex
     // counts command fences, not blocks)
     property int pendingCommandBlockIndex: messageBlocks
-        .map((block, i) => (block.lang?.split(":")[0] === "command") ? i : -1)
+        .map((block, i) => StringUtils.isCommandFence(block) ? i : -1)
         .filter(i => i >= 0)[root.messageData?.pendingCommandIndex ?? -1] ?? -1
 
     anchors.left: parent?.left

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -270,26 +270,10 @@ Rectangle {
 
         ColumnLayout { // Message content
             id: messageContentColumnLayout
-            spacing: 0
+            spacing: root.messagePadding
+            Layout.topMargin: 1
+            Layout.bottomMargin: 6
 
-            Item {
-                Layout.fillWidth: true
-                implicitHeight: loadingIndicatorLoader.shown ? loadingIndicatorLoader.implicitHeight : 0
-                implicitWidth: loadingIndicatorLoader.implicitWidth
-                visible: implicitHeight > 0
-
-                Behavior on implicitHeight {
-                    animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
-                }
-                FadeLoader {
-                    id: loadingIndicatorLoader
-                    anchors.centerIn: parent
-                    shown: (root.messageBlocks.length < 1) && (!root.messageData.done)
-                    sourceComponent: MaterialLoadingIndicator {
-                        loading: true
-                    }
-                }
-            }
             Repeater {
                 model: ScriptModel {
                     values: root.messageBlocks
@@ -325,6 +309,39 @@ Rectangle {
                         done: root.messageData?.done ?? false
                         forceDisableChunkSplitting: root.messageData?.content.includes("```") ?? true
                     } }
+                }
+            }
+            Item {
+                Layout.fillWidth: true
+                implicitHeight: loadingIndicatorLoader.shown ? loadingIndicatorLoader.implicitHeight : 0
+                implicitWidth: loadingIndicatorLoader.implicitWidth
+                visible: implicitHeight > 0
+                // Cancels the column's edge padding below so the indicator sits centered
+                // between the last block and the card bottom
+                Layout.bottomMargin: loadingIndicatorLoader.shown ? -6 : 0
+                Behavior on Layout.bottomMargin {
+                    animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+                }
+
+                // Delayed show, instant hide: the active gap right after answering an
+                // approval is shorter than the delay, so the spinner doesn't flash
+                property bool indicatorWanted: !root.messageData.done && !root.messageData.functionPending
+                onIndicatorWantedChanged: if (indicatorWanted) showDelayTimer.restart()
+
+                Timer {
+                    id: showDelayTimer
+                    interval: 300
+                }
+                Behavior on implicitHeight {
+                    animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+                }
+                FadeLoader {
+                    id: loadingIndicatorLoader
+                    anchors.centerIn: parent
+                    shown: parent.indicatorWanted && !showDelayTimer.running
+                    sourceComponent: MaterialLoadingIndicator {
+                        loading: true
+                    }
                 }
             }
         }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageControlButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageControlButton.qml
@@ -7,6 +7,19 @@ GroupButton {
     id: button
     property string buttonIcon
     property bool activated: false
+    // For actions that report back by holding a confirmed icon; buttons whose activated
+    // state means something lasting, like an open editor, just set it and leave it
+    function confirm() {
+        button.activated = true;
+        confirmationTimer.restart();
+    }
+    Timer {
+        id: confirmationTimer
+        interval: 1500
+        repeat: false
+        onTriggered: button.activated = false
+    }
+
     toggled: activated
     baseWidth: height
     colBackgroundHover: Appearance.colors.colSecondaryContainerHover

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageCopyButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageCopyButton.qml
@@ -1,0 +1,23 @@
+import qs.services
+import qs.modules.common.widgets
+import QtQuick
+import Quickshell
+
+/**
+ * Copies text and confirms by holding a checked icon for a moment.
+ */
+AiMessageControlButton {
+    id: root
+    property string copyText: ""
+    property string tooltipText: Translation.tr("Copy")
+
+    buttonIcon: activated ? "inventory" : "content_copy"
+    onClicked: {
+        Quickshell.clipboardText = root.copyText;
+        root.confirm();
+    }
+
+    StyledToolTip {
+        text: root.tooltipText
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageSaveButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/AiMessageSaveButton.qml
@@ -1,0 +1,34 @@
+import qs.services
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+
+/**
+ * Writes text to a file in Downloads, names it in a notification, and confirms on the button.
+ */
+AiMessageControlButton {
+    id: root
+    property string saveText: ""
+    property string fileName: "file.txt"
+    property string notificationTitle: Translation.tr("Saved to file")
+    property string tooltipText: Translation.tr("Save to Downloads")
+
+    buttonIcon: activated ? "check" : "save"
+    onClicked: {
+        const target = `${FileUtils.trimFileProtocol(Directories.downloads)}/${root.fileName}`;
+        Quickshell.execDetached(["bash", "-c",
+            `echo '${StringUtils.shellSingleQuoteEscape(root.saveText)}' > '${StringUtils.shellSingleQuoteEscape(target)}'`
+        ]);
+        Quickshell.execDetached(["notify-send",
+            root.notificationTitle,
+            Translation.tr("Saved to %1").arg(target),
+            "-a", "Shell"
+        ]);
+        root.confirm();
+    }
+
+    StyledToolTip {
+        text: root.tooltipText
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -284,6 +284,10 @@ ColumnLayout {
                         Item { Layout.fillWidth: true }
                         ButtonGroup {
                             GroupButton {
+                                // The default hover (colLayer1Hover) is invisible on the
+                                // block's colLayer2 background
+                                colBackgroundHover: Appearance.colors.colLayer2Hover
+                                colBackgroundActive: Appearance.colors.colLayer2Active
                                 contentItem: StyledText {
                                     text: Translation.tr("Reject")
                                     font.pixelSize: Appearance.font.pixelSize.small

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -116,8 +116,7 @@ ColumnLayout {
     readonly property int hiddenOutputLines: outputClipped
         ? outputLineCount - outputLineStarts.filter(s => outputRowOf(s) < outputPeekRows).length
         : 0
-    // A peek answers "did it work" without a click; a failure is the case where it never does
-    property bool outputExpanded: root.state === "failed"
+    property bool outputExpanded: false
 
     property real codeBlockBackgroundRounding: Appearance.rounding.small
     property real codeBlockHeaderPadding: 3
@@ -461,9 +460,6 @@ ColumnLayout {
 
                 CollapsibleContent {
                     id: outputCollapsibleContent
-                    // A failure arrives expanded mid-generation, wrap still settling; only the
-                    // toggle is worth animating
-                    animated: root.messageData?.done ?? true
                     collapsed: !root.outputExpanded
                     contentHeight: outputTextEdit.implicitHeight
                     collapsedHeight: Math.min(contentHeight, root.outputPeekHeight)

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -23,6 +23,7 @@ ColumnLayout {
     // Command fences carry the tool name in the info string: command:Read, command:Bash...
     property bool isCommandRequest: (segmentLang ?? "").split(":")[0] === "command"
     property string commandToolName: isCommandRequest ? ((segmentLang ?? "").split(":")[1] || "Bash") : ""
+    property bool commandDenied: isCommandRequest && (segmentLang ?? "").split(":").includes("denied")
     // Bash runs shell commands; every other tool takes JSON input
     property var displayLang: isCommandRequest
         ? (commandToolName === "Bash" ? "bash" : "json")
@@ -52,19 +53,36 @@ ColumnLayout {
             anchors.rightMargin: codeBlockHeaderPadding
             spacing: 5
 
-            StyledText {
-                id: codeBlockLanguage
+            RowLayout {
                 Layout.alignment: Qt.AlignLeft
-                Layout.fillWidth: false
                 Layout.topMargin: 7
                 Layout.bottomMargin: 7
                 Layout.leftMargin: 10
-                font.pixelSize: Appearance.font.pixelSize.small
-                font.weight: Font.DemiBold
-                color: Appearance.colors.colOnLayer2
-                text: root.isCommandRequest
-                    ? root.commandToolName
-                    : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
+                spacing: 6
+
+                StyledText {
+                    id: codeBlockLanguage
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnLayer2
+                    text: root.isCommandRequest
+                        ? root.commandToolName
+                        : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
+                }
+                Rectangle {
+                    visible: root.commandDenied
+                    implicitWidth: 4
+                    implicitHeight: 4
+                    radius: implicitWidth / 2
+                    color: Appearance.colors.colOnLayer1Inactive
+                }
+                StyledText {
+                    visible: root.commandDenied
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colError
+                    text: Translation.tr("denied")
+                }
             }
 
             Item { Layout.fillWidth: true }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -19,6 +19,7 @@ ColumnLayout {
     property var segmentContent: ({})
     property var segmentLang: "txt"
     property var messageData: {}
+    property bool isLatestCommand: true
     property bool isCommandRequest: segmentLang === "command"
     property var displayLang: (isCommandRequest ? "bash" : segmentLang)
 
@@ -249,7 +250,7 @@ ColumnLayout {
                     }
                 }
                 Loader {
-                    active: root.isCommandRequest && root.messageData.functionPending
+                    active: root.isCommandRequest && root.isLatestCommand && root.messageData.functionPending
                     visible: active
                     Layout.fillWidth: true
                     Layout.margins: 6

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -40,6 +40,11 @@ ColumnLayout {
                 && !(isPendingCommand && (messageData?.functionPending ?? false))) {
             return "denied";
         }
+        // One that did run is left over only when the shell died before the turn could settle
+        // it, which is the same end the CLI strategy gives an interrupted run
+        if (commandState === "running" && (messageData?.done ?? true)) {
+            return "failed";
+        }
         return commandState;
     }
     // Spelled out because the translation extractor only sees literal keys. Streaming shows
@@ -54,17 +59,126 @@ ColumnLayout {
         "denied": Translation.tr("rejected"),
         "answered": Translation.tr("answered"),
     })
+    // Written by the CLI strategy: t<epoch milliseconds> while running, d<seconds> once finished
+    readonly property double startedAtMs: Number(commandFlags.find(s => /^t\d+$/.test(s))?.slice(1) ?? 0)
+    readonly property int finishedSeconds: Number(commandFlags.find(s => /^d\d+$/.test(s))?.slice(1) ?? 0)
+    property double clockMs: 0
+    readonly property int runningSeconds: (startedAtMs > 0 && clockMs > 0)
+        ? Math.max(0, Math.floor((clockMs - startedAtMs) / 1000)) : 0
     readonly property string stateLabel: commandStateLabels[state] ?? state
+    readonly property string durationLabel: {
+        const seconds = state === "running" ? runningSeconds : finishedSeconds;
+        if (["running", "done", "failed"].includes(state) && seconds >= 1)
+            return StringUtils.friendlyDurationForSeconds(seconds);
+        return "";
+    }
+
+    Timer {
+        running: root.state === "running" && root.startedAtMs > 0
+        interval: 1000
+        repeat: true
+        triggeredOnStart: true
+        // Recomputed from the start rather than counted up, so a dropped tick costs nothing
+        onTriggered: root.clockMs = Date.now()
+    }
     // Bash runs shell commands; every other tool takes JSON input
     property var displayLang: isCommandRequest
         ? (commandToolName === "Bash" ? "bash" : "json")
         : segmentLang
 
+    // Only command fences carry a log, and only they may be split on the separator a plain
+    // block could contain
+    readonly property var commandBody: isCommandRequest
+        ? StringUtils.splitCommandFenceBody(segmentContent)
+        : ({ command: String(segmentContent ?? ""), output: "" })
+    readonly property string commandOutput: commandBody.output
+    // The strategy prefixes a log it had to cut short; that is a note about the log, not a line of it
+    readonly property bool outputTruncated: commandOutput.startsWith("…\n")
+    readonly property string outputBody: outputTruncated ? commandOutput.slice(2) : commandOutput
+    // Rows rather than lines, so one long line cannot make the peek arbitrarily tall
+    readonly property int outputPeekRows: 3
+    // Off the laid-out total rather than the cursor rectangle, which is a couple of pixels
+    // adrift of the row spacing
+    readonly property real outputRowHeight: outputTextEdit.lineCount > 0
+        ? outputTextEdit.contentHeight / outputTextEdit.lineCount : 0
+    readonly property real outputPeekHeight:
+        outputRowHeight * Math.min(outputPeekRows, outputTextEdit.lineCount)
+    readonly property bool outputClipped: outputTextEdit.lineCount > outputPeekRows
+    readonly property var outputLineStarts: StringUtils.lineStartOffsets(outputBody)
+    readonly property int outputLineCount: outputLineStarts.length
+    function outputRowOf(offset) {
+        if (outputRowHeight <= 0) return 0;
+        // Width read so a rewrap resettles every line
+        return Math.round((outputTextEdit.width, outputTextEdit.positionToRectangle(offset).y)
+            / outputRowHeight);
+    }
+    // The line the peek's last row belongs to is a line you can read, so it counts as shown
+    readonly property int hiddenOutputLines: outputClipped
+        ? outputLineCount - outputLineStarts.filter(s => outputRowOf(s) < outputPeekRows).length
+        : 0
+    // A peek answers "did it work" without a click; a failure is the case where it never does
+    property bool outputExpanded: root.state === "failed"
+
     property real codeBlockBackgroundRounding: Appearance.rounding.small
     property real codeBlockHeaderPadding: 3
     property real codeBlockComponentSpacing: 2
+    // The log has no TextArea padding of its own, so its band and gutter share this
+    property real outputBandPadding: 6
 
     spacing: codeBlockComponentSpacing
+
+    component HeaderDot: Rectangle {
+        implicitWidth: 4
+        implicitHeight: 4
+        radius: implicitWidth / 2
+        color: Appearance.colors.colOnLayer1Inactive
+    }
+
+    component LineNumberColumn: Rectangle {
+        id: gutter
+        required property var textItem
+        // Matches the band's own top padding, so numbers share the rows' baselines
+        property real contentInset: 0
+        // Bands with something under the text set this to the text's own height, so numbers
+        // stop where it does rather than at the band's bottom edge
+        property real contentHeight: gutter.height - gutter.contentInset * 2
+
+        implicitWidth: 40
+        Layout.fillHeight: true
+        Layout.fillWidth: false
+        topLeftRadius: Appearance.rounding.unsharpen
+        topRightRadius: Appearance.rounding.unsharpen
+        bottomLeftRadius: Appearance.rounding.unsharpen
+        bottomRightRadius: Appearance.rounding.unsharpen
+        color: Appearance.colors.colLayer2
+
+        Item {
+            // Clips here rather than on the gutter, whose padding leaves room below the last row
+            clip: true
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.rightMargin: 5
+            y: gutter.contentInset
+            height: gutter.contentHeight
+
+            Repeater {
+                // Wrapped lines share one number, so this walks lines rather than rows
+                model: StringUtils.lineStartOffsets(gutter.textItem.text)
+                Text {
+                    required property int index
+                    required property var modelData
+                    anchors.right: parent.right
+                    // Width referenced so rewrapping recomputes each line's y
+                    y: (gutter.textItem.width, gutter.textItem.positionToRectangle(modelData).y)
+                    font.family: Appearance.font.family.monospace
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colSubtext
+                    horizontalAlignment: Text.AlignRight
+                    text: index + 1
+                }
+            }
+        }
+    }
 
     Rectangle { // Code background
         Layout.fillWidth: true
@@ -100,12 +214,8 @@ ColumnLayout {
                         ? root.commandToolName
                         : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
                 }
-                Rectangle {
+                HeaderDot {
                     visible: root.stateLabel.length > 0
-                    implicitWidth: 4
-                    implicitHeight: 4
-                    radius: implicitWidth / 2
-                    color: Appearance.colors.colOnLayer1Inactive
                 }
                 StyledText {
                     visible: root.stateLabel.length > 0
@@ -116,106 +226,43 @@ ColumnLayout {
                         : Appearance.colors.colSubtext
                     text: root.stateLabel
                 }
+                HeaderDot {
+                    visible: root.durationLabel.length > 0
+                }
+                StyledText {
+                    visible: root.durationLabel.length > 0
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colSubtext
+                    text: root.durationLabel
+                }
             }
 
             Item { Layout.fillWidth: true }
 
             ButtonGroup {
-                AiMessageControlButton {
-                    id: copyCodeButton
-                    buttonIcon: activated ? "inventory" : "content_copy"
-
-                    onClicked: {
-                        Quickshell.clipboardText = segmentContent
-                        copyCodeButton.activated = true
-                        copyIconTimer.restart()
-                    }
-
-                    Timer {
-                        id: copyIconTimer
-                        interval: 1500
-                        repeat: false
-                        onTriggered: {
-                            copyCodeButton.activated = false
-                        }
-                    }
-                    StyledToolTip {
-                        text: Translation.tr("Copy code")
-                    }
+                AiMessageCopyButton {
+                    copyText: root.commandBody.command
+                    tooltipText: Translation.tr("Copy code")
                 }
-                AiMessageControlButton {
-                    id: saveCodeButton
-                    buttonIcon: activated ? "check" : "save"
-
-                    onClicked: {
-                        const downloadPath = FileUtils.trimFileProtocol(Directories.downloads)
-                        Quickshell.execDetached(["bash", "-c",
-                            `echo '${StringUtils.shellSingleQuoteEscape(segmentContent)}' > '${downloadPath}/code.${root.displayLang || "txt"}'`
-                        ])
-                        Quickshell.execDetached(["notify-send",
-                            Translation.tr("Code saved to file"),
-                            Translation.tr("Saved to %1").arg(`${downloadPath}/code.${root.displayLang || "txt"}`),
-                            "-a", "Shell"
-                        ])
-                        saveCodeButton.activated = true
-                        saveIconTimer.restart()
-                    }
-
-                    Timer {
-                        id: saveIconTimer
-                        interval: 1500
-                        repeat: false
-                        onTriggered: {
-                            saveCodeButton.activated = false
-                        }
-                    }
-                    StyledToolTip {
-                        text: Translation.tr("Save to Downloads")
-                    }
+                AiMessageSaveButton {
+                    saveText: root.commandBody.command
+                    fileName: `code.${root.displayLang || "txt"}`
+                    notificationTitle: Translation.tr("Code saved to file")
                 }
             }
         }
     }
 
     RowLayout { // Line numbers and code
+        Layout.fillWidth: true
         spacing: codeBlockComponentSpacing
 
-        Rectangle { // Line numbers
-            implicitWidth: 40
-            implicitHeight: lineNumberColumnLayout.implicitHeight
-            Layout.fillHeight: true
-            Layout.fillWidth: false
-            topLeftRadius: Appearance.rounding.unsharpen
-            bottomLeftRadius: codeBlockBackgroundRounding
-            topRightRadius: Appearance.rounding.unsharpen
-            bottomRightRadius: Appearance.rounding.unsharpen
-            color: Appearance.colors.colLayer2
-
-            ColumnLayout {
-                id: lineNumberColumnLayout
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    rightMargin: 5
-                    top: parent.top
-                    topMargin: 6
-                }
-                spacing: 0
-                
-                Repeater {
-                    model: codeTextArea.text.split("\n").length
-                    Text {
-                        required property int index
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignRight
-                        font.family: Appearance.font.family.monospace
-                        font.pixelSize: Appearance.font.pixelSize.small
-                        color: Appearance.colors.colSubtext
-                        horizontalAlignment: Text.AlignRight
-                        text: index + 1
-                    }
-                }
-            }
+        LineNumberColumn {
+            textItem: codeTextArea
+            bottomLeftRadius: root.commandOutput.length > 0
+                ? Appearance.rounding.unsharpen
+                : codeBlockBackgroundRounding
         }
 
         Rectangle { // Code background
@@ -223,7 +270,9 @@ ColumnLayout {
             topLeftRadius: Appearance.rounding.unsharpen
             bottomLeftRadius: Appearance.rounding.unsharpen
             topRightRadius: Appearance.rounding.unsharpen
-            bottomRightRadius: codeBlockBackgroundRounding
+            bottomRightRadius: root.commandOutput.length > 0
+                ? Appearance.rounding.unsharpen
+                : codeBlockBackgroundRounding
             color: Appearance.colors.colLayer2
             implicitHeight: codeColumnLayout.implicitHeight
 
@@ -231,80 +280,47 @@ ColumnLayout {
                 id: codeColumnLayout
                 anchors.fill: parent
                 spacing: 0
-                ScrollView {
-                    id: codeScrollView
+                TextArea { // Code
+                    id: codeTextArea
                     Layout.fillWidth: true
-                    // Layout.fillHeight: true
-                    implicitWidth: parent.width
-                    implicitHeight: codeTextArea.implicitHeight + 1
-                    contentWidth: codeTextArea.width - 1
-                    // contentHeight: codeTextArea.contentHeight
-                    clip: true
-                    ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-                    
-                    ScrollBar.horizontal: ScrollBar {
-                        anchors.bottom: parent.bottom
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        padding: 5
-                        policy: ScrollBar.AsNeeded
-                        opacity: visualSize == 1 ? 0 : 1
-                        visible: opacity > 0
+                    readOnly: !editing
+                    selectByMouse: enableMouseSelection || editing
+                    renderType: Text.NativeRendering
+                    font.family: Appearance.font.family.monospace
+                    font.hintingPreference: Font.PreferNoHinting // Prevent weird bold text
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
+                    selectionColor: Appearance.colors.colSecondaryContainer
+                    wrapMode: TextEdit.Wrap
+                    color: messageData.thinking ? Appearance.colors.colSubtext : Appearance.colors.colOnLayer1
 
-                        Behavior on opacity {
-                            NumberAnimation {
-                                duration: Appearance.animation.elementMoveFast.duration
-                                easing.type: Appearance.animation.elementMoveFast.type
-                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
-                            }
-                        }
-                        
-                        contentItem: Rectangle {
-                            implicitHeight: 6
-                            radius: Appearance.rounding.small
-                            color: Appearance.colors.colLayer2Active
+                    text: root.commandBody.command
+                    // Output is not editable, but it has to survive an edit of the command
+                    onTextChanged: {
+                        segmentContent = root.commandOutput.length > 0
+                            ? `${text}\n${StringUtils.commandOutputSeparator}\n${root.commandOutput}`
+                            : text
+                    }
+
+                    Keys.onPressed: (event) => {
+                        if (event.key === Qt.Key_Tab) {
+                            // Insert 4 spaces at cursor
+                            const cursor = codeTextArea.cursorPosition;
+                            codeTextArea.insert(cursor, "    ");
+                            codeTextArea.cursorPosition = cursor + 4;
+                            event.accepted = true;
+                        } else if ((event.key === Qt.Key_C) && event.modifiers == Qt.ControlModifier) {
+                            codeTextArea.copy();
+                            event.accepted = true;
                         }
                     }
 
-                    TextArea { // Code
-                        id: codeTextArea
-                        Layout.fillWidth: true
-                        readOnly: !editing
-                        selectByMouse: enableMouseSelection || editing
-                        renderType: Text.NativeRendering
-                        font.family: Appearance.font.family.monospace
-                        font.hintingPreference: Font.PreferNoHinting // Prevent weird bold text
-                        font.pixelSize: Appearance.font.pixelSize.small
-                        selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
-                        selectionColor: Appearance.colors.colSecondaryContainer
-                        // wrapMode: TextEdit.Wrap
-                        color: messageData.thinking ? Appearance.colors.colSubtext : Appearance.colors.colOnLayer1
-
-                        text: segmentContent
-                        onTextChanged: {
-                            segmentContent = text
-                        }
-
-                        Keys.onPressed: (event) => {
-                            if (event.key === Qt.Key_Tab) {
-                                // Insert 4 spaces at cursor
-                                const cursor = codeTextArea.cursorPosition;
-                                codeTextArea.insert(cursor, "    ");
-                                codeTextArea.cursorPosition = cursor + 4;
-                                event.accepted = true;
-                            } else if ((event.key === Qt.Key_C) && event.modifiers == Qt.ControlModifier) {
-                                codeTextArea.copy();
-                                event.accepted = true;
-                            }
-                        }
-
-                        SyntaxHighlighter {
-                            id: highlighter
-                            textEdit: codeTextArea
-                            repository: Repository
-                            definition: Repository.definitionForName(root.displayLang || "plaintext")
-                            theme: Appearance.syntaxHighlightingTheme
-                        }
+                    SyntaxHighlighter {
+                        id: highlighter
+                        textEdit: codeTextArea
+                        repository: Repository
+                        definition: Repository.definitionForName(root.displayLang || "plaintext")
+                        theme: Appearance.syntaxHighlightingTheme
                     }
                 }
                 Loader {
@@ -341,17 +357,160 @@ ColumnLayout {
                     }
                 }
             }
+        }
+    }
 
-            // MouseArea to block scrolling
-            // MouseArea {
-            //     id: codeBlockMouseArea
-            //     anchors.fill: parent
-            //     acceptedButtons: editing ? Qt.NoButton : Qt.LeftButton
-            //     cursorShape: (enableMouseSelection || editing) ? Qt.IBeamCursor : Qt.ArrowCursor
-            //     onWheel: (event) => {
-            //         event.accepted = false
-            //     }
-            // }
+    Rectangle { // Output header, styled like the block's own title bar
+        visible: root.commandOutput.length > 0
+        Layout.fillWidth: true
+        radius: Appearance.rounding.unsharpen
+        color: Appearance.colors.colSurfaceContainerHighest
+        implicitHeight: outputHeaderRowLayout.implicitHeight + codeBlockHeaderPadding * 2
+
+        RowLayout {
+            id: outputHeaderRowLayout
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: codeBlockHeaderPadding
+            anchors.rightMargin: codeBlockHeaderPadding
+            spacing: 5
+
+            RowLayout {
+                Layout.alignment: Qt.AlignLeft
+                Layout.topMargin: 7
+                Layout.bottomMargin: 7
+                Layout.leftMargin: 10
+                spacing: 6
+
+                StyledText {
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnLayer2
+                    text: Translation.tr("Output")
+                }
+                HeaderDot {}
+                StyledText {
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colSubtext
+                    // Spelled out per case: the translation extractor only sees literal keys
+                    text: root.outputLineCount === 1
+                        ? Translation.tr("1 line")
+                        : Translation.tr("%1 lines").arg(root.outputLineCount)
+                }
+                HeaderDot {
+                    visible: root.outputTruncated
+                }
+                StyledText {
+                    visible: root.outputTruncated
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colSubtext
+                    text: Translation.tr("truncated")
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            ButtonGroup {
+                AiMessageCopyButton {
+                    copyText: root.outputBody
+                    tooltipText: Translation.tr("Copy output")
+                }
+                AiMessageSaveButton {
+                    saveText: root.outputBody
+                    fileName: "output.log"
+                    notificationTitle: Translation.tr("Output saved to file")
+                }
+            }
+        }
+    }
+
+    RowLayout { // Line numbers and output
+        visible: root.commandOutput.length > 0
+        Layout.fillWidth: true
+        spacing: codeBlockComponentSpacing
+
+        LineNumberColumn {
+            textItem: outputTextEdit
+            contentInset: root.outputBandPadding
+            contentHeight: outputCollapsibleContent.implicitHeight
+            bottomLeftRadius: codeBlockBackgroundRounding
+        }
+
+        Rectangle { // Command output
+            Layout.fillWidth: true
+            topLeftRadius: Appearance.rounding.unsharpen
+            topRightRadius: Appearance.rounding.unsharpen
+            bottomLeftRadius: Appearance.rounding.unsharpen
+            bottomRightRadius: codeBlockBackgroundRounding
+            color: Appearance.colors.colLayer2
+            implicitHeight: outputColumnLayout.implicitHeight + root.outputBandPadding * 2
+
+            ColumnLayout {
+                id: outputColumnLayout
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.topMargin: root.outputBandPadding
+                // Lines up with the command above, which shares this column
+                anchors.leftMargin: codeTextArea.leftPadding
+                anchors.rightMargin: codeTextArea.rightPadding
+                spacing: 4
+
+                CollapsibleContent {
+                    id: outputCollapsibleContent
+                    // A failure arrives expanded mid-generation, wrap still settling; only the
+                    // toggle is worth animating
+                    animated: root.messageData?.done ?? true
+                    collapsed: !root.outputExpanded
+                    contentHeight: outputTextEdit.implicitHeight
+                    collapsedHeight: Math.min(contentHeight, root.outputPeekHeight)
+
+                    TextEdit {
+                        id: outputTextEdit
+                        anchors.top: parent.top
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        readOnly: true
+                        selectByMouse: root.enableMouseSelection || root.editing
+                        renderType: Text.NativeRendering
+                        font.family: Appearance.font.family.monospace
+                        font.hintingPreference: Font.PreferNoHinting
+                        font.pixelSize: Appearance.font.pixelSize.small
+                        color: Appearance.colors.colOnLayer1
+                        selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
+                        selectionColor: Appearance.colors.colSecondaryContainer
+                        wrapMode: TextEdit.Wrap
+                        text: root.outputBody
+                    }
+                }
+
+                GroupButton {
+                    visible: root.outputClipped
+                    // Outside a ButtonGroup this defaults to filling the whole band
+                    Layout.fillWidth: false
+                    Layout.alignment: Qt.AlignLeft
+                    buttonRadius: Appearance.rounding.full
+                    // The default hover (colLayer1Hover) is invisible on the band's colLayer2
+                    colBackgroundHover: Appearance.colors.colLayer2Hover
+                    colBackgroundActive: Appearance.colors.colLayer2Active
+                    contentItem: StyledText {
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: Appearance.font.pixelSize.small
+                        font.weight: Font.DemiBold
+                        color: Appearance.colors.colOnLayer1
+                        // Spelled out per case: the translation extractor only sees literal keys.
+                        // What is cut can be the tail of a line, which has no honest count
+                        text: root.outputExpanded ? Translation.tr("Show less")
+                            : root.hiddenOutputLines === 0 ? Translation.tr("Show more")
+                            : root.hiddenOutputLines === 1 ? Translation.tr("+1 more line")
+                            : Translation.tr("+%1 more lines").arg(root.hiddenOutputLines)
+                    }
+                    onClicked: root.outputExpanded = !root.outputExpanded
+                }
+            }
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -19,7 +19,7 @@ ColumnLayout {
     property var segmentContent: ({})
     property var segmentLang: "txt"
     property var messageData: {}
-    property bool isLatestCommand: true
+    property bool isPendingCommand: false
     property bool isCommandRequest: segmentLang === "command"
     property var displayLang: (isCommandRequest ? "bash" : segmentLang)
 
@@ -250,7 +250,7 @@ ColumnLayout {
                     }
                 }
                 Loader {
-                    active: root.isCommandRequest && root.isLatestCommand && root.messageData.functionPending
+                    active: root.isCommandRequest && root.isPendingCommand && root.messageData.functionPending
                     visible: active
                     Layout.fillWidth: true
                     Layout.margins: 6

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -20,8 +20,13 @@ ColumnLayout {
     property var segmentLang: "txt"
     property var messageData: {}
     property bool isPendingCommand: false
-    property bool isCommandRequest: segmentLang === "command"
-    property var displayLang: (isCommandRequest ? "bash" : segmentLang)
+    // Command fences carry the tool name in the info string: command:Read, command:Bash...
+    property bool isCommandRequest: (segmentLang ?? "").split(":")[0] === "command"
+    property string commandToolName: isCommandRequest ? ((segmentLang ?? "").split(":")[1] || "Bash") : ""
+    // Bash runs shell commands; every other tool takes JSON input
+    property var displayLang: isCommandRequest
+        ? (commandToolName === "Bash" ? "bash" : "json")
+        : segmentLang
 
     property real codeBlockBackgroundRounding: Appearance.rounding.small
     property real codeBlockHeaderPadding: 3
@@ -57,7 +62,9 @@ ColumnLayout {
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 color: Appearance.colors.colOnLayer2
-                text: root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain"
+                text: root.isCommandRequest
+                    ? root.commandToolName
+                    : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
             }
 
             Item { Layout.fillWidth: true }
@@ -91,12 +98,12 @@ ColumnLayout {
 
                     onClicked: {
                         const downloadPath = FileUtils.trimFileProtocol(Directories.downloads)
-                        Quickshell.execDetached(["bash", "-c", 
-                            `echo '${StringUtils.shellSingleQuoteEscape(segmentContent)}' > '${downloadPath}/code.${segmentLang || "txt"}'`
+                        Quickshell.execDetached(["bash", "-c",
+                            `echo '${StringUtils.shellSingleQuoteEscape(segmentContent)}' > '${downloadPath}/code.${root.displayLang || "txt"}'`
                         ])
-                        Quickshell.execDetached(["notify-send", 
-                            Translation.tr("Code saved to file"), 
-                            Translation.tr("Saved to %1").arg(`${downloadPath}/code.${segmentLang || "txt"}`),
+                        Quickshell.execDetached(["notify-send",
+                            Translation.tr("Code saved to file"),
+                            Translation.tr("Saved to %1").arg(`${downloadPath}/code.${root.displayLang || "txt"}`),
                             "-a", "Shell"
                         ])
                         saveCodeButton.activated = true

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -30,20 +30,31 @@ ColumnLayout {
     property string commandToolName: isCommandRequest
         ? (commandFlags.find(s => !StringUtils.commandFenceStates.includes(s)) ?? "Bash")
         : ""
-    // An un-approved request keeps its :pending token for good, so being live is checked against
-    // the message. It reads as denied because either way the command never ran
-    readonly property string state: (commandState === "pending"
-            && !(isPendingCommand && (messageData?.functionPending ?? false)))
-        ? "denied" : commandState
-    // Spelled out because the translation extractor only sees literal keys
+    // Unfinished states keep their token for good, so being live is checked against the message
+    // rather than read off the fence. What is left over reads as denied: the command never ran
+    readonly property string state: {
+        if (commandState === "streaming") {
+            return (messageData?.done ?? true) ? "denied" : "streaming";
+        }
+        if (commandState === "pending"
+                && !(isPendingCommand && (messageData?.functionPending ?? false))) {
+            return "denied";
+        }
+        return commandState;
+    }
+    // Spelled out because the translation extractor only sees literal keys. Streaming shows
+    // nothing: there is no state to report yet, and the message has its own loading indicator
     readonly property var commandStateLabels: ({
+        "streaming": "",
         "pending": Translation.tr("pending"),
         "running": Translation.tr("running"),
         "done": Translation.tr("done"),
         "failed": Translation.tr("failed"),
-        "denied": Translation.tr("denied"),
+        // Labelled for the Reject button that produces it, as the rest of the copy already is
+        "denied": Translation.tr("rejected"),
         "answered": Translation.tr("answered"),
     })
+    readonly property string stateLabel: commandStateLabels[state] ?? state
     // Bash runs shell commands; every other tool takes JSON input
     property var displayLang: isCommandRequest
         ? (commandToolName === "Bash" ? "bash" : "json")
@@ -90,20 +101,20 @@ ColumnLayout {
                         : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
                 }
                 Rectangle {
-                    visible: root.state.length > 0
+                    visible: root.stateLabel.length > 0
                     implicitWidth: 4
                     implicitHeight: 4
                     radius: implicitWidth / 2
                     color: Appearance.colors.colOnLayer1Inactive
                 }
                 StyledText {
-                    visible: root.state.length > 0
+                    visible: root.stateLabel.length > 0
                     font.pixelSize: Appearance.font.pixelSize.small
                     font.weight: Font.DemiBold
                     color: ["denied", "failed"].includes(root.state)
                         ? Appearance.colors.colTertiary
                         : Appearance.colors.colSubtext
-                    text: root.commandStateLabels[root.state] ?? root.state
+                    text: root.stateLabel
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -20,10 +20,16 @@ ColumnLayout {
     property var segmentLang: "txt"
     property var messageData: {}
     property bool isPendingCommand: false
-    // Command fences carry the tool name in the info string: command:Read, command:Bash...
+    // Command fences carry tool name then state: command:Bash:running, command:Read:done...
+    // Either segment can be absent on fences written outside the CLI path
+    property var commandFlags: (segmentLang ?? "").split(":").slice(1).filter(s => s.length > 0)
     property bool isCommandRequest: (segmentLang ?? "").split(":")[0] === "command"
-    property string commandToolName: isCommandRequest ? ((segmentLang ?? "").split(":")[1] || "Bash") : ""
-    property bool commandDenied: isCommandRequest && (segmentLang ?? "").split(":").includes("denied")
+    property string commandState: isCommandRequest
+        ? (commandFlags.filter(s => StringUtils.commandFenceStates.includes(s)).pop() ?? "")
+        : ""
+    property string commandToolName: isCommandRequest
+        ? (commandFlags.find(s => !StringUtils.commandFenceStates.includes(s)) ?? "Bash")
+        : ""
     // Bash runs shell commands; every other tool takes JSON input
     property var displayLang: isCommandRequest
         ? (commandToolName === "Bash" ? "bash" : "json")
@@ -70,18 +76,20 @@ ColumnLayout {
                         : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
                 }
                 Rectangle {
-                    visible: root.commandDenied
+                    visible: root.commandState.length > 0
                     implicitWidth: 4
                     implicitHeight: 4
                     radius: implicitWidth / 2
                     color: Appearance.colors.colOnLayer1Inactive
                 }
                 StyledText {
-                    visible: root.commandDenied
+                    visible: root.commandState.length > 0
                     font.pixelSize: Appearance.font.pixelSize.small
                     font.weight: Font.DemiBold
-                    color: Appearance.colors.colError
-                    text: Translation.tr("denied")
+                    color: ["denied", "failed"].includes(root.commandState)
+                        ? Appearance.colors.colTertiary
+                        : Appearance.colors.colSubtext
+                    text: Translation.tr(root.commandState)
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -30,8 +30,12 @@ ColumnLayout {
     property string commandToolName: isCommandRequest
         ? (commandFlags.find(s => !StringUtils.commandFenceStates.includes(s)) ?? "Bash")
         : ""
-    // Spelled out rather than tr(commandState): the extractor only sees literal strings, so a
-    // dynamic key leaves every state untranslatable
+    // An un-approved request keeps its :pending token for good, so being live is checked against
+    // the message. It reads as denied because either way the command never ran
+    readonly property string state: (commandState === "pending"
+            && !(isPendingCommand && (messageData?.functionPending ?? false)))
+        ? "denied" : commandState
+    // Spelled out because the translation extractor only sees literal keys
     readonly property var commandStateLabels: ({
         "pending": Translation.tr("pending"),
         "running": Translation.tr("running"),
@@ -86,20 +90,20 @@ ColumnLayout {
                         : (root.displayLang ? Repository.definitionForName(root.displayLang).name : "plain")
                 }
                 Rectangle {
-                    visible: root.commandState.length > 0
+                    visible: root.state.length > 0
                     implicitWidth: 4
                     implicitHeight: 4
                     radius: implicitWidth / 2
                     color: Appearance.colors.colOnLayer1Inactive
                 }
                 StyledText {
-                    visible: root.commandState.length > 0
+                    visible: root.state.length > 0
                     font.pixelSize: Appearance.font.pixelSize.small
                     font.weight: Font.DemiBold
-                    color: ["denied", "failed"].includes(root.commandState)
+                    color: ["denied", "failed"].includes(root.state)
                         ? Appearance.colors.colTertiary
                         : Appearance.colors.colSubtext
-                    text: root.commandStateLabels[root.commandState] ?? root.commandState
+                    text: root.commandStateLabels[root.state] ?? root.state
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -30,6 +30,16 @@ ColumnLayout {
     property string commandToolName: isCommandRequest
         ? (commandFlags.find(s => !StringUtils.commandFenceStates.includes(s)) ?? "Bash")
         : ""
+    // Spelled out rather than tr(commandState): the extractor only sees literal strings, so a
+    // dynamic key leaves every state untranslatable
+    readonly property var commandStateLabels: ({
+        "pending": Translation.tr("pending"),
+        "running": Translation.tr("running"),
+        "done": Translation.tr("done"),
+        "failed": Translation.tr("failed"),
+        "denied": Translation.tr("denied"),
+        "answered": Translation.tr("answered"),
+    })
     // Bash runs shell commands; every other tool takes JSON input
     property var displayLang: isCommandRequest
         ? (commandToolName === "Bash" ? "bash" : "json")
@@ -89,7 +99,7 @@ ColumnLayout {
                     color: ["denied", "failed"].includes(root.commandState)
                         ? Appearance.colors.colTertiary
                         : Appearance.colors.colSubtext
-                    text: Translation.tr(root.commandState)
+                    text: root.commandStateLabels[root.commandState] ?? root.commandState
                 }
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -325,20 +325,10 @@ ColumnLayout {
                                     text: freeTextInput.placeholder
                                 }
 
-                                MouseArea { // Owns the drag so the list view can't steal it and
-                                    // scroll mid-selection; drives cursor/selection itself
+                                MouseArea { // Hover only; presses belong to the TextInput
                                     anchors.fill: parent
-                                    enabled: root.interactive
-                                    cursorShape: Qt.IBeamCursor
-                                    preventStealing: true
-                                    onPressed: mouse => {
-                                        freeTextInput.forceActiveFocus();
-                                        freeTextInput.cursorPosition = freeTextInput.positionAt(mouse.x, mouse.y);
-                                    }
-                                    onPositionChanged: mouse => {
-                                        freeTextInput.moveCursorSelection(freeTextInput.positionAt(mouse.x, mouse.y));
-                                    }
-                                    onDoubleClicked: freeTextInput.selectWord()
+                                    acceptedButtons: Qt.NoButton
+                                    cursorShape: root.interactive ? Qt.IBeamCursor : Qt.ArrowCursor
                                 }
 
                                 // The one custom entry this pill has contributed; edits replace it

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -38,8 +38,11 @@ ColumnLayout {
     property var questions: parsed?.questions ?? []
     property bool interactive: isPendingCommand && (messageData?.functionPending ?? false) && !submitted && !dismissed
     // While the tool input is still streaming (before the permission handshake), the
-    // controls render disabled so the box has its final geometry from the start
-    property bool streamingPreview: !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
+    // controls render disabled so the box has its final geometry from the start. Only the
+    // fence still streaming qualifies: a question the model abandoned keeps its :pending state
+    // for good, and must not keep offering controls just because the message runs on
+    property bool streamingPreview: (segmentLang ?? "").split(":").includes("running")
+        && !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
     // Picks live in the service until Submit writes them into the fence body
     function chosenLabels(question) {
         if (root.interactive) return Ai.questionSelections[question] ?? [];
@@ -70,6 +73,7 @@ ColumnLayout {
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
             iconSize: Appearance.font.pixelSize.normal
+            // Only ever visible on a selected pill
             color: Appearance.colors.colOnPrimary
             text: "check"
             opacity: slot.checked ? 1 : 0
@@ -196,8 +200,6 @@ ColumnLayout {
                                 horizontalPadding: 8
                                 verticalPadding: 6
                                 toggled: root.chosenLabels(questionSection.question).includes(label)
-                                // colBackground carries the toggled fill so the chosen pill
-                                // stays highlighted in the submitted (disabled) transcript
                                 colBackground: toggled ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
                                 colBackgroundHover: Appearance.colors.colSecondaryContainerHover
                                 colBackgroundActive: Appearance.colors.colSecondaryContainerActive
@@ -210,7 +212,8 @@ ColumnLayout {
                                     StyledText {
                                         font.pixelSize: Appearance.font.pixelSize.small
                                         horizontalAlignment: Text.AlignHCenter
-                                        color: optionPill.toggled ? Appearance.colors.colOnPrimary : Appearance.m3colors.m3onSurface
+                                        color: optionPill.toggled ? Appearance.colors.colOnPrimary
+                                            : Appearance.colors.colOnSecondaryContainer
                                         text: optionPill.label
                                     }
                                 }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -237,8 +237,20 @@ ColumnLayout {
                         }
 
                         Flow {
+                            id: optionsFlow
                             Layout.fillWidth: true
                             spacing: 5
+
+                            // The box's own height animates as the flow reflows, so pills that
+                            // change row travel with it instead of teleporting
+                            move: Transition {
+                                NumberAnimation {
+                                    properties: "x,y"
+                                    duration: Appearance.animation.elementMoveFast.duration
+                                    easing.type: Appearance.animation.elementMoveFast.type
+                                    easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                }
+                            }
 
                             Repeater {
                                 model: ScriptModel {
@@ -334,10 +346,20 @@ ColumnLayout {
                                 border.width: freeTextInput.activeFocus && !committed ? 1 : 0
                                 border.color: Appearance.colors.colPrimary
                                 implicitHeight: freeTextInput.implicitHeight + 6 * 2
-                                // Empty keeps room for the placeholder; typed text sizes the pill exactly
+                                // Empty keeps room for the placeholder; typed text sizes the pill
+                                // exactly, up to the row width, past which the text wraps instead.
+                                // Width comes off unwrapped metrics rather than the input's own
+                                // content size, which would depend right back on this width
                                 implicitWidth: freeTextInput.text.length > 0
-                                    ? freeTextInput.contentWidth + root.pillTextInset * 2 + freeCheckSlot.width
+                                    ? Math.min(Math.ceil(freeTextMetrics.advanceWidth) + root.pillTextInset * 2 + freeCheckSlot.width,
+                                        optionsFlow.width)
                                     : 120
+
+                                TextMetrics {
+                                    id: freeTextMetrics
+                                    font: freeTextInput.font
+                                    text: freeTextInput.text
+                                }
 
                                 CheckSlot {
                                     id: freeCheckSlot
@@ -347,16 +369,18 @@ ColumnLayout {
                                     anchors.verticalCenter: parent.verticalCenter
                                 }
 
-                                TextInput {
+                                TextEdit {
                                     id: freeTextInput
                                     enabled: root.interactive
                                     // Interactive typing replaces this binding; for a loaded
                                     // transcript it fills in the submitted custom answer
                                     text: freeTextPill.historyFreeText
-                                    anchors.fill: parent
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
                                     anchors.leftMargin: root.pillTextInset + freeCheckSlot.width
                                     anchors.rightMargin: root.pillTextInset
-                                    verticalAlignment: TextInput.AlignVCenter
+                                    wrapMode: TextEdit.Wrap
                                     clip: true
                                     font.family: Appearance.font.family.main
                                     font.pixelSize: Appearance.font.pixelSize.small
@@ -428,8 +452,15 @@ ColumnLayout {
                                         }
                                     }
 
-                                    // Blur commits, so Enter just drops focus
-                                    onAccepted: root.forceActiveFocus()
+                                    // Blur commits, so Enter just drops focus. Shift+Enter is left
+                                    // to the editor for a deliberate newline
+                                    Keys.onPressed: event => {
+                                        if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
+                                                && !(event.modifiers & Qt.ShiftModifier)) {
+                                            root.forceActiveFocus();
+                                            event.accepted = true;
+                                        }
+                                    }
                                 }
                             }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -404,7 +404,7 @@ ColumnLayout {
                             font.pixelSize: Appearance.font.pixelSize.small
                             color: Appearance.colors.colOnLayer2
                         }
-                        onClicked: Ai.dismissQuestions(root.messageData)
+                        onClicked: Ai.rejectCommand(root.messageData)
                     }
                     GroupButton {
                         enabled: root.interactive

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -83,13 +83,6 @@ ColumnLayout {
         }
     }
 
-    StyledText { // Input still streaming, no question parsed yet
-        visible: root.questions.length === 0
-        font.pixelSize: Appearance.font.pixelSize.small
-        color: Appearance.colors.colSubtext
-        text: Translation.tr("Preparing question...")
-    }
-
     Rectangle { // Title bar, mirrors the command block header
         visible: root.questions.length > 0
         Layout.fillWidth: true

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -26,60 +26,20 @@ ColumnLayout {
 
     property bool submitted: (segmentLang ?? "").split(":").includes("answered")
     property bool dismissed: (segmentLang ?? "").split(":").includes("denied")
-    // Parsed tolerantly while the tool input streams, so the box renders progressively;
-    // the last good parse is kept when a prefix is momentarily unparseable
-    property var parsed: null
+    // The strategy re-closes the still-streaming tool input before writing it, so the body is
+    // always valid JSON and the box renders progressively off a plain parse
+    property var parsed: {
+        try {
+            return JSON.parse(String(root.segmentContent ?? ""));
+        } catch (e) {
+            return null;
+        }
+    }
     property var questions: parsed?.questions ?? []
     property bool interactive: isPendingCommand && (messageData?.functionPending ?? false) && !submitted && !dismissed
     // While the tool input is still streaming (before the permission handshake), the
     // controls render disabled so the box has its final geometry from the start
     property bool streamingPreview: !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
-    onSegmentContentChanged: reparse()
-    Component.onCompleted: reparse()
-
-    function reparse() {
-        const result = parsePartialJson(String(segmentContent ?? ""));
-        if (result !== null) parsed = result;
-    }
-
-    // Closes open strings and brackets of truncated JSON; null means cut mid-escape
-    function closeJson(s) {
-        let stack = [];
-        let inStr = false;
-        for (let i = 0; i < s.length; i++) {
-            const c = s[i];
-            if (inStr) {
-                if (c === '\\') {
-                    if (i + 1 >= s.length) return null;
-                    i++;
-                    continue;
-                }
-                if (c === '"') inStr = false;
-                continue;
-            }
-            if (c === '"') inStr = true;
-            else if (c === '{' || c === '[') stack.push(c);
-            else if (c === '}' || c === ']') stack.pop();
-        }
-        let out = s;
-        if (inStr) out += '"';
-        out = out.replace(/,\s*$/, "");
-        for (let i = stack.length - 1; i >= 0; i--) {
-            out += stack[i] === '{' ? '}' : ']';
-        }
-        return out;
-    }
-
-    // Chops back past dangling keys/colons/partial literals until a close succeeds
-    function parsePartialJson(s) {
-        for (let end = s.length; end > 0 && end > s.length - 64; end--) {
-            const closed = closeJson(s.slice(0, end));
-            if (closed === null) continue;
-            try { return JSON.parse(closed); } catch (e) {}
-        }
-        return null;
-    }
-
     function chosenLabels(question) {
         if (root.interactive) return Ai.questionSelections[question] ?? [];
         const answer = root.parsed?.answers?.[question];
@@ -119,15 +79,15 @@ ColumnLayout {
         }
     }
 
-    StyledText { // Input still streaming, nothing parseable yet
-        visible: root.parsed === null
+    StyledText { // Input still streaming, no question parsed yet
+        visible: root.questions.length === 0
         font.pixelSize: Appearance.font.pixelSize.small
         color: Appearance.colors.colSubtext
         text: Translation.tr("Preparing question...")
     }
 
     Rectangle { // Title bar, mirrors the command block header
-        visible: root.parsed !== null
+        visible: root.questions.length > 0
         Layout.fillWidth: true
         topLeftRadius: Appearance.rounding.small
         topRightRadius: Appearance.rounding.small
@@ -171,7 +131,7 @@ ColumnLayout {
     }
 
     Rectangle { // Questions, option pills, and the Submit/Dismiss pair
-        visible: root.parsed !== null
+        visible: root.questions.length > 0
         Layout.fillWidth: true
         topLeftRadius: Appearance.rounding.unsharpen
         topRightRadius: Appearance.rounding.unsharpen

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -1,0 +1,439 @@
+pragma ComponentBehavior: Bound
+
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+
+/**
+ * Renders an AskUserQuestion command fence as one box for the whole question set:
+ * a command-block style title bar, then per question its text, option pills and
+ * a free-text pill, and a Submit/Dismiss pair modeled after command
+ * approval. Submit sends one permission response; questions with no selection
+ * are skipped. Dismiss denies the request. The fence body is the tool's JSON
+ * input; once submitted it is rewritten to {questions, answers} with an
+ * :answered flag and renders statically.
+ */
+ColumnLayout {
+    id: root
+    property var segmentContent: ({})
+    property var segmentLang: ""
+    property var messageData: {}
+    property bool isPendingCommand: false
+
+    property bool submitted: (segmentLang ?? "").split(":").includes("answered")
+    property bool dismissed: (segmentLang ?? "").split(":").includes("denied")
+    // Parsed tolerantly while the tool input streams, so the box renders progressively;
+    // the last good parse is kept when a prefix is momentarily unparseable
+    property var parsed: null
+    property var questions: parsed?.questions ?? []
+    property bool interactive: isPendingCommand && (messageData?.functionPending ?? false) && !submitted && !dismissed
+    // While the tool input is still streaming (before the permission handshake), the
+    // controls render disabled so the box has its final geometry from the start
+    property bool streamingPreview: !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
+    onSegmentContentChanged: reparse()
+    Component.onCompleted: reparse()
+
+    function reparse() {
+        const result = parsePartialJson(String(segmentContent ?? ""));
+        if (result !== null) parsed = result;
+    }
+
+    // Closes open strings and brackets of truncated JSON; null means cut mid-escape
+    function closeJson(s) {
+        let stack = [];
+        let inStr = false;
+        for (let i = 0; i < s.length; i++) {
+            const c = s[i];
+            if (inStr) {
+                if (c === '\\') {
+                    if (i + 1 >= s.length) return null;
+                    i++;
+                    continue;
+                }
+                if (c === '"') inStr = false;
+                continue;
+            }
+            if (c === '"') inStr = true;
+            else if (c === '{' || c === '[') stack.push(c);
+            else if (c === '}' || c === ']') stack.pop();
+        }
+        let out = s;
+        if (inStr) out += '"';
+        out = out.replace(/,\s*$/, "");
+        for (let i = stack.length - 1; i >= 0; i--) {
+            out += stack[i] === '{' ? '}' : ']';
+        }
+        return out;
+    }
+
+    // Chops back past dangling keys/colons/partial literals until a close succeeds
+    function parsePartialJson(s) {
+        for (let end = s.length; end > 0 && end > s.length - 64; end--) {
+            const closed = closeJson(s.slice(0, end));
+            if (closed === null) continue;
+            try { return JSON.parse(closed); } catch (e) {}
+        }
+        return null;
+    }
+
+    function chosenLabels(question) {
+        if (root.interactive) return Ai.questionSelections[question] ?? [];
+        const answer = root.parsed?.answers?.[question];
+        return typeof answer === "string" ? answer.split(", ") : [];
+    }
+
+    // Committed answer parts that match no option label (free-text answers)
+    function freeTextOf(question, options) {
+        const labels = (options ?? []).map(opt => opt.label);
+        return chosenLabels(question).filter(part => !labels.includes(part)).join(", ");
+    }
+
+    spacing: 2
+
+    // Animated slot for the multiSelect checkmark: its width changes continuously,
+    // so the pill and text stay in step instead of the icon popping in a single frame
+    component CheckSlot: Item {
+        id: slot
+        required property bool checked
+        implicitHeight: checkIcon.implicitHeight
+        implicitWidth: checked ? checkIcon.implicitWidth + 4 : 0
+        clip: true
+        Behavior on implicitWidth {
+            animation: Appearance.animation.clickBounce.numberAnimation.createObject(this)
+        }
+        MaterialSymbol {
+            id: checkIcon
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            iconSize: Appearance.font.pixelSize.normal
+            color: Appearance.colors.colOnPrimary
+            text: "check"
+            opacity: slot.checked ? 1 : 0
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+        }
+    }
+
+    StyledText { // Input still streaming, nothing parseable yet
+        visible: root.parsed === null
+        font.pixelSize: Appearance.font.pixelSize.small
+        color: Appearance.colors.colSubtext
+        text: Translation.tr("Preparing question...")
+    }
+
+    Rectangle { // Title bar, mirrors the command block header
+        visible: root.parsed !== null
+        Layout.fillWidth: true
+        topLeftRadius: Appearance.rounding.small
+        topRightRadius: Appearance.rounding.small
+        bottomLeftRadius: Appearance.rounding.unsharpen
+        bottomRightRadius: Appearance.rounding.unsharpen
+        color: Appearance.colors.colSurfaceContainerHighest
+        implicitHeight: titleRowLayout.implicitHeight + 10 * 2
+
+        RowLayout {
+            id: titleRowLayout
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 13
+            spacing: 6
+
+            MaterialSymbol {
+                color: Appearance.colors.colOnLayer2
+                text: "question_exchange"
+            }
+            StyledText {
+                font.pixelSize: Appearance.font.pixelSize.small
+                font.weight: Font.DemiBold
+                color: Appearance.colors.colOnLayer2
+                text: root.questions.length > 1 ? Translation.tr("Questions") : Translation.tr("Question")
+            }
+            Rectangle {
+                visible: root.dismissed
+                implicitWidth: 4
+                implicitHeight: 4
+                radius: implicitWidth / 2
+                color: Appearance.colors.colOnLayer1Inactive
+            }
+            StyledText {
+                visible: root.dismissed
+                font.pixelSize: Appearance.font.pixelSize.small
+                font.weight: Font.DemiBold
+                color: Appearance.colors.colError
+                text: Translation.tr("dismissed")
+            }
+        }
+    }
+
+    Rectangle { // Questions, option pills, and the Submit/Dismiss pair
+        visible: root.parsed !== null
+        Layout.fillWidth: true
+        topLeftRadius: Appearance.rounding.unsharpen
+        topRightRadius: Appearance.rounding.unsharpen
+        bottomLeftRadius: Appearance.rounding.small
+        bottomRightRadius: Appearance.rounding.small
+        color: Appearance.colors.colLayer2
+        implicitHeight: questionContentColumn.implicitHeight + 10 * 2
+
+        MouseArea { // Click on box dead space to unfocus the text pill
+            anchors.fill: parent
+            onPressed: root.forceActiveFocus()
+        }
+
+        ColumnLayout {
+            id: questionContentColumn
+            anchors {
+                fill: parent
+                margins: 10
+            }
+            spacing: 8
+
+            Repeater {
+                model: ScriptModel {
+                    values: root.questions
+                }
+                delegate: ColumnLayout { // One section per question
+                    id: questionSection
+                    required property var modelData
+                    required property int index
+                    property string question: modelData.question ?? ""
+                    property bool multiSelect: modelData.multiSelect ?? false
+
+                    Layout.fillWidth: true
+                    Layout.topMargin: index > 0 ? 6 : 0
+                    spacing: 8
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        color: Appearance.colors.colOnLayer1
+                        text: questionSection.question
+                    }
+
+                    Flow {
+                        Layout.fillWidth: true
+                        spacing: 5
+
+                        Repeater {
+                            model: ScriptModel {
+                                values: questionSection.modelData.options ?? []
+                            }
+                            delegate: GroupButton { // Styled like the command suggestion pills
+                                id: optionPill
+                                required property var modelData
+                                property string label: modelData.label ?? ""
+                                enabled: root.interactive
+                                bounce: false
+                                // The checkmark slot animates its own width; the pill follows it
+                                // rigidly so the size change is animated exactly once
+                                enableImplicitWidthAnimation: false
+                                buttonRadius: optionPill.down ? Appearance.rounding.verysmall : Appearance.rounding.small
+                                horizontalPadding: 8
+                                verticalPadding: 6
+                                toggled: root.chosenLabels(questionSection.question).includes(label)
+                                // colBackground carries the toggled fill so the chosen pill
+                                // stays highlighted in the submitted (disabled) transcript
+                                colBackground: toggled ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
+                                colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+                                colBackgroundActive: Appearance.colors.colSecondaryContainerActive
+                                contentItem: RowLayout {
+                                    spacing: 0
+                                    CheckSlot {
+                                        checked: questionSection.multiSelect && optionPill.toggled
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+                                    StyledText {
+                                        font.pixelSize: Appearance.font.pixelSize.small
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: optionPill.toggled ? Appearance.colors.colOnPrimary : Appearance.m3colors.m3onSurface
+                                        text: optionPill.label
+                                    }
+                                }
+                                onClicked: {
+                                    if (questionSection.multiSelect) {
+                                        Ai.toggleQuestionOption(questionSection.question, optionPill.label);
+                                    } else {
+                                        Ai.setQuestionSelection(questionSection.question,
+                                            optionPill.toggled ? [] : [optionPill.label]);
+                                    }
+                                }
+                                StyledToolTip {
+                                    text: optionPill.modelData.description ?? ""
+                                }
+                            }
+                        }
+
+                        Rectangle { // Free-text pill, expands with its content
+                            id: freeTextPill
+                            // Renders selected exactly like an option pill: lit when its
+                            // text is among the question's current picks
+                            property bool committed: freeTextInput.text.trim().length > 0
+                                && root.chosenLabels(questionSection.question).includes(freeTextInput.text.trim())
+                            // In the submitted transcript the pill stays, showing the custom answer
+                            property string historyFreeText: root.interactive || root.streamingPreview
+                                ? "" : root.freeTextOf(questionSection.question, questionSection.modelData.options ?? [])
+                            visible: root.interactive || root.streamingPreview || historyFreeText.length > 0
+                            radius: Appearance.rounding.small
+                            color: committed ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
+                            border.width: freeTextInput.activeFocus && !committed ? 1 : 0
+                            border.color: Appearance.colors.colPrimary
+                            implicitHeight: freeTextInput.implicitHeight + 6 * 2
+                            // Empty keeps room for the placeholder; typed text sizes the pill exactly
+                            implicitWidth: freeTextInput.text.length > 0
+                                ? freeTextInput.contentWidth + 8 * 2 + freeCheckSlot.width
+                                : 120
+
+                            CheckSlot {
+                                id: freeCheckSlot
+                                checked: questionSection.multiSelect && freeTextPill.committed
+                                anchors.left: parent.left
+                                anchors.leftMargin: 8
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            TextInput {
+                                id: freeTextInput
+                                enabled: root.interactive
+                                // Interactive typing replaces this binding; for a loaded
+                                // transcript it fills in the submitted custom answer
+                                text: freeTextPill.historyFreeText
+                                anchors.fill: parent
+                                anchors.leftMargin: 8 + freeCheckSlot.width
+                                anchors.rightMargin: 8
+                                verticalAlignment: TextInput.AlignVCenter
+                                clip: true
+                                font.family: Appearance.font.family.main
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                color: freeTextPill.committed ? Appearance.colors.colOnPrimary : Appearance.m3colors.m3onSurface
+                                selectByMouse: true
+                                // Editing only happens uncommitted (focus un-commits), so the
+                                // background is always colSecondaryContainer; primary stands out
+                                selectedTextColor: Appearance.colors.colOnPrimary
+                                selectionColor: Appearance.colors.colPrimary
+
+                                property string placeholder: Translation.tr("Other...")
+                                Text {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    visible: freeTextInput.text.length === 0 && !freeTextInput.activeFocus
+                                    font: freeTextInput.font
+                                    color: Appearance.colors.colSubtext
+                                    text: freeTextInput.placeholder
+                                }
+
+                                MouseArea { // Owns the drag so the list view can't steal it and
+                                    // scroll mid-selection; drives cursor/selection itself
+                                    anchors.fill: parent
+                                    enabled: root.interactive
+                                    cursorShape: Qt.IBeamCursor
+                                    preventStealing: true
+                                    onPressed: mouse => {
+                                        freeTextInput.forceActiveFocus();
+                                        freeTextInput.cursorPosition = freeTextInput.positionAt(mouse.x, mouse.y);
+                                    }
+                                    onPositionChanged: mouse => {
+                                        freeTextInput.moveCursorSelection(freeTextInput.positionAt(mouse.x, mouse.y));
+                                    }
+                                    onDoubleClicked: freeTextInput.selectWord()
+                                }
+
+                                // The one custom entry this pill has contributed; edits replace it
+                                property string committedText: ""
+
+                                // Single-select: text becomes the answer. multiSelect: text joins
+                                // the picks like a toggled chip
+                                function commitFreeText() {
+                                    const answer = text.trim();
+                                    if (questionSection.multiSelect) {
+                                        if (committedText.length > 0 && committedText !== answer
+                                                && root.chosenLabels(questionSection.question).includes(committedText)) {
+                                            Ai.toggleQuestionOption(questionSection.question, committedText);
+                                        }
+                                        if (answer.length > 0
+                                                && !root.chosenLabels(questionSection.question).includes(answer)) {
+                                            Ai.toggleQuestionOption(questionSection.question, answer);
+                                        }
+                                        committedText = answer;
+                                    } else if (answer.length > 0) {
+                                        // Don't clobber an option picked while this field kept focus
+                                        const current = root.chosenLabels(questionSection.question);
+                                        if (current.length === 0 || current.includes(committedText)) {
+                                            Ai.setQuestionSelection(questionSection.question, [answer]);
+                                            committedText = answer;
+                                        }
+                                    }
+                                }
+
+                                // Focus un-commits this pill's entry (single-select: the whole
+                                // selection) so it drops back to the typing look; leaving
+                                // with text commits — Enter also commits, but isn't required
+                                onActiveFocusChanged: {
+                                    if (!root.interactive) return;
+                                    if (activeFocus) {
+                                        if (questionSection.multiSelect) {
+                                            if (committedText.length > 0
+                                                    && root.chosenLabels(questionSection.question).includes(committedText)) {
+                                                Ai.toggleQuestionOption(questionSection.question, committedText);
+                                            }
+                                        } else {
+                                            Ai.setQuestionSelection(questionSection.question, []);
+                                        }
+                                    } else {
+                                        commitFreeText();
+                                    }
+                                }
+
+                                // Blur commits, so Enter just drops focus
+                                onAccepted: root.forceActiveFocus()
+                            }
+                        }
+
+                    }
+                }
+            }
+
+            RowLayout { // Submit/Dismiss pair, mirrors command approval
+                visible: root.interactive || root.streamingPreview
+                Layout.fillWidth: true
+                Layout.topMargin: 2
+
+                Item { Layout.fillWidth: true }
+                ButtonGroup {
+                    GroupButton {
+                        enabled: root.interactive
+                        // The default hover (colLayer1Hover) is invisible on this
+                        // box's colLayer2 background
+                        colBackgroundHover: Appearance.colors.colLayer2Hover
+                        colBackgroundActive: Appearance.colors.colLayer2Active
+                        contentItem: StyledText {
+                            text: Translation.tr("Dismiss")
+                            font.pixelSize: Appearance.font.pixelSize.small
+                            color: Appearance.colors.colOnLayer2
+                        }
+                        onClicked: Ai.dismissQuestions(root.messageData)
+                    }
+                    GroupButton {
+                        enabled: root.interactive
+                        toggled: true
+                        // colBackground carries the fill so it survives the disabled state
+                        colBackground: Appearance.colors.colPrimary
+                        contentItem: StyledText {
+                            text: Translation.tr("Submit")
+                            font.pixelSize: Appearance.font.pixelSize.small
+                            color: Appearance.colors.colOnPrimary
+                        }
+                        onClicked: {
+                            // Commit free text still sitting in a focused pill first
+                            root.forceActiveFocus();
+                            Ai.submitQuestions(root.messageData);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -14,8 +14,9 @@ import Quickshell
  * a free-text pill, and a Submit/Dismiss pair modeled after command
  * approval. Submit sends one permission response; questions with no selection
  * are skipped. Dismiss denies the request. The fence body is the tool's JSON
- * input; once submitted it is rewritten to {questions, answers} with an
- * :answered flag and renders statically.
+ * input; once submitted it is rewritten to {questions, selections} with an
+ * :answered flag and renders statically. The header carries the outcome and the
+ * box collapses, folding itself away if the model abandons the question.
  */
 ColumnLayout {
     id: root
@@ -43,8 +44,26 @@ ColumnLayout {
     // for good, and must not keep offering controls just because the message runs on
     property bool streamingPreview: (segmentLang ?? "").split(":").includes("running")
         && !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
-    // Defaults open: unlike a thought, a question is addressed to the user
-    property bool collapsed: false
+    // Mirrors the command block's state. An abandoned question sits at :pending like a live one,
+    // so telling them apart takes the pending-fence check rather than the token
+    readonly property string state: {
+        if (root.submitted) return "answered";
+        if (root.dismissed) return "dismissed";
+        if (root.streamingPreview) return "streaming";
+        return root.interactive ? "pending" : "unanswered";
+    }
+    readonly property var stateLabels: ({
+        "pending": Translation.tr("pending"),
+        "unanswered": Translation.tr("unanswered"),
+        "answered": Translation.tr("answered"),
+        "dismissed": Translation.tr("dismissed"),
+    })
+    // Streaming has no label: the message's own loading indicator already says as much
+    readonly property string stateLabel: root.stateLabels[root.state] ?? ""
+
+    // Open by default since a question is addressed to the user; a spent one folds away.
+    // Clicking the header replaces this binding
+    property bool collapsed: root.state === "unanswered"
     property var collapseAnimation: questionContentColumn.implicitHeight > 40
         ? Appearance.animation.elementMoveEnter : Appearance.animation.elementMoveFast
 
@@ -99,8 +118,7 @@ ColumnLayout {
         bottomLeftRadius: root.collapsed ? Appearance.rounding.small : Appearance.rounding.unsharpen
         bottomRightRadius: bottomLeftRadius
         color: Appearance.colors.colSurfaceContainerHighest
-        // Same recipe as the think and command block headers, so the three line up: the row is
-        // padded by 3 and the icon carries the rest, which keeps the chevron from setting the height
+        // Row padded by 3 with the icon carrying the rest, as in the think and command headers
         implicitHeight: titleRowLayout.implicitHeight + 3 * 2
 
         Behavior on bottomLeftRadius {
@@ -142,18 +160,20 @@ ColumnLayout {
                 text: root.questions.length > 1 ? Translation.tr("Questions") : Translation.tr("Question")
             }
             Rectangle {
-                visible: root.dismissed
+                visible: root.stateLabel.length > 0
                 implicitWidth: 4
                 implicitHeight: 4
                 radius: implicitWidth / 2
                 color: Appearance.colors.colOnLayer1Inactive
             }
             StyledText {
-                visible: root.dismissed
+                visible: root.stateLabel.length > 0
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
-                color: Appearance.colors.colError
-                text: Translation.tr("dismissed")
+                // As in the command block, the outcomes that cost the user something stand out
+                color: ["unanswered", "dismissed"].includes(root.state)
+                    ? Appearance.colors.colTertiary : Appearance.colors.colSubtext
+                text: root.stateLabel
             }
             Item { Layout.fillWidth: true }
             ExpandButton {

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -40,10 +40,10 @@ ColumnLayout {
     // While the tool input is still streaming (before the permission handshake), the
     // controls render disabled so the box has its final geometry from the start
     property bool streamingPreview: !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
+    // Picks live in the service until Submit writes them into the fence body
     function chosenLabels(question) {
         if (root.interactive) return Ai.questionSelections[question] ?? [];
-        const answer = root.parsed?.answers?.[question];
-        return typeof answer === "string" ? answer.split(", ") : [];
+        return root.parsed?.selections?.[question] ?? [];
     }
 
     // Committed answer parts that match no option label (free-text answers)

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -99,7 +99,9 @@ ColumnLayout {
         bottomLeftRadius: root.collapsed ? Appearance.rounding.small : Appearance.rounding.unsharpen
         bottomRightRadius: bottomLeftRadius
         color: Appearance.colors.colSurfaceContainerHighest
-        implicitHeight: titleRowLayout.implicitHeight + 10 * 2
+        // Same recipe as the think and command block headers, so the three line up: the row is
+        // padded by 3 and the icon carries the rest, which keeps the chevron from setting the height
+        implicitHeight: titleRowLayout.implicitHeight + 3 * 2
 
         Behavior on bottomLeftRadius {
             NumberAnimation {
@@ -124,13 +126,16 @@ ColumnLayout {
             anchors.right: parent.right
             anchors.leftMargin: 13
             anchors.rightMargin: 10
-            spacing: 6
+            spacing: 5
 
             MaterialSymbol {
+                Layout.topMargin: 7
+                Layout.bottomMargin: 7
                 color: Appearance.colors.colOnLayer2
                 text: "question_exchange"
             }
             StyledText {
+                Layout.leftMargin: 5
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 color: Appearance.colors.colOnLayer2

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -27,6 +27,7 @@ ColumnLayout {
 
     property bool submitted: (segmentLang ?? "").split(":").includes("answered")
     property bool dismissed: (segmentLang ?? "").split(":").includes("denied")
+    property bool streaming: (segmentLang ?? "").split(":").includes("streaming")
     // The strategy re-closes the still-streaming tool input before writing it, so the body is
     // always valid JSON and the box renders progressively off a plain parse
     property var parsed: {
@@ -38,23 +39,16 @@ ColumnLayout {
     }
     property var questions: parsed?.questions ?? []
     property bool interactive: isPendingCommand && (messageData?.functionPending ?? false) && !submitted && !dismissed
-    // While the tool input is still streaming (before the permission handshake), the
-    // controls render disabled so the box has its final geometry from the start. Only the
-    // fence still streaming qualifies: a question the model abandoned keeps its :pending state
-    // for good, and must not keep offering controls just because the message runs on
-    property bool streamingPreview: (segmentLang ?? "").split(":").includes("streaming")
-        && !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
-    // Mirrors the command block's state. An abandoned question sits at :pending like a live one,
-    // so telling them apart takes the pending-fence check rather than the token
+    // A question left un-answered reads as dismissed like an explicitly dismissed one: either way
+    // it is spent, and the fence alone cannot tell them apart since both sit at :pending
     readonly property string state: {
         if (root.submitted) return "answered";
-        if (root.dismissed) return "dismissed";
-        if (root.streamingPreview) return "streaming";
-        return root.interactive ? "pending" : "unanswered";
+        if (root.streaming) return "streaming";
+        if (root.dismissed || !root.interactive) return "dismissed";
+        return "pending";
     }
     readonly property var stateLabels: ({
         "pending": Translation.tr("pending"),
-        "unanswered": Translation.tr("unanswered"),
         "answered": Translation.tr("answered"),
         "dismissed": Translation.tr("dismissed"),
     })
@@ -63,7 +57,7 @@ ColumnLayout {
 
     // Open by default since a question is addressed to the user; a spent one folds away.
     // Clicking the header replaces this binding
-    property bool collapsed: root.state === "unanswered"
+    property bool collapsed: root.state === "dismissed"
     property var collapseAnimation: questionContentColumn.implicitHeight > 40
         ? Appearance.animation.elementMoveEnter : Appearance.animation.elementMoveFast
 
@@ -82,6 +76,7 @@ ColumnLayout {
     // The gap between the two cards lives in the collapsing wrapper, so it closes with them
     spacing: 0
     property real questionBlockComponentSpacing: 2
+    property real pillTextInset: 8
 
     // Animated slot for the multiSelect checkmark: its width changes continuously,
     // so the pill and text stay in step instead of the icon popping in a single frame
@@ -171,7 +166,7 @@ ColumnLayout {
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 // As in the command block, the outcomes that cost the user something stand out
-                color: ["unanswered", "dismissed"].includes(root.state)
+                color: root.state === "dismissed"
                     ? Appearance.colors.colTertiary : Appearance.colors.colSubtext
                 text: root.stateLabel
             }
@@ -190,13 +185,15 @@ ColumnLayout {
         contentHeight: questionBody.implicitHeight + root.questionBlockComponentSpacing
         animation: root.collapseAnimation
         // While the input streams the body grows on its own; animating that reads as a stutter
-        animated: !root.streamingPreview
+        animated: !root.streaming
 
         Rectangle { // Questions, option pills, and the Submit/Dismiss pair
             id: questionBody
+            // Top-anchored: the hint changes this body's height while expanded, and a bottom
+            // anchor would push that growth out of the window, dragging the pills up with it
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.bottom: parent.bottom
+            anchors.top: parent.top
             topLeftRadius: Appearance.rounding.unsharpen
             topRightRadius: Appearance.rounding.unsharpen
             bottomLeftRadius: Appearance.rounding.small
@@ -257,7 +254,7 @@ ColumnLayout {
                                     // rigidly so the size change is animated exactly once
                                     enableImplicitWidthAnimation: false
                                     buttonRadius: optionPill.down ? Appearance.rounding.verysmall : Appearance.rounding.small
-                                    horizontalPadding: 8
+                                    horizontalPadding: root.pillTextInset
                                     verticalPadding: 6
                                     toggled: root.chosenLabels(questionSection.question).includes(label)
                                     colBackground: toggled ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
@@ -285,7 +282,8 @@ ColumnLayout {
                                                 optionPill.toggled ? [] : [optionPill.label]);
                                         }
                                     }
-                                    StyledToolTip {
+                                    PillHint {
+                                        bounds: questionContentColumn
                                         text: optionPill.modelData.description ?? ""
                                     }
                                 }
@@ -295,12 +293,20 @@ ColumnLayout {
                                 id: freeTextPill
                                 // Renders selected exactly like an option pill: lit when its
                                 // text is among the question's current picks
+                                PillHint {
+                                    bounds: questionContentColumn
+                                    extraVisibleCondition: freeTextHover.hovered
+                                    text: freeTextPill.committed
+                                        ? Translation.tr("Your own answer")
+                                        : Translation.tr("Type your own answer")
+                                }
+                                HoverHandler { id: freeTextHover }
                                 property bool committed: freeTextInput.text.trim().length > 0
                                     && root.chosenLabels(questionSection.question).includes(freeTextInput.text.trim())
                                 // In the submitted transcript the pill stays, showing the custom answer
-                                property string historyFreeText: root.interactive || root.streamingPreview
+                                property string historyFreeText: root.interactive || root.streaming
                                     ? "" : root.freeTextOf(questionSection.question, questionSection.modelData.options ?? [])
-                                visible: root.interactive || root.streamingPreview || historyFreeText.length > 0
+                                visible: root.interactive || root.streaming || historyFreeText.length > 0
                                 radius: Appearance.rounding.small
                                 color: committed ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
                                 border.width: freeTextInput.activeFocus && !committed ? 1 : 0
@@ -308,14 +314,14 @@ ColumnLayout {
                                 implicitHeight: freeTextInput.implicitHeight + 6 * 2
                                 // Empty keeps room for the placeholder; typed text sizes the pill exactly
                                 implicitWidth: freeTextInput.text.length > 0
-                                    ? freeTextInput.contentWidth + 8 * 2 + freeCheckSlot.width
+                                    ? freeTextInput.contentWidth + root.pillTextInset * 2 + freeCheckSlot.width
                                     : 120
 
                                 CheckSlot {
                                     id: freeCheckSlot
                                     checked: questionSection.multiSelect && freeTextPill.committed
                                     anchors.left: parent.left
-                                    anchors.leftMargin: 8
+                                    anchors.leftMargin: root.pillTextInset
                                     anchors.verticalCenter: parent.verticalCenter
                                 }
 
@@ -326,8 +332,8 @@ ColumnLayout {
                                     // transcript it fills in the submitted custom answer
                                     text: freeTextPill.historyFreeText
                                     anchors.fill: parent
-                                    anchors.leftMargin: 8 + freeCheckSlot.width
-                                    anchors.rightMargin: 8
+                                    anchors.leftMargin: root.pillTextInset + freeCheckSlot.width
+                                    anchors.rightMargin: root.pillTextInset
                                     verticalAlignment: TextInput.AlignVCenter
                                     clip: true
                                     font.family: Appearance.font.family.main
@@ -410,7 +416,7 @@ ColumnLayout {
                 }
 
                 RowLayout { // Submit/Dismiss pair, mirrors command approval
-                    visible: root.interactive || root.streamingPreview
+                    visible: root.interactive || root.streaming
                     Layout.fillWidth: true
                     Layout.topMargin: 2
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -42,7 +42,7 @@ ColumnLayout {
     // controls render disabled so the box has its final geometry from the start. Only the
     // fence still streaming qualifies: a question the model abandoned keeps its :pending state
     // for good, and must not keep offering controls just because the message runs on
-    property bool streamingPreview: (segmentLang ?? "").split(":").includes("running")
+    property bool streamingPreview: (segmentLang ?? "").split(":").includes("streaming")
         && !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
     // Mirrors the command block's state. An abandoned question sits at :pending like a live one,
     // so telling them apart takes the pending-fence check rather than the token

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -242,8 +242,10 @@ ColumnLayout {
                             spacing: 5
 
                             // The box's own height animates as the flow reflows, so pills that
-                            // change row travel with it instead of teleporting
+                            // change row travel with it instead of teleporting. Off while the
+                            // options are still arriving, where every new pill reflows the rest
                             move: Transition {
+                                enabled: !root.streaming
                                 NumberAnimation {
                                     properties: "x,y"
                                     duration: Appearance.animation.elementMoveFast.duration
@@ -346,12 +348,10 @@ ColumnLayout {
                                 border.width: freeTextInput.activeFocus && !committed ? 1 : 0
                                 border.color: Appearance.colors.colPrimary
                                 implicitHeight: freeTextInput.implicitHeight + 6 * 2
-                                // Empty keeps room for the placeholder; typed text sizes the pill
-                                // exactly, up to the row width, past which the text wraps instead.
-                                // Width comes off unwrapped metrics rather than the input's own
-                                // content size, which would depend right back on this width
+                                // Off unwrapped metrics: the input's own content size would depend
+                                // right back on this width. The spare pixel is its cursor column
                                 implicitWidth: freeTextInput.text.length > 0
-                                    ? Math.min(Math.ceil(freeTextMetrics.advanceWidth) + root.pillTextInset * 2 + freeCheckSlot.width,
+                                    ? Math.min(Math.ceil(freeTextMetrics.advanceWidth) + 1 + root.pillTextInset * 2 + freeCheckSlot.width,
                                         optionsFlow.width)
                                     : 120
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -300,7 +300,29 @@ ColumnLayout {
                                         ? Translation.tr("Your own answer")
                                         : Translation.tr("Type your own answer")
                                 }
-                                HoverHandler { id: freeTextHover }
+                                HoverHandler {
+                                    id: freeTextHover
+                                    cursorShape: root.interactive ? Qt.IBeamCursor : Qt.ArrowCursor
+                                }
+                                // The input is inset, so a click on the pill's padding or
+                                // checkmark would fall through and blur it instead of focusing
+                                TapHandler {
+                                    enabled: root.interactive
+                                    onTapped: freeTextInput.forceActiveFocus()
+                                }
+                                StateOverlay { // Hover feedback, as the option pills get
+                                    anchors.fill: parent
+                                    topLeftRadius: freeTextPill.radius
+                                    topRightRadius: freeTextPill.radius
+                                    bottomLeftRadius: freeTextPill.radius
+                                    bottomRightRadius: freeTextPill.radius
+                                    hover: root.interactive && freeTextHover.hovered
+                                    // Focus is already called out by the pill's own border, which
+                                    // is how M3 marks a focused text field
+                                    contentColor: freeTextPill.committed
+                                        ? Appearance.colors.colOnPrimary
+                                        : Appearance.colors.colOnSecondaryContainer
+                                }
                                 property bool committed: freeTextInput.text.trim().length > 0
                                     && root.chosenLabels(questionSection.question).includes(freeTextInput.text.trim())
                                 // In the submitted transcript the pill stays, showing the custom answer

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageQuestionBlock.qml
@@ -43,6 +43,11 @@ ColumnLayout {
     // for good, and must not keep offering controls just because the message runs on
     property bool streamingPreview: (segmentLang ?? "").split(":").includes("running")
         && !submitted && !dismissed && !interactive && !(messageData?.done ?? true)
+    // Defaults open: unlike a thought, a question is addressed to the user
+    property bool collapsed: false
+    property var collapseAnimation: questionContentColumn.implicitHeight > 40
+        ? Appearance.animation.elementMoveEnter : Appearance.animation.elementMoveFast
+
     // Picks live in the service until Submit writes them into the fence body
     function chosenLabels(question) {
         if (root.interactive) return Ai.questionSelections[question] ?? [];
@@ -55,7 +60,9 @@ ColumnLayout {
         return chosenLabels(question).filter(part => !labels.includes(part)).join(", ");
     }
 
-    spacing: 2
+    // The gap between the two cards lives in the collapsing wrapper, so it closes with them
+    spacing: 0
+    property real questionBlockComponentSpacing: 2
 
     // Animated slot for the multiSelect checkmark: its width changes continuously,
     // so the pill and text stay in step instead of the icon popping in a single frame
@@ -88,16 +95,35 @@ ColumnLayout {
         Layout.fillWidth: true
         topLeftRadius: Appearance.rounding.small
         topRightRadius: Appearance.rounding.small
-        bottomLeftRadius: Appearance.rounding.unsharpen
-        bottomRightRadius: Appearance.rounding.unsharpen
+        // Rounds off into a standalone card once the body is gone
+        bottomLeftRadius: root.collapsed ? Appearance.rounding.small : Appearance.rounding.unsharpen
+        bottomRightRadius: bottomLeftRadius
         color: Appearance.colors.colSurfaceContainerHighest
         implicitHeight: titleRowLayout.implicitHeight + 10 * 2
+
+        Behavior on bottomLeftRadius {
+            NumberAnimation {
+                duration: root.collapseAnimation.duration
+                easing.type: root.collapseAnimation.type
+                easing.bezierCurve: root.collapseAnimation.bezierCurve
+            }
+        }
+
+        MouseArea { // Click the bar to collapse or reveal
+            id: titleMouseArea
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            hoverEnabled: true
+            onClicked: root.collapsed = !root.collapsed
+        }
 
         RowLayout {
             id: titleRowLayout
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
+            anchors.right: parent.right
             anchors.leftMargin: 13
+            anchors.rightMargin: 10
             spacing: 6
 
             MaterialSymbol {
@@ -124,258 +150,275 @@ ColumnLayout {
                 color: Appearance.colors.colError
                 text: Translation.tr("dismissed")
             }
+            Item { Layout.fillWidth: true }
+            ExpandButton {
+                expanded: !root.collapsed
+                headerHovered: titleMouseArea.containsMouse
+                onClicked: root.collapsed = !root.collapsed
+            }
         }
     }
 
-    Rectangle { // Questions, option pills, and the Submit/Dismiss pair
+    CollapsibleContent {
         visible: root.questions.length > 0
-        Layout.fillWidth: true
-        topLeftRadius: Appearance.rounding.unsharpen
-        topRightRadius: Appearance.rounding.unsharpen
-        bottomLeftRadius: Appearance.rounding.small
-        bottomRightRadius: Appearance.rounding.small
-        color: Appearance.colors.colLayer2
-        implicitHeight: questionContentColumn.implicitHeight + 10 * 2
+        collapsed: root.collapsed
+        contentHeight: questionBody.implicitHeight + root.questionBlockComponentSpacing
+        animation: root.collapseAnimation
+        // While the input streams the body grows on its own; animating that reads as a stutter
+        animated: !root.streamingPreview
 
-        MouseArea { // Click on box dead space to unfocus the text pill
-            anchors.fill: parent
-            onPressed: root.forceActiveFocus()
-        }
+        Rectangle { // Questions, option pills, and the Submit/Dismiss pair
+            id: questionBody
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            topLeftRadius: Appearance.rounding.unsharpen
+            topRightRadius: Appearance.rounding.unsharpen
+            bottomLeftRadius: Appearance.rounding.small
+            bottomRightRadius: Appearance.rounding.small
+            color: Appearance.colors.colLayer2
+            implicitHeight: questionContentColumn.implicitHeight + 10 * 2
 
-        ColumnLayout {
-            id: questionContentColumn
-            anchors {
-                fill: parent
-                margins: 10
+            MouseArea { // Click on box dead space to unfocus the text pill
+                anchors.fill: parent
+                onPressed: root.forceActiveFocus()
             }
-            spacing: 8
 
-            Repeater {
-                model: ScriptModel {
-                    values: root.questions
+            ColumnLayout {
+                id: questionContentColumn
+                anchors {
+                    fill: parent
+                    margins: 10
                 }
-                delegate: ColumnLayout { // One section per question
-                    id: questionSection
-                    required property var modelData
-                    required property int index
-                    property string question: modelData.question ?? ""
-                    property bool multiSelect: modelData.multiSelect ?? false
+                spacing: 8
 
-                    Layout.fillWidth: true
-                    Layout.topMargin: index > 0 ? 6 : 0
-                    spacing: 8
-
-                    StyledText {
-                        Layout.fillWidth: true
-                        wrapMode: Text.Wrap
-                        color: Appearance.colors.colOnLayer1
-                        text: questionSection.question
+                Repeater {
+                    model: ScriptModel {
+                        values: root.questions
                     }
+                    delegate: ColumnLayout { // One section per question
+                        id: questionSection
+                        required property var modelData
+                        required property int index
+                        property string question: modelData.question ?? ""
+                        property bool multiSelect: modelData.multiSelect ?? false
 
-                    Flow {
                         Layout.fillWidth: true
-                        spacing: 5
+                        Layout.topMargin: index > 0 ? 6 : 0
+                        spacing: 8
 
-                        Repeater {
-                            model: ScriptModel {
-                                values: questionSection.modelData.options ?? []
-                            }
-                            delegate: GroupButton { // Styled like the command suggestion pills
-                                id: optionPill
-                                required property var modelData
-                                property string label: modelData.label ?? ""
-                                enabled: root.interactive
-                                bounce: false
-                                // The checkmark slot animates its own width; the pill follows it
-                                // rigidly so the size change is animated exactly once
-                                enableImplicitWidthAnimation: false
-                                buttonRadius: optionPill.down ? Appearance.rounding.verysmall : Appearance.rounding.small
-                                horizontalPadding: 8
-                                verticalPadding: 6
-                                toggled: root.chosenLabels(questionSection.question).includes(label)
-                                colBackground: toggled ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
-                                colBackgroundHover: Appearance.colors.colSecondaryContainerHover
-                                colBackgroundActive: Appearance.colors.colSecondaryContainerActive
-                                contentItem: RowLayout {
-                                    spacing: 0
-                                    CheckSlot {
-                                        checked: questionSection.multiSelect && optionPill.toggled
-                                        Layout.alignment: Qt.AlignVCenter
-                                    }
-                                    StyledText {
-                                        font.pixelSize: Appearance.font.pixelSize.small
-                                        horizontalAlignment: Text.AlignHCenter
-                                        color: optionPill.toggled ? Appearance.colors.colOnPrimary
-                                            : Appearance.colors.colOnSecondaryContainer
-                                        text: optionPill.label
-                                    }
-                                }
-                                onClicked: {
-                                    if (questionSection.multiSelect) {
-                                        Ai.toggleQuestionOption(questionSection.question, optionPill.label);
-                                    } else {
-                                        Ai.setQuestionSelection(questionSection.question,
-                                            optionPill.toggled ? [] : [optionPill.label]);
-                                    }
-                                }
-                                StyledToolTip {
-                                    text: optionPill.modelData.description ?? ""
-                                }
-                            }
+                        StyledText {
+                            Layout.fillWidth: true
+                            wrapMode: Text.Wrap
+                            color: Appearance.colors.colOnLayer1
+                            text: questionSection.question
                         }
 
-                        Rectangle { // Free-text pill, expands with its content
-                            id: freeTextPill
-                            // Renders selected exactly like an option pill: lit when its
-                            // text is among the question's current picks
-                            property bool committed: freeTextInput.text.trim().length > 0
-                                && root.chosenLabels(questionSection.question).includes(freeTextInput.text.trim())
-                            // In the submitted transcript the pill stays, showing the custom answer
-                            property string historyFreeText: root.interactive || root.streamingPreview
-                                ? "" : root.freeTextOf(questionSection.question, questionSection.modelData.options ?? [])
-                            visible: root.interactive || root.streamingPreview || historyFreeText.length > 0
-                            radius: Appearance.rounding.small
-                            color: committed ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
-                            border.width: freeTextInput.activeFocus && !committed ? 1 : 0
-                            border.color: Appearance.colors.colPrimary
-                            implicitHeight: freeTextInput.implicitHeight + 6 * 2
-                            // Empty keeps room for the placeholder; typed text sizes the pill exactly
-                            implicitWidth: freeTextInput.text.length > 0
-                                ? freeTextInput.contentWidth + 8 * 2 + freeCheckSlot.width
-                                : 120
+                        Flow {
+                            Layout.fillWidth: true
+                            spacing: 5
 
-                            CheckSlot {
-                                id: freeCheckSlot
-                                checked: questionSection.multiSelect && freeTextPill.committed
-                                anchors.left: parent.left
-                                anchors.leftMargin: 8
-                                anchors.verticalCenter: parent.verticalCenter
-                            }
-
-                            TextInput {
-                                id: freeTextInput
-                                enabled: root.interactive
-                                // Interactive typing replaces this binding; for a loaded
-                                // transcript it fills in the submitted custom answer
-                                text: freeTextPill.historyFreeText
-                                anchors.fill: parent
-                                anchors.leftMargin: 8 + freeCheckSlot.width
-                                anchors.rightMargin: 8
-                                verticalAlignment: TextInput.AlignVCenter
-                                clip: true
-                                font.family: Appearance.font.family.main
-                                font.pixelSize: Appearance.font.pixelSize.small
-                                color: freeTextPill.committed ? Appearance.colors.colOnPrimary : Appearance.m3colors.m3onSurface
-                                selectByMouse: true
-                                // Editing only happens uncommitted (focus un-commits), so the
-                                // background is always colSecondaryContainer; primary stands out
-                                selectedTextColor: Appearance.colors.colOnPrimary
-                                selectionColor: Appearance.colors.colPrimary
-
-                                property string placeholder: Translation.tr("Other...")
-                                Text {
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    visible: freeTextInput.text.length === 0 && !freeTextInput.activeFocus
-                                    font: freeTextInput.font
-                                    color: Appearance.colors.colSubtext
-                                    text: freeTextInput.placeholder
+                            Repeater {
+                                model: ScriptModel {
+                                    values: questionSection.modelData.options ?? []
                                 }
-
-                                MouseArea { // Hover only; presses belong to the TextInput
-                                    anchors.fill: parent
-                                    acceptedButtons: Qt.NoButton
-                                    cursorShape: root.interactive ? Qt.IBeamCursor : Qt.ArrowCursor
-                                }
-
-                                // The one custom entry this pill has contributed; edits replace it
-                                property string committedText: ""
-
-                                // Single-select: text becomes the answer. multiSelect: text joins
-                                // the picks like a toggled chip
-                                function commitFreeText() {
-                                    const answer = text.trim();
-                                    if (questionSection.multiSelect) {
-                                        if (committedText.length > 0 && committedText !== answer
-                                                && root.chosenLabels(questionSection.question).includes(committedText)) {
-                                            Ai.toggleQuestionOption(questionSection.question, committedText);
+                                delegate: GroupButton { // Styled like the command suggestion pills
+                                    id: optionPill
+                                    required property var modelData
+                                    property string label: modelData.label ?? ""
+                                    enabled: root.interactive
+                                    bounce: false
+                                    // The checkmark slot animates its own width; the pill follows it
+                                    // rigidly so the size change is animated exactly once
+                                    enableImplicitWidthAnimation: false
+                                    buttonRadius: optionPill.down ? Appearance.rounding.verysmall : Appearance.rounding.small
+                                    horizontalPadding: 8
+                                    verticalPadding: 6
+                                    toggled: root.chosenLabels(questionSection.question).includes(label)
+                                    colBackground: toggled ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
+                                    colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+                                    colBackgroundActive: Appearance.colors.colSecondaryContainerActive
+                                    contentItem: RowLayout {
+                                        spacing: 0
+                                        CheckSlot {
+                                            checked: questionSection.multiSelect && optionPill.toggled
+                                            Layout.alignment: Qt.AlignVCenter
                                         }
-                                        if (answer.length > 0
-                                                && !root.chosenLabels(questionSection.question).includes(answer)) {
-                                            Ai.toggleQuestionOption(questionSection.question, answer);
-                                        }
-                                        committedText = answer;
-                                    } else if (answer.length > 0) {
-                                        // Don't clobber an option picked while this field kept focus
-                                        const current = root.chosenLabels(questionSection.question);
-                                        if (current.length === 0 || current.includes(committedText)) {
-                                            Ai.setQuestionSelection(questionSection.question, [answer]);
-                                            committedText = answer;
+                                        StyledText {
+                                            font.pixelSize: Appearance.font.pixelSize.small
+                                            horizontalAlignment: Text.AlignHCenter
+                                            color: optionPill.toggled ? Appearance.colors.colOnPrimary
+                                                : Appearance.colors.colOnSecondaryContainer
+                                            text: optionPill.label
                                         }
                                     }
+                                    onClicked: {
+                                        if (questionSection.multiSelect) {
+                                            Ai.toggleQuestionOption(questionSection.question, optionPill.label);
+                                        } else {
+                                            Ai.setQuestionSelection(questionSection.question,
+                                                optionPill.toggled ? [] : [optionPill.label]);
+                                        }
+                                    }
+                                    StyledToolTip {
+                                        text: optionPill.modelData.description ?? ""
+                                    }
+                                }
+                            }
+
+                            Rectangle { // Free-text pill, expands with its content
+                                id: freeTextPill
+                                // Renders selected exactly like an option pill: lit when its
+                                // text is among the question's current picks
+                                property bool committed: freeTextInput.text.trim().length > 0
+                                    && root.chosenLabels(questionSection.question).includes(freeTextInput.text.trim())
+                                // In the submitted transcript the pill stays, showing the custom answer
+                                property string historyFreeText: root.interactive || root.streamingPreview
+                                    ? "" : root.freeTextOf(questionSection.question, questionSection.modelData.options ?? [])
+                                visible: root.interactive || root.streamingPreview || historyFreeText.length > 0
+                                radius: Appearance.rounding.small
+                                color: committed ? Appearance.colors.colPrimary : Appearance.colors.colSecondaryContainer
+                                border.width: freeTextInput.activeFocus && !committed ? 1 : 0
+                                border.color: Appearance.colors.colPrimary
+                                implicitHeight: freeTextInput.implicitHeight + 6 * 2
+                                // Empty keeps room for the placeholder; typed text sizes the pill exactly
+                                implicitWidth: freeTextInput.text.length > 0
+                                    ? freeTextInput.contentWidth + 8 * 2 + freeCheckSlot.width
+                                    : 120
+
+                                CheckSlot {
+                                    id: freeCheckSlot
+                                    checked: questionSection.multiSelect && freeTextPill.committed
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: 8
+                                    anchors.verticalCenter: parent.verticalCenter
                                 }
 
-                                // Focus un-commits this pill's entry (single-select: the whole
-                                // selection) so it drops back to the typing look; leaving
-                                // with text commits — Enter also commits, but isn't required
-                                onActiveFocusChanged: {
-                                    if (!root.interactive) return;
-                                    if (activeFocus) {
+                                TextInput {
+                                    id: freeTextInput
+                                    enabled: root.interactive
+                                    // Interactive typing replaces this binding; for a loaded
+                                    // transcript it fills in the submitted custom answer
+                                    text: freeTextPill.historyFreeText
+                                    anchors.fill: parent
+                                    anchors.leftMargin: 8 + freeCheckSlot.width
+                                    anchors.rightMargin: 8
+                                    verticalAlignment: TextInput.AlignVCenter
+                                    clip: true
+                                    font.family: Appearance.font.family.main
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: freeTextPill.committed ? Appearance.colors.colOnPrimary : Appearance.m3colors.m3onSurface
+                                    selectByMouse: true
+                                    // Editing only happens uncommitted (focus un-commits), so the
+                                    // background is always colSecondaryContainer; primary stands out
+                                    selectedTextColor: Appearance.colors.colOnPrimary
+                                    selectionColor: Appearance.colors.colPrimary
+
+                                    property string placeholder: Translation.tr("Other...")
+                                    Text {
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        visible: freeTextInput.text.length === 0 && !freeTextInput.activeFocus
+                                        font: freeTextInput.font
+                                        color: Appearance.colors.colSubtext
+                                        text: freeTextInput.placeholder
+                                    }
+
+                                    MouseArea { // Hover only; presses belong to the TextInput
+                                        anchors.fill: parent
+                                        acceptedButtons: Qt.NoButton
+                                        cursorShape: root.interactive ? Qt.IBeamCursor : Qt.ArrowCursor
+                                    }
+
+                                    // The one custom entry this pill has contributed; edits replace it
+                                    property string committedText: ""
+
+                                    // Single-select: text becomes the answer. multiSelect: text joins
+                                    // the picks like a toggled chip
+                                    function commitFreeText() {
+                                        const answer = text.trim();
                                         if (questionSection.multiSelect) {
-                                            if (committedText.length > 0
+                                            if (committedText.length > 0 && committedText !== answer
                                                     && root.chosenLabels(questionSection.question).includes(committedText)) {
                                                 Ai.toggleQuestionOption(questionSection.question, committedText);
                                             }
-                                        } else {
-                                            Ai.setQuestionSelection(questionSection.question, []);
+                                            if (answer.length > 0
+                                                    && !root.chosenLabels(questionSection.question).includes(answer)) {
+                                                Ai.toggleQuestionOption(questionSection.question, answer);
+                                            }
+                                            committedText = answer;
+                                        } else if (answer.length > 0) {
+                                            // Don't clobber an option picked while this field kept focus
+                                            const current = root.chosenLabels(questionSection.question);
+                                            if (current.length === 0 || current.includes(committedText)) {
+                                                Ai.setQuestionSelection(questionSection.question, [answer]);
+                                                committedText = answer;
+                                            }
                                         }
-                                    } else {
-                                        commitFreeText();
                                     }
+
+                                    // Focus un-commits this pill's entry (single-select: the whole
+                                    // selection) so it drops back to the typing look; leaving
+                                    // with text commits — Enter also commits, but isn't required
+                                    onActiveFocusChanged: {
+                                        if (!root.interactive) return;
+                                        if (activeFocus) {
+                                            if (questionSection.multiSelect) {
+                                                if (committedText.length > 0
+                                                        && root.chosenLabels(questionSection.question).includes(committedText)) {
+                                                    Ai.toggleQuestionOption(questionSection.question, committedText);
+                                                }
+                                            } else {
+                                                Ai.setQuestionSelection(questionSection.question, []);
+                                            }
+                                        } else {
+                                            commitFreeText();
+                                        }
+                                    }
+
+                                    // Blur commits, so Enter just drops focus
+                                    onAccepted: root.forceActiveFocus()
                                 }
-
-                                // Blur commits, so Enter just drops focus
-                                onAccepted: root.forceActiveFocus()
                             }
-                        }
 
+                        }
                     }
                 }
-            }
 
-            RowLayout { // Submit/Dismiss pair, mirrors command approval
-                visible: root.interactive || root.streamingPreview
-                Layout.fillWidth: true
-                Layout.topMargin: 2
+                RowLayout { // Submit/Dismiss pair, mirrors command approval
+                    visible: root.interactive || root.streamingPreview
+                    Layout.fillWidth: true
+                    Layout.topMargin: 2
 
-                Item { Layout.fillWidth: true }
-                ButtonGroup {
-                    GroupButton {
-                        enabled: root.interactive
-                        // The default hover (colLayer1Hover) is invisible on this
-                        // box's colLayer2 background
-                        colBackgroundHover: Appearance.colors.colLayer2Hover
-                        colBackgroundActive: Appearance.colors.colLayer2Active
-                        contentItem: StyledText {
-                            text: Translation.tr("Dismiss")
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            color: Appearance.colors.colOnLayer2
+                    Item { Layout.fillWidth: true }
+                    ButtonGroup {
+                        GroupButton {
+                            enabled: root.interactive
+                            // The default hover (colLayer1Hover) is invisible on this
+                            // box's colLayer2 background
+                            colBackgroundHover: Appearance.colors.colLayer2Hover
+                            colBackgroundActive: Appearance.colors.colLayer2Active
+                            contentItem: StyledText {
+                                text: Translation.tr("Dismiss")
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                color: Appearance.colors.colOnLayer2
+                            }
+                            onClicked: Ai.rejectCommand(root.messageData)
                         }
-                        onClicked: Ai.rejectCommand(root.messageData)
-                    }
-                    GroupButton {
-                        enabled: root.interactive
-                        toggled: true
-                        // colBackground carries the fill so it survives the disabled state
-                        colBackground: Appearance.colors.colPrimary
-                        contentItem: StyledText {
-                            text: Translation.tr("Submit")
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            color: Appearance.colors.colOnPrimary
-                        }
-                        onClicked: {
-                            // Commit free text still sitting in a focused pill first
-                            root.forceActiveFocus();
-                            Ai.submitQuestions(root.messageData);
+                        GroupButton {
+                            enabled: root.interactive
+                            toggled: true
+                            // colBackground carries the fill so it survives the disabled state
+                            colBackground: Appearance.colors.colPrimary
+                            contentItem: StyledText {
+                                text: Translation.tr("Submit")
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                color: Appearance.colors.colOnPrimary
+                            }
+                            onClicked: {
+                                // Commit free text still sitting in a focused pill first
+                                root.forceActiveFocus();
+                                Ai.submitQuestions(root.messageData);
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageTextBlock.qml
@@ -150,6 +150,8 @@ ColumnLayout {
             }
 
             Layout.fillWidth: true
+            topPadding: 0
+            bottomPadding: 0
             readOnly: !editing
             selectByMouse: enableMouseSelection || editing
             renderType: Text.NativeRendering

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
@@ -3,7 +3,6 @@ pragma ComponentBehavior: Bound
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
-import qs.modules.common.functions
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
@@ -94,55 +93,24 @@ Item {
                     text: root.completed ? Translation.tr("Thought") : (Translation.tr("Thinking") + ".".repeat(Math.random() * 4))
                 }
                 Item { Layout.fillWidth: true }
-                RippleButton { // Expand button
+                ExpandButton {
                     id: expandButton
                     visible: root.completed
-                    implicitWidth: 22
-                    implicitHeight: 22
-                    colBackground: headerMouseArea.containsMouse ? Appearance.colors.colLayer2Hover
-                        : ColorUtils.transparentize(Appearance.colors.colLayer2, 1)
-                    colBackgroundHover: Appearance.colors.colLayer2Hover
-                    colRipple: Appearance.colors.colLayer2Active
-
-                    onClicked: { root.collapsed = !root.collapsed }
-                    
-                    contentItem: MaterialSymbol {
-                        anchors.centerIn: parent
-                        text: "keyboard_arrow_down"
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                        iconSize: Appearance.font.pixelSize.normal
-                        color: Appearance.colors.colOnLayer2
-                        rotation: root.collapsed ? 0 : 180
-                        Behavior on rotation {
-                            NumberAnimation {
-                                duration: Appearance.animation.elementMoveFast.duration
-                                easing.type: Appearance.animation.elementMoveFast.type
-                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
-                            }
-                        }
-                    }
-
+                    expanded: !root.collapsed
+                    headerHovered: headerMouseArea.containsMouse
+                    onClicked: root.collapsed = !root.collapsed
                 }
-                
+
             }
 
         }
 
-        Item {
+        CollapsibleContent {
             id: content
-            Layout.fillWidth: true
-            implicitHeight: collapsed ? 0 : contentBackground.implicitHeight + thinkBlockComponentSpacing
-            clip: true
-
-            Behavior on implicitHeight {
-                enabled: root.completed ?? false
-                NumberAnimation {
-                    duration: collapseAnimation.duration
-                    easing.type: collapseAnimation.type
-                    easing.bezierCurve: collapseAnimation.bezierCurve
-                }
-            }
+            collapsed: root.collapsed
+            contentHeight: contentBackground.implicitHeight + root.thinkBlockComponentSpacing
+            animation: root.collapseAnimation
+            animated: root.completed ?? false
 
             Rectangle {
                 id: contentBackground

--- a/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/PillHint.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarLeft/aiChat/PillHint.qml
@@ -1,0 +1,121 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Controls
+
+/**
+ * Explains the pill it hangs off, in the card's own colours rather than a tooltip's dark bubble,
+ * so it reads as part of the question. Floats instead of taking layout space, so the pills hold
+ * still. Set extraVisibleCondition when the parent has no `hovered` of its own.
+ */
+ToolTip {
+    id: root
+    property bool extraVisibleCondition: true
+    // A comfortable line length to read a sentence or two at, not however much room happens to
+    // be going: the sidebar being extended should not stretch this into one long line
+    property real maximumTextWidth: 400
+    readonly property real fittedTextWidth: root.bounds
+        ? Math.min(root.maximumTextWidth, root.bounds.width - root.padding * 2)
+        : root.maximumTextWidth
+
+    // Held inside this item, not the window: the left sidebar's window is far wider than the
+    // panel you can see, so the popup's own fitting would still leave it over the desktop
+    property Item bounds
+
+    readonly property bool internalVisibleCondition: extraVisibleCondition
+        && (parent?.hovered === undefined || parent?.hovered)
+    visible: internalVisibleCondition && root.text.length > 0
+    delay: 0
+    padding: 8
+    y: parent.height + 4
+    // Centered on the pill, then slid back inside bounds if that would hang over an edge.
+    // Recomputed on show rather than bound: mapToItem reads live positions instead of properties,
+    // so a binding would keep whatever the layout looked like when the pill was created — which
+    // for a pill in the Flow's second row is its spot before the row wrapped
+    function updatePosition() {
+        const centred = (parent.width - root.width) / 2;
+        const origin = root.bounds ? parent.mapToItem(root.bounds, 0, 0) : null;
+        if (!origin) {
+            root.x = centred;
+            return;
+        }
+        const left = origin.x + centred;
+        const maxLeft = Math.max(0, root.bounds.width - root.width);
+        root.x = centred + (Math.min(Math.max(left, 0), maxLeft) - left);
+    }
+    onVisibleChanged: if (visible) Qt.callLater(root.updatePosition)
+    onWidthChanged: if (visible) Qt.callLater(root.updatePosition)
+    // Sized from the label, which keeps its own width: the popup assigns its content item's
+    // width, so a label bound to that would feed back into this
+    width: implicitContentWidth + leftPadding + rightPadding
+
+    background: Item {
+        StyledRectangularShadow {
+            target: hintBackground
+        }
+        Rectangle {
+            id: hintBackground
+            anchors.fill: parent
+            color: Appearance.m3colors.m3surfaceContainer
+            radius: Appearance.rounding.small
+
+            border.width: 1
+            border.color: Appearance.colors.colLayer0Border
+        }
+    }
+
+    // Sized from the widest line the label actually lays out, so the box loses the slack on the
+    // right without moving any break: wrapping happens at the full width, keeping early lines full
+    contentItem: Item {
+        implicitWidth: label.contentWidth
+        implicitHeight: label.contentHeight
+
+        StyledText {
+            id: label
+            width: root.fittedTextWidth
+            wrapMode: Text.Wrap
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colSubtext
+            text: root.text
+        }
+    }
+
+    // Grows and fades like the shell's other tooltips, but leaves the same way instead of
+    // blinking out. Scale rather than size: the width is bound, so a transition cannot drive it
+    enter: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 0
+            to: 1
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Appearance.animation.elementMoveFast.type
+            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+        }
+        NumberAnimation {
+            property: "scale"
+            from: 0.9
+            to: 1
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Appearance.animation.elementMoveFast.type
+            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+        }
+    }
+    exit: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 1
+            to: 0
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Appearance.animation.elementMoveFast.type
+            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+        }
+        NumberAnimation {
+            property: "scale"
+            from: 1
+            to: 0.9
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Appearance.animation.elementMoveFast.type
+            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -948,7 +948,9 @@ Singleton {
                 addFunctionOutputMessage(name, Translation.tr("Invalid arguments. Must provide `command`."));
                 return;
             }
-            const contentToAppend = `\n\n**Command execution request**\n\n\`\`\`command\n${args.command}\n\`\`\``;
+            message.pendingCommandIndex = CF.StringUtils.splitMarkdownBlocks(message.content)
+                .filter(b => b.type === "code" && b.lang === "command").length;
+            const contentToAppend = `\n\n**${Translation.tr("Command execution request")}**\n\n\`\`\`command\n${args.command}\n\`\`\``;
             message.rawContent += contentToAppend;
             message.content += contentToAppend;
             message.functionPending = true; // Use thinking to indicate the command is waiting for approval

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -23,6 +23,7 @@ Singleton {
     property Component geminiApiStrategy: GeminiApiStrategy {}
     property Component openaiApiStrategy: OpenAiApiStrategy {}
     property Component mistralApiStrategy: MistralApiStrategy {}
+    property Component claudeCliStrategy: ClaudeCliStrategy {}
     readonly property string interfaceRole: "interface"
     readonly property string apiKeyEnvVarName: "API_KEY"
 
@@ -49,6 +50,9 @@ Singleton {
         const key = apiKeys[model.key_id];
         return (key?.length > 0);
     }
+    readonly property bool busy: requester.running
+    // Pending CLI tool-permission request awaiting user approval: {requestId, input}
+    property var pendingCliPermission: null
     property var postResponseHook
     property real temperature: Persistent.states?.ai?.temperature ?? 0.5
     property QtObject tokenCount: QtObject {
@@ -233,9 +237,12 @@ Singleton {
             ],
             "search": [],
             "none": [],
+        },
+        "claude-cli": {
+            "none": []
         }
     }
-    property list<var> availableTools: Object.keys(root.tools[models[currentModelId]?.api_format])
+    property list<var> availableTools: Object.keys(root.tools[models[currentModelId]?.api_format] ?? {})
     property var toolDescriptions: {
         "functions": Translation.tr("Commands, edit configs, search.\nTakes an extra turn to switch to search mode if that's needed"),
         "search": Translation.tr("Gives the model search capabilities (immediately)"),
@@ -302,6 +309,7 @@ Singleton {
         "openai": openaiApiStrategy.createObject(this),
         "gemini": geminiApiStrategy.createObject(this),
         "mistral": mistralApiStrategy.createObject(this),
+        "claude-cli": claudeCliStrategy.createObject(this),
     }
     property ApiStrategy currentApiStrategy: apiStrategies[models[currentModelId]?.api_format || "openai"]
 
@@ -388,6 +396,43 @@ Singleton {
     }
 
     Process {
+        id: getClaudeModels
+        // The CLI runs locally but sends chats to Anthropic, so the local-only policy excludes it
+        running: Config.options.policies.ai !== 2
+        command: ["bash", "-c", "claude -p '/model' 2>/dev/null"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (Config.options.policies.ai === 2) return;
+                try {
+                    // Replies like "... Available: sonnet, opus, fable, default, or a full model ID."
+                    const match = text.match(/Available: ([^\n]+)/);
+                    if (!match) return;
+                    const aliases = match[1].split(",")
+                        .map(alias => alias.trim().replace(/\.$/, ""))
+                        // Drops the trailing "or a full model ID" and meta aliases
+                        .filter(alias => alias.length > 0 && !alias.includes(" ")
+                            && !["default", "best", "opusplan"].includes(alias));
+                    aliases.forEach(alias => {
+                        root.addModel("claude-" + root.safeModelName(alias), {
+                            "name": "Claude " + CF.StringUtils.toTitleCase(alias),
+                            "icon": "spark-symbolic",
+                            "description": Translation.tr("Local CLI | Anthropic's %1 model via the Claude Code CLI").arg(alias),
+                            "homepage": "https://claude.com/claude-code",
+                            "endpoint": "https://api.anthropic.com",
+                            "model": alias,
+                            "requires_key": false,
+                            "api_format": "claude-cli",
+                        });
+                    });
+                    root.modelList = Object.keys(root.models);
+                } catch (e) {
+                    console.log("Could not fetch Claude CLI models:", e);
+                }
+            }
+        }
+    }
+
+    Process {
         id: getDefaultPrompts
         running: true
         command: ["ls", "-1", Directories.defaultAiPrompts]
@@ -466,9 +511,14 @@ Singleton {
     function removeMessage(index) {
         if (index < 0 || index >= messageIDs.length) return;
         const id = root.messageIDs[index];
+        const removedRole = root.messageByID[id].role;
         root.messageIDs.splice(index, 1);
         root.messageIDs = [...root.messageIDs];
         delete root.messageByID[id];
+        // CLI sessions are append-only; drop the ids so an edited chat starts fresh
+        if (removedRole !== root.interfaceRole) {
+            root.messageIDs.forEach(mid => { root.messageByID[mid].cliSessionId = "" });
+        }
     }
 
     function addApiKeyAdvice(model) {
@@ -579,12 +629,20 @@ Singleton {
 
     Process {
         id: requester
+        // Launch claude cli in ~/.config/illogical-impulse
+        workingDirectory: Directories.shellConfig
         property list<string> baseCommand: ["bash"]
         property AiMessageData message
         property ApiStrategy currentStrategy
+        // Used when interrupting previous messages to wait 
+        // until process exits before starting new request
+        property bool restartOnExit: false
 
         function markDone() {
             requester.message.done = true;
+            root.pendingCliPermission = null;
+            requester.message.functionPending = false;
+            requester.stdinEnabled = false;
             if (root.postResponseHook) {
                 root.postResponseHook();
                 root.postResponseHook = null; // Reset hook after use
@@ -594,6 +652,13 @@ Singleton {
         }
 
         function makeRequest() {
+            // Kill previous request before making new one
+            if (requester.running) {
+                requester.restartOnExit = true;
+                root.interrupt();
+                return;
+            }
+            requester.restartOnExit = false;
             const model = models[currentModelId];
 
             // Fetch API keys if needed
@@ -654,7 +719,7 @@ Singleton {
 
             /* Create command string */
             let scriptRequestContent = ""
-            scriptRequestContent += `curl --no-buffer "${endpoint}"`
+            scriptRequestContent += `curl --no-buffer -sS "${endpoint}"`
                 + ` ${headerString}`
                 + (authHeader ? ` ${authHeader}` : "")
                 + ` --data '${CF.StringUtils.shellSingleQuoteEscape(JSON.stringify(data))}'`
@@ -666,7 +731,15 @@ Singleton {
             requesterScriptFile.path = Qt.resolvedUrl(shellScriptPath)
             requesterScriptFile.setText(scriptContent)
             requester.command = baseCommand.concat([shellScriptPath]);
+            requester.stdinEnabled = true;
             requester.running = true
+        }
+
+        // Claude CLI takes input over stdin
+        onStarted: {
+            if (requester.currentStrategy.isCli) {
+                requester.write(requester.currentStrategy.buildStdinPayload() + "\n");
+            }
         }
 
         stdout: SplitParser {
@@ -683,6 +756,9 @@ Singleton {
                     if (result.functionCall) {
                         requester.message.functionCall = result.functionCall;
                         root.handleFunctionCall(result.functionCall.name, result.functionCall.args, requester.message);
+                    }
+                    if (result.permissionRequest) {
+                        root.pendingCliPermission = result.permissionRequest;
                     }
                     if (result.tokenUsage) {
                         root.tokenCount.input = result.tokenUsage.input;
@@ -701,7 +777,22 @@ Singleton {
             }
         }
 
+        stderr: SplitParser {
+            onRead: data => {
+                if (data.length === 0) return;
+                // Show errors to user (useful for CLI)
+                if (requester.currentStrategy.isCli) {
+                    requester.message.thinking = false;
+                    requester.message.content += data + "\n";
+                    requester.message.rawContent += data + "\n";
+                } else {
+                    console.log("[Ai] Request stderr: ", data);
+                }
+            }
+        }
+
         onExited: (exitCode, exitStatus) => {
+            interruptKillTimer.stop();
             const result = requester.currentStrategy.onRequestFinished(requester.message);
             
             if (result.finished) {
@@ -714,6 +805,29 @@ Singleton {
             if (requester.message.content.includes("API key not valid")) {
                 root.addApiKeyAdvice(models[requester.message.model]);
             }
+
+            if (requester.restartOnExit) {
+                requester.restartOnExit = false;
+                requester.makeRequest();
+            }
+        }
+    }
+
+    Timer {
+        id: interruptKillTimer
+        interval: 3000
+        onTriggered: requester.running = false
+    }
+
+    function interrupt() {
+        // CLI strategies get a graceful stop first, so claude records the partial turn
+        // in its session; the timer (or a second press) hard-kills if it doesn't wind down
+        if (requester.running && !interruptKillTimer.running
+                && requester.currentStrategy.isCli) {
+            requester.write(requester.currentStrategy.buildInterruptRequest() + "\n");
+            interruptKillTimer.start();
+        } else {
+            requester.running = false;
         }
     }
 
@@ -759,15 +873,25 @@ Singleton {
         root.messageByID[id] = aiMessage;
     }
 
+    // CLI permission requests are answered over the running process's stdin
+    function answerCliPermission(allow: bool): bool {
+        if (!root.pendingCliPermission) return false;
+        requester.write(requester.currentStrategy.buildPermissionResponse(root.pendingCliPermission, allow) + "\n");
+        root.pendingCliPermission = null;
+        return true;
+    }
+
     function rejectCommand(message: AiMessageData) {
         if (!message.functionPending) return;
         message.functionPending = false; // User decided, no more "thinking"
+        if (answerCliPermission(false)) return;
         addFunctionOutputMessage(message.functionName, Translation.tr("Command rejected by user"))
     }
 
     function approveCommand(message: AiMessageData) {
         if (!message.functionPending) return;
         message.functionPending = false; // User decided, no more "thinking"
+        if (answerCliPermission(true)) return;
 
         const responseMessage = createFunctionOutputMessage(message.functionName, "", false);
         const id = idForMessage(responseMessage);
@@ -842,6 +966,7 @@ Singleton {
                 "fileUri": message.fileUri,
                 "localFilePath": message.localFilePath,
                 "model": message.model,
+                "cliSessionId": message.cliSessionId,
                 "thinking": false,
                 "done": true,
                 "annotations": message.annotations,
@@ -898,6 +1023,7 @@ Singleton {
                     "fileUri": message.fileUri,
                     "localFilePath": message.localFilePath,
                     "model": message.model,
+                    "cliSessionId": message.cliSessionId ?? "",
                     "thinking": message.thinking,
                     "done": message.done,
                     "annotations": message.annotations,

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -400,19 +400,32 @@ Singleton {
         }
     }
 
-    // Ids added by CLI/cache discovery, so the refresh only ever removes its own
-    // models and not user-configured claude-cli entries from extraModels
+    // Tracked separately so a refresh only ever removes models it added itself, and not
+    // user-configured claude-cli entries from extraModels
     property var claudeDiscoveredIds: []
 
-    function addClaudeModels(aliases) {
+    // ClaudeCli.aliases is authoritative whenever it changes, so an alias that is gone (a stale
+    // cache entry, an alias Anthropic retired, the CLI uninstalled) takes its model with it
+    function syncClaudeModels() {
+        const aliases = ClaudeCli.aliases;
         const ids = aliases.map(alias => "claude-" + root.safeModelName(alias));
-        root.claudeDiscoveredIds = [...new Set([...root.claudeDiscoveredIds, ...ids])];
-        aliases.forEach(alias => {
-            root.addModel("claude-" + root.safeModelName(alias), {
+        const stale = root.claudeDiscoveredIds.filter(id => !ids.includes(id));
+        if (stale.length > 0) {
+            const keptModels = {};
+            Object.keys(root.models).forEach(id => {
+                if (!stale.includes(id)) keptModels[id] = root.models[id];
+            });
+            root.models = keptModels;
+        }
+        root.claudeDiscoveredIds = ids;
+        aliases.forEach((alias, i) => {
+            root.addModel(ids[i], {
                 "name": "Claude " + CF.StringUtils.toTitleCase(alias),
                 "icon": "spark-symbolic",
                 "description": Translation.tr("Online | Claude Code CLI\nAnthropic's %1 model").arg(alias),
                 "homepage": "https://claude.com/claude-code",
+                // Never requested (finalizeScriptContent discards the curl line); it marks the
+                // model as online so the local-only policy in setModel() rejects it
                 "endpoint": "https://api.anthropic.com",
                 "model": alias,
                 "requires_key": false,
@@ -421,57 +434,10 @@ Singleton {
         });
     }
 
-    // Models appear instantly from the last run's cache; the CLI query refreshes it
-    // in the background (a cold `claude` start takes a few seconds)
-    FileView {
-        id: claudeModelsCache
-        path: Directories.claudeModelListCachePath
-        watchChanges: false
-        onLoadedChanged: {
-            if (!loaded || Config.options.policies.ai === 2) return;
-            try {
-                root.addClaudeModels(JSON.parse(claudeModelsCache.text()));
-            } catch (e) {
-                console.log("Could not load cached Claude CLI models:", e);
-            }
-        }
-    }
-
-    Process {
-        id: getClaudeModels
-        // The CLI runs locally but sends chats to Anthropic, so the local-only policy excludes it
-        running: Config.options.policies.ai !== 2
-        command: ["bash", "-c", "claude -p '/model' 2>/dev/null"]
-        stdout: StdioCollector {
-            onStreamFinished: {
-                if (Config.options.policies.ai === 2) return;
-                try {
-                    // Replies like "... Available: sonnet, opus, fable, default, or a full model ID."
-                    // No usable reply (claude missing, logged out, broken) yields an empty
-                    // list, dropping every discovered model through the same path below
-                    const aliases = (text.match(/Available: ([^\n]+)/)?.[1] ?? "").split(",")
-                        .map(alias => alias.trim().replace(/\.$/, ""))
-                        // Drops the trailing "or a full model ID" and meta aliases
-                        .filter(alias => alias.length > 0 && !alias.includes(" ")
-                            && !["default", "best", "opusplan"].includes(alias));
-                    // The CLI's list is authoritative: discovered models whose alias
-                    // no longer exists (e.g. stale cache entries) are dropped
-                    const freshIds = new Set(aliases.map(alias => "claude-" + root.safeModelName(alias)));
-                    const stale = root.claudeDiscoveredIds.filter(id => !freshIds.has(id));
-                    if (stale.length > 0) {
-                        const keptModels = {};
-                        Object.keys(root.models).forEach(id => {
-                            if (!stale.includes(id)) keptModels[id] = root.models[id];
-                        });
-                        root.models = keptModels;
-                    }
-                    root.claudeDiscoveredIds = Array.from(freshIds);
-                    root.addClaudeModels(aliases);
-                    claudeModelsCache.setText(JSON.stringify(aliases));
-                } catch (e) {
-                    console.log("Could not fetch Claude CLI models:", e);
-                }
-            }
+    Connections {
+        target: ClaudeCli
+        function onAliasesChanged() {
+            root.syncClaudeModels();
         }
     }
 
@@ -576,6 +542,16 @@ Singleton {
         return models[currentModelId];
     }
 
+    // No model is a reachable state: discovery can remove the selected one, and the local-only
+    // policy with no local models leaves the list empty
+    function requireModel() {
+        const model = models[currentModelId];
+        if (!model) {
+            root.addMessage(Translation.tr("No model selected. Pick one with `%1`").arg("/model"), root.interfaceRole);
+        }
+        return model ?? null;
+    }
+
     function setModel(modelId, feedback = true, setPersistentState = true) {
         if (!modelId) modelId = ""
         modelId = modelId.toLowerCase()
@@ -626,13 +602,13 @@ Singleton {
     }
 
     function setApiKey(key) {
-        const model = models[currentModelId];
+        const model = root.requireModel();
+        if (!model) return;
         if (!model.requires_key) {
             root.addMessage(Translation.tr("%1 does not require an API key").arg(model.name), Ai.interfaceRole);
             return;
         }
         if (!key || key.length === 0) {
-            const model = models[currentModelId];
             root.addApiKeyAdvice(model)
             return;
         }
@@ -641,7 +617,8 @@ Singleton {
     }
 
     function printApiKey() {
-        const model = models[currentModelId];
+        const model = root.requireModel();
+        if (!model) return;
         if (model.requires_key) {
             const key = root.apiKeys[model.key_id];
             if (key) {
@@ -702,10 +679,11 @@ Singleton {
                 return;
             }
             requester.restartOnExit = false;
-            const model = models[currentModelId];
+            const model = root.requireModel();
+            if (!model) return;
 
             // Fetch API keys if needed
-            if (model?.requires_key && !KeyringStorage.loaded) KeyringStorage.fetchKeyringData();
+            if (model.requires_key && !KeyringStorage.loaded) KeyringStorage.fetchKeyringData();
             
             requester.currentStrategy = root.currentApiStrategy;
             requester.currentStrategy.reset(); // Reset strategy state

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -958,19 +958,11 @@ Singleton {
     }
 
     // Rewrites the pending command fence (by pendingCommandIndex ordinal) in both
-    // content and rawContent. Empty-bodied fences are skipped so the ordinal counts
-    // the same fences splitMarkdownBlocks renders
+    // content and rawContent
     function editPendingCommandFence(message: AiMessageData, transform) {
         const index = message.pendingCommandIndex ?? -1;
-        if (index < 0) return;
-        const edit = content => {
-            let seen = 0;
-            return content.replace(/```command(?::[\w-]+)*\n([\s\S]*?)```/g,
-                (m, body) => body.trim().length === 0 ? m
-                    : (seen++ === index) ? transform(m) : m);
-        };
-        message.content = edit(message.content);
-        message.rawContent = edit(message.rawContent);
+        message.content = CF.StringUtils.editCommandFence(message.content, index, transform);
+        message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, index, transform);
     }
 
     // Rewrites the fence body to {questions, answers} and flags it :answered, so the
@@ -980,10 +972,16 @@ Singleton {
             + JSON.stringify({ questions: questions, answers: answers }) + "\n```");
     }
 
-    // Appends the :denied flag to the fence's info string, so the decision
-    // persists in the transcript and the block title renders it
+    // Replaces the fence's state token, so the decision persists in the transcript
+    // and the block title renders it
     function markCommandDenied(message: AiMessageData) {
-        editPendingCommandFence(message, m => m.replace(/\n/, ":denied\n"));
+        editPendingCommandFence(message, m => CF.StringUtils.withCommandFenceState(m, "denied"));
+    }
+
+    // Approval is the only thing standing between "pending" and the tool actually
+    // running; the result event takes it from there
+    function markCommandRunning(message: AiMessageData) {
+        editPendingCommandFence(message, m => CF.StringUtils.withCommandFenceState(m, "running"));
     }
 
     function rejectCommand(message: AiMessageData) {
@@ -999,7 +997,10 @@ Singleton {
     function approveCommand(message: AiMessageData) {
         if (!message.functionPending) return;
         message.functionPending = false; // User decided, no more "thinking"
-        if (answerCliPermission(true)) return;
+        if (answerCliPermission(true)) {
+            markCommandRunning(message);
+            return;
+        }
 
         const responseMessage = createFunctionOutputMessage(message.functionName, "", false);
         const id = idForMessage(responseMessage);

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -636,6 +636,9 @@ Singleton {
     }
 
     function clearMessages() {
+        if (requester.running) root.interrupt();
+        requester.restartOnExit = false;
+        root.pendingCliPermission = null;
         root.messageIDs = [];
         root.messageByID = ({});
         root.tokenCount.input = -1;

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -881,10 +881,26 @@ Singleton {
         return true;
     }
 
+    // Appends the :denied flag to the pending command fence's info string, so the
+    // decision persists in the transcript and the block title renders it
+    function markCommandDenied(message: AiMessageData) {
+        const index = message.pendingCommandIndex ?? -1;
+        if (index < 0) return;
+        let seen = 0;
+        const mark = content => content.replace(/```command((?::[\w-]+)*)\n/g,
+            m => (seen++ === index) ? m.replace(/\n$/, ":denied\n") : m);
+        message.content = mark(message.content);
+        seen = 0;
+        message.rawContent = mark(message.rawContent);
+    }
+
     function rejectCommand(message: AiMessageData) {
         if (!message.functionPending) return;
         message.functionPending = false; // User decided, no more "thinking"
-        if (answerCliPermission(false)) return;
+        if (answerCliPermission(false)) {
+            markCommandDenied(message);
+            return;
+        }
         addFunctionOutputMessage(message.functionName, Translation.tr("Command rejected by user"))
     }
 

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -863,6 +863,9 @@ Singleton {
     }
 
     function interrupt() {
+        // A pending permission blocks the turn, so decline it first; otherwise the tool
+        // call is left unanswered in claude's session and the fence renders half-asked
+        if (root.pendingCliPermission) root.rejectCommand(requester.message);
         // CLI strategies get a graceful stop first, so claude records the partial turn
         // in its session; the timer (or a second press) hard-kills if it doesn't wind down
         if (requester.running && !interruptKillTimer.running
@@ -948,13 +951,6 @@ Singleton {
         message.functionPending = false;
         markQuestionAnswered(message, questions, updatedInput.answers);
         answerCliPermission(true, updatedInput);
-    }
-
-    // Declines the whole question set; the model continues with no answers
-    function dismissQuestions(message: AiMessageData) {
-        if (!message.functionPending) return;
-        message.functionPending = false;
-        if (answerCliPermission(false)) markCommandDenied(message);
     }
 
     // Rewrites the pending command fence (by pendingCommandIndex ordinal) in both

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -416,7 +416,7 @@ Singleton {
                         root.addModel("claude-" + root.safeModelName(alias), {
                             "name": "Claude " + CF.StringUtils.toTitleCase(alias),
                             "icon": "spark-symbolic",
-                            "description": Translation.tr("Local CLI | Anthropic's %1 model via the Claude Code CLI").arg(alias),
+                            "description": Translation.tr("Online | Claude Code CLI\nAnthropic's %1 model").arg(alias),
                             "homepage": "https://claude.com/claude-code",
                             "endpoint": "https://api.anthropic.com",
                             "model": alias,

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -372,7 +372,6 @@ Singleton {
                 try {
                     if (data.length === 0) return;
                     const dataJson = JSON.parse(data);
-                    root.modelList = [...root.modelList, ...dataJson];
                     dataJson.forEach(model => {
                         const safeModelName = root.safeModelName(model);
                         root.addModel(safeModelName, {
@@ -386,11 +385,46 @@ Singleton {
                         })
                     });
 
-                    root.modelList = Object.keys(root.models);
-
                 } catch (e) {
                     console.log("Could not fetch Ollama models:", e);
                 }
+            }
+        }
+    }
+
+    // Ids added by CLI/cache discovery, so the refresh only ever removes its own
+    // models and not user-configured claude-cli entries from extraModels
+    property var claudeDiscoveredIds: []
+
+    function addClaudeModels(aliases) {
+        const ids = aliases.map(alias => "claude-" + root.safeModelName(alias));
+        root.claudeDiscoveredIds = [...new Set([...root.claudeDiscoveredIds, ...ids])];
+        aliases.forEach(alias => {
+            root.addModel("claude-" + root.safeModelName(alias), {
+                "name": "Claude " + CF.StringUtils.toTitleCase(alias),
+                "icon": "spark-symbolic",
+                "description": Translation.tr("Online | Claude Code CLI\nAnthropic's %1 model").arg(alias),
+                "homepage": "https://claude.com/claude-code",
+                "endpoint": "https://api.anthropic.com",
+                "model": alias,
+                "requires_key": false,
+                "api_format": "claude-cli",
+            });
+        });
+    }
+
+    // Models appear instantly from the last run's cache; the CLI query refreshes it
+    // in the background (a cold `claude` start takes a few seconds)
+    FileView {
+        id: claudeModelsCache
+        path: Directories.claudeModelListCachePath
+        watchChanges: false
+        onLoadedChanged: {
+            if (!loaded || Config.options.policies.ai === 2) return;
+            try {
+                root.addClaudeModels(JSON.parse(claudeModelsCache.text()));
+            } catch (e) {
+                console.log("Could not load cached Claude CLI models:", e);
             }
         }
     }
@@ -405,26 +439,27 @@ Singleton {
                 if (Config.options.policies.ai === 2) return;
                 try {
                     // Replies like "... Available: sonnet, opus, fable, default, or a full model ID."
-                    const match = text.match(/Available: ([^\n]+)/);
-                    if (!match) return;
-                    const aliases = match[1].split(",")
+                    // No usable reply (claude missing, logged out, broken) yields an empty
+                    // list, dropping every discovered model through the same path below
+                    const aliases = (text.match(/Available: ([^\n]+)/)?.[1] ?? "").split(",")
                         .map(alias => alias.trim().replace(/\.$/, ""))
                         // Drops the trailing "or a full model ID" and meta aliases
                         .filter(alias => alias.length > 0 && !alias.includes(" ")
                             && !["default", "best", "opusplan"].includes(alias));
-                    aliases.forEach(alias => {
-                        root.addModel("claude-" + root.safeModelName(alias), {
-                            "name": "Claude " + CF.StringUtils.toTitleCase(alias),
-                            "icon": "spark-symbolic",
-                            "description": Translation.tr("Online | Claude Code CLI\nAnthropic's %1 model").arg(alias),
-                            "homepage": "https://claude.com/claude-code",
-                            "endpoint": "https://api.anthropic.com",
-                            "model": alias,
-                            "requires_key": false,
-                            "api_format": "claude-cli",
+                    // The CLI's list is authoritative: discovered models whose alias
+                    // no longer exists (e.g. stale cache entries) are dropped
+                    const freshIds = new Set(aliases.map(alias => "claude-" + root.safeModelName(alias)));
+                    const stale = root.claudeDiscoveredIds.filter(id => !freshIds.has(id));
+                    if (stale.length > 0) {
+                        const keptModels = {};
+                        Object.keys(root.models).forEach(id => {
+                            if (!stale.includes(id)) keptModels[id] = root.models[id];
                         });
-                    });
-                    root.modelList = Object.keys(root.models);
+                        root.models = keptModels;
+                    }
+                    root.claudeDiscoveredIds = Array.from(freshIds);
+                    root.addClaudeModels(aliases);
+                    claudeModelsCache.setText(JSON.stringify(aliases));
                 } catch (e) {
                     console.log("Could not fetch Claude CLI models:", e);
                 }

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -1031,8 +1031,7 @@ Singleton {
                 addFunctionOutputMessage(name, Translation.tr("Invalid arguments. Must provide `command`."));
                 return;
             }
-            message.pendingCommandIndex = CF.StringUtils.splitMarkdownBlocks(message.content)
-                .filter(b => b.type === "code" && b.lang?.split(":")[0] === "command").length;
+            message.pendingCommandIndex = CF.StringUtils.commandFences(message.content).length;
             const contentToAppend = `\n\n**${Translation.tr("Command execution request")}**\n\n\`\`\`command\n${args.command}\n\`\`\``;
             message.rawContent += contentToAppend;
             message.content += contentToAppend;

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -927,7 +927,7 @@ Singleton {
         const updatedInput = requester.currentStrategy.buildQuestionAnswers(
             questions, root.questionSelections);
         message.functionPending = false;
-        markQuestionAnswered(message, questions, updatedInput.answers);
+        markQuestionAnswered(message, questions, root.questionSelections);
         answerCliPermission(true, updatedInput);
     }
 
@@ -939,11 +939,11 @@ Singleton {
         message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, index, transform);
     }
 
-    // Rewrites the fence body to {questions, answers} and flags it :answered, so the
+    // Rewrites the fence body to {questions, selections} and flags it :answered, so the
     // transcript renders the chosen answers instead of a stale interactive card
-    function markQuestionAnswered(message: AiMessageData, questions, answers) {
+    function markQuestionAnswered(message: AiMessageData, questions, selections) {
         editPendingCommandFence(message, () => "```command:AskUserQuestion:answered\n"
-            + JSON.stringify({ questions: questions, answers: answers }) + "\n```");
+            + JSON.stringify({ questions: questions, selections: selections }) + "\n```");
     }
 
     // Replaces the fence's state token, so the decision persists in the transcript

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -949,7 +949,7 @@ Singleton {
                 return;
             }
             message.pendingCommandIndex = CF.StringUtils.splitMarkdownBlocks(message.content)
-                .filter(b => b.type === "code" && b.lang === "command").length;
+                .filter(b => b.type === "code" && b.lang?.split(":")[0] === "command").length;
             const contentToAppend = `\n\n**${Translation.tr("Command execution request")}**\n\n\`\`\`command\n${args.command}\n\`\`\``;
             message.rawContent += contentToAppend;
             message.content += contentToAppend;

--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -53,6 +53,14 @@ Singleton {
     readonly property bool busy: requester.running
     // Pending CLI tool-permission request awaiting user approval: {requestId, input}
     property var pendingCliPermission: null
+    // Questions of a pending AskUserQuestion call. Selections hold each question's
+    // picked labels (or free text); the set submits as one permission response when
+    // the user hits Submit, and questions left unselected are skipped.
+    readonly property var pendingQuestions: pendingCliPermission?.input?.questions ?? null
+    property var questionSelections: ({})
+    onPendingCliPermissionChanged: {
+        questionSelections = ({});
+    }
     property var postResponseHook
     property real temperature: Persistent.states?.ai?.temperature ?? 0.5
     property QtObject tokenCount: QtObject {
@@ -909,24 +917,73 @@ Singleton {
     }
 
     // CLI permission requests are answered over the running process's stdin
-    function answerCliPermission(allow: bool): bool {
+    function answerCliPermission(allow, updatedInput): bool {
         if (!root.pendingCliPermission) return false;
-        requester.write(requester.currentStrategy.buildPermissionResponse(root.pendingCliPermission, allow) + "\n");
+        requester.write(requester.currentStrategy.buildPermissionResponse(root.pendingCliPermission, allow, updatedInput) + "\n");
         root.pendingCliPermission = null;
         return true;
     }
 
-    // Appends the :denied flag to the pending command fence's info string, so the
-    // decision persists in the transcript and the block title renders it
-    function markCommandDenied(message: AiMessageData) {
+    // multiSelect chip toggle: adds/removes one label in the question's pick list
+    function toggleQuestionOption(question: string, label: string) {
+        const list = (root.questionSelections[question] ?? []).slice();
+        const i = list.indexOf(label);
+        if (i >= 0) list.splice(i, 1); else list.push(label);
+        setQuestionSelection(question, list);
+    }
+
+    function setQuestionSelection(question: string, labels: list<string>) {
+        const selections = Object.assign({}, root.questionSelections);
+        selections[question] = labels;
+        root.questionSelections = selections;
+    }
+
+    // Sends the one permission response for the whole question set; the strategy
+    // encodes the answers, omitting (skipping) questions with no selection
+    function submitQuestions(message: AiMessageData) {
+        if (!message.functionPending || !root.pendingQuestions) return;
+        const questions = root.pendingQuestions;
+        const updatedInput = requester.currentStrategy.buildQuestionAnswers(
+            questions, root.questionSelections);
+        message.functionPending = false;
+        markQuestionAnswered(message, questions, updatedInput.answers);
+        answerCliPermission(true, updatedInput);
+    }
+
+    // Declines the whole question set; the model continues with no answers
+    function dismissQuestions(message: AiMessageData) {
+        if (!message.functionPending) return;
+        message.functionPending = false;
+        if (answerCliPermission(false)) markCommandDenied(message);
+    }
+
+    // Rewrites the pending command fence (by pendingCommandIndex ordinal) in both
+    // content and rawContent. Empty-bodied fences are skipped so the ordinal counts
+    // the same fences splitMarkdownBlocks renders
+    function editPendingCommandFence(message: AiMessageData, transform) {
         const index = message.pendingCommandIndex ?? -1;
         if (index < 0) return;
-        let seen = 0;
-        const mark = content => content.replace(/```command((?::[\w-]+)*)\n/g,
-            m => (seen++ === index) ? m.replace(/\n$/, ":denied\n") : m);
-        message.content = mark(message.content);
-        seen = 0;
-        message.rawContent = mark(message.rawContent);
+        const edit = content => {
+            let seen = 0;
+            return content.replace(/```command(?::[\w-]+)*\n([\s\S]*?)```/g,
+                (m, body) => body.trim().length === 0 ? m
+                    : (seen++ === index) ? transform(m) : m);
+        };
+        message.content = edit(message.content);
+        message.rawContent = edit(message.rawContent);
+    }
+
+    // Rewrites the fence body to {questions, answers} and flags it :answered, so the
+    // transcript renders the chosen answers instead of a stale interactive card
+    function markQuestionAnswered(message: AiMessageData, questions, answers) {
+        editPendingCommandFence(message, () => "```command:AskUserQuestion:answered\n"
+            + JSON.stringify({ questions: questions, answers: answers }) + "\n```");
+    }
+
+    // Appends the :denied flag to the fence's info string, so the decision
+    // persists in the transcript and the block title renders it
+    function markCommandDenied(message: AiMessageData) {
+        editPendingCommandFence(message, m => m.replace(/\n/, ":denied\n"));
     }
 
     function rejectCommand(message: AiMessageData) {

--- a/dots/.config/quickshell/ii/services/DateTime.qml
+++ b/dots/.config/quickshell/ii/services/DateTime.qml
@@ -2,6 +2,7 @@ pragma Singleton
 pragma ComponentBehavior: Bound
 import qs
 import qs.modules.common
+import qs.modules.common.functions
 import QtQuick
 import Quickshell
 import Quickshell.Io
@@ -33,21 +34,7 @@ Singleton {
             fileUptime.reload();
             const textUptime = fileUptime.text();
             const uptimeSeconds = Number(textUptime.split(" ")[0] ?? 0);
-
-            // Convert seconds to days, hours, and minutes
-            const days = Math.floor(uptimeSeconds / 86400);
-            const hours = Math.floor((uptimeSeconds % 86400) / 3600);
-            const minutes = Math.floor((uptimeSeconds % 3600) / 60);
-
-            // Build the formatted uptime string
-            let formatted = "";
-            if (days > 0)
-                formatted += `${days}d`;
-            if (hours > 0)
-                formatted += `${formatted ? ", " : ""}${hours}h`;
-            if (minutes > 0 || !formatted)
-                formatted += `${formatted ? ", " : ""}${minutes}m`;
-            uptime = formatted;
+            uptime = StringUtils.friendlyDurationForSeconds(uptimeSeconds, false);
             interval = Config.options?.resources?.updateInterval ?? 3000;
         }
     }

--- a/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
+++ b/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
@@ -16,6 +16,7 @@ QtObject {
     property var annotations: []
     property var annotationSources: []
     property list<string> searchQueries: []
+    property string cliSessionId
     property string functionName
     property var functionCall
     property string functionResponse

--- a/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
+++ b/dots/.config/quickshell/ii/services/ai/AiMessageData.qml
@@ -21,5 +21,7 @@ QtObject {
     property var functionCall
     property string functionResponse
     property bool functionPending: false
+    // Ordinal (among the message's ```command fences) of the one awaiting approval
+    property int pendingCommandIndex: -1
     property bool visibleToUser: true
 }

--- a/dots/.config/quickshell/ii/services/ai/ApiStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ApiStrategy.qml
@@ -1,6 +1,8 @@
 import QtQuick
 
 QtObject {
+    // CLI strategies run a local process fed over stdin (buildStdinPayload etc.) instead of curl
+    property bool isCli: false
     function buildEndpoint(model: AiModel): string { throw new Error("Not implemented") }
     function buildRequestData(model: AiModel, messages, systemPrompt: string, temperature: real, tools: list<var>, filePath: string) { throw new Error("Not implemented") }
     function buildAuthorizationHeader(apiKeyEnvVarName: string): string { throw new Error("Not implemented") }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCli.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCli.qml
@@ -1,0 +1,87 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+/**
+ * Model aliases offered by the local Claude Code CLI.
+ * Fetched through /models
+ */
+Singleton {
+    id: root
+
+    property var aliases: []
+
+    // The CLI runs locally but sends chats to Anthropic, so the local-only policy excludes it
+    readonly property bool allowed: Config.options.policies.ai !== 2
+
+    function forget() {
+        cache.setText("[]");
+        root.aliases = [];
+    }
+
+    // Aliases come back instantly from the last run's cache; the CLI query refreshes them
+    // in the background (a cold `claude` start takes a few seconds)
+    FileView {
+        id: cache
+        path: Directories.claudeModelListCachePath
+        watchChanges: false
+        onLoadedChanged: {
+            if (!loaded || !root.allowed) return;
+            try {
+                root.aliases = JSON.parse(cache.text());
+            } catch (e) {
+                console.log("Could not load cached Claude CLI models:", e);
+            }
+        }
+    }
+
+    Process {
+        id: checkAuth
+        running: root.allowed
+        // `command -v` first, so a missing CLI is 127 and not whatever claude itself exited with
+        command: ["bash", "-c", "command -v claude >/dev/null || exit 127; claude auth status --json"]
+        stdout: StdioCollector { id: authOutput }
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 127) { // Not installed
+                root.forget();
+                return;
+            }
+            if (exitCode !== 0) return;
+            let loggedIn;
+            try {
+                loggedIn = JSON.parse(authOutput.text).loggedIn;
+            } catch (e) {
+                console.log("Could not read Claude CLI auth status:", e);
+                return;
+            }
+            if (loggedIn) queryModels.running = true;
+            else root.forget();
+        }
+    }
+
+    Process {
+        id: queryModels
+        // Started by checkAuth, so a logged-out user never pays for a cold `claude` start
+        command: ["bash", "-c", "claude -p '/model'"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                // Replies like "... Available: sonnet, opus, fable, default, or a full model ID."
+                const found = (text.match(/Available: ([^\n]+)/)?.[1] ?? "").split(",")
+                    .map(alias => alias.trim().replace(/\.$/, ""))
+                    // Drops the trailing "or a full model ID" and meta aliases
+                    .filter(alias => alias.length > 0 && !alias.includes(" ")
+                        && !["default", "best", "opusplan"].includes(alias));
+                if (found.length === 0) {
+                    console.log("Could not read the Claude CLI model list");
+                    return;
+                }
+                root.aliases = found;
+                cache.setText(JSON.stringify(found));
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -65,6 +65,10 @@ ApiStrategy {
     }
 
     function buildPermissionResponse(permissionRequest, allow, updatedInput): string {
+        // A denial still comes back as an error tool_result; recording the decision here
+        // stops that result from relabelling the fence as failed
+        const tool = pendingTools[permissionRequest.toolUseId];
+        if (tool) tool.state = allow ? "running" : "denied";
         return JSON.stringify({
             type: "control_response",
             response: {
@@ -122,6 +126,7 @@ ApiStrategy {
             name: name,
             inputJson: "",
             open: true,
+            state: "running",
             ordinal: commandFenceCount(message.content),
             fenceStart: message.content.length,
             rawFenceStart: message.rawContent.length,
@@ -134,9 +139,17 @@ ApiStrategy {
     // Valid only while the fence is the message tail: from registerTool until the
     // block's stop event (tool.open), plus the stop event's own final rewrite
     function rewriteFence(message, tool) {
-        const fence = `\n\n\`\`\`command:${tool.name}\n${commandSummary(tool)}\n\`\`\`\n\n`;
+        const fence = `\n\n\`\`\`command:${tool.name}:${tool.state}\n${commandSummary(tool)}\n\`\`\`\n\n`;
         message.content = message.content.slice(0, tool.fenceStart) + fence;
         message.rawContent = message.rawContent.slice(0, tool.rawFenceStart) + fence;
+    }
+
+    // Results land after the block's stop event, by which point the fence is no longer
+    // the message tail, so the state token is swapped in place by ordinal instead
+    function setFenceState(message, tool) {
+        const swap = fence => CF.StringUtils.withCommandFenceState(fence, tool.state);
+        message.content = CF.StringUtils.editCommandFence(message.content, tool.ordinal, swap);
+        message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, tool.ordinal, swap);
     }
 
     function commandSummary(tool) {
@@ -220,20 +233,45 @@ ApiStrategy {
                 return {};
             }
 
+            // Tool results ride on "user" lines and settle the fence's state
+            if (dataJson.type === "user") {
+                const blocks = dataJson.message?.content;
+                if (Array.isArray(blocks)) {
+                    for (const block of blocks) {
+                        if (block.type !== "tool_result") continue;
+                        const tool = pendingTools[block.tool_use_id];
+                        // AskUserQuestion keeps its own delegate and :answered end state
+                        if (!tool || tool.state !== "running" || tool.name === "AskUserQuestion") continue;
+                        tool.state = block.is_error ? "failed" : "done";
+                        setFenceState(message, tool);
+                    }
+                }
+                return {};
+            }
+
             if (dataJson.type === "control_request") {
                 const request = dataJson.request ?? {};
                 if (request.subtype === "can_use_tool") {
                     let tool = pendingTools[request.tool_use_id];
                     if (!tool) tool = registerTool(request.tool_use_id, request.tool_name ?? "", message);
+                    // Nothing runs until the user decides; tools that need no approval
+                    // never reach here and stay "running"
+                    tool.state = "pending";
                     if (tool.open) {
                         // The request can beat the block's stop event; its input is authoritative
                         tool.input = request.input ?? {};
                         rewriteFence(message, tool);
+                    } else {
+                        setFenceState(message, tool);
                     }
                     message.pendingCommandIndex = tool.ordinal;
                     message.functionName = request.tool_name ?? "";
                     message.functionPending = true;
-                    return { permissionRequest: { requestId: dataJson.request_id, input: request.input ?? {} } };
+                    return { permissionRequest: {
+                        requestId: dataJson.request_id,
+                        toolUseId: request.tool_use_id ?? "",
+                        input: request.input ?? {}
+                    } };
                 }
                 return {};
             }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -293,6 +293,17 @@ ApiStrategy {
             inThinkingBlock = false;
             appendContent(message, "\n</think>\n\n");
         }
+        // An interrupt can also land mid-input, before the tool ever asked for approval, leaving a
+        // fence claiming to still be streaming for good. Stopping the turn refuses it; ending any
+        // other way means it never got to run
+        const leftover = interruptRequested ? "denied" : "failed";
+        Object.keys(pendingTools).forEach(id => {
+            const tool = pendingTools[id];
+            if (tool.state !== "streaming") return;
+            tool.state = leftover;
+            if (tool.open) rewriteFence(message, tool);
+            else setFenceState(message, tool);
+        });
         return {};
     }
 

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import qs.services
 import qs.modules.common.functions as CF
 
 /**
@@ -11,7 +12,11 @@ ApiStrategy {
     // The request captured by buildRequestData: {model, messages, systemPrompt, filePath, sessionId}
     property var pendingRequest: null
     property bool inThinkingBlock: false
-    property bool inToolBlock: false
+    // Tool calls are buffered while streaming and rendered once: on the permission
+    // request, or on the tool result for auto-approved ones. Entries are registered at
+    // content_block_start because the permission request can beat the block's stop event
+    property string currentToolId: ""
+    property var pendingTools: ({})
     property bool interruptRequested: false
 
     function buildEndpoint(model: AiModel): string { return "" }
@@ -93,6 +98,17 @@ ApiStrategy {
         message.rawContent += text;
     }
 
+    function appendCommandFence(message, name, input, requestApproval) {
+        if (requestApproval) {
+            // The same splitter the renderer uses, so the ordinal can't desync from it
+            message.pendingCommandIndex = CF.StringUtils.splitMarkdownBlocks(message.content)
+                .filter(b => b.type === "code" && b.lang === "command").length;
+        }
+        const header = requestApproval ? `**${Translation.tr("Command execution request")}**\n\n` : "";
+        const summary = input?.command ?? JSON.stringify(input ?? {});
+        appendContent(message, `\n\n${header}\`\`\`command\n${name}: ${summary}\n\`\`\`\n\n`);
+    }
+
     function parseResponseLine(line, message) {
         try {
             const dataJson = JSON.parse(line);
@@ -111,10 +127,8 @@ ApiStrategy {
                         inThinkingBlock = true;
                         appendContent(message, "\n\n<think>\n");
                     } else if (block.type === "tool_use") {
-                        // No buttons appear: they are gated on functionPending, which
-                        // only a permission control_request sets
-                        inToolBlock = true;
-                        appendContent(message, `\n\n\`\`\`command\n${block.name}: `);
+                        currentToolId = block.id ?? "";
+                        pendingTools[currentToolId] = { name: block.name ?? "", inputJson: "" };
                     }
                 } else if (event.type === "content_block_delta") {
                     const delta = event.delta ?? {};
@@ -122,16 +136,36 @@ ApiStrategy {
                         appendContent(message, delta.text ?? "");
                     } else if (delta.type === "thinking_delta") {
                         appendContent(message, delta.thinking ?? "");
-                    } else if (delta.type === "input_json_delta" && inToolBlock) {
-                        appendContent(message, delta.partial_json ?? "");
+                    } else if (delta.type === "input_json_delta") {
+                        const tool = pendingTools[currentToolId];
+                        if (tool) tool.inputJson += delta.partial_json ?? "";
                     }
                 } else if (event.type === "content_block_stop") {
                     if (inThinkingBlock) {
                         inThinkingBlock = false;
                         appendContent(message, "\n</think>\n\n");
-                    } else if (inToolBlock) {
-                        inToolBlock = false;
-                        appendContent(message, "\n```\n\n");
+                    } else {
+                        const tool = pendingTools[currentToolId];
+                        if (tool) {
+                            try { tool.input = JSON.parse(tool.inputJson); } catch (e) {}
+                        }
+                        currentToolId = "";
+                    }
+                }
+                return {};
+            }
+
+            // A tool result is the first sign an auto-approved call ran; gated calls
+            // already rendered their fence with the permission request
+            if (dataJson.type === "user") {
+                const blocks = dataJson.message?.content;
+                if (Array.isArray(blocks)) {
+                    for (const block of blocks) {
+                        if (block.type !== "tool_result") continue;
+                        const tool = pendingTools[block.tool_use_id];
+                        if (!tool) continue;
+                        delete pendingTools[block.tool_use_id];
+                        appendCommandFence(message, tool.name, tool.input, false);
                     }
                 }
                 return {};
@@ -140,10 +174,9 @@ ApiStrategy {
             if (dataJson.type === "control_request") {
                 const request = dataJson.request ?? {};
                 if (request.subtype === "can_use_tool") {
-                    const inputSummary = request.input?.command
-                        ?? JSON.stringify(request.input ?? {});
-                    // The ```command fence triggers the chat's approve/reject buttons
-                    appendContent(message, `\n\n**Command execution request**\n\n\`\`\`command\n${request.tool_name}: ${inputSummary}\n\`\`\``);
+                    // This call's fence renders here; its tool result must not render another
+                    delete pendingTools[request.tool_use_id];
+                    appendCommandFence(message, request.tool_name ?? "", request.input ?? {}, true);
                     message.functionName = request.tool_name ?? "";
                     message.functionPending = true;
                     return { permissionRequest: { requestId: dataJson.request_id, input: request.input ?? {} } };
@@ -186,17 +219,14 @@ ApiStrategy {
             inThinkingBlock = false;
             appendContent(message, "\n</think>\n\n");
         }
-        if (inToolBlock) {
-            inToolBlock = false;
-            appendContent(message, "\n```\n\n");
-        }
         return {};
     }
 
     function reset() {
         pendingRequest = null;
         inThinkingBlock = false;
-        inToolBlock = false;
+        currentToolId = "";
+        pendingTools = ({});
         interruptRequested = false;
     }
 }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -11,6 +11,7 @@ ApiStrategy {
     // The request captured by buildRequestData: {model, messages, systemPrompt, filePath, sessionId}
     property var pendingRequest: null
     property bool inThinkingBlock: false
+    property bool inToolBlock: false
     property bool interruptRequested: false
 
     function buildEndpoint(model: AiModel): string { return "" }
@@ -110,7 +111,10 @@ ApiStrategy {
                         inThinkingBlock = true;
                         appendContent(message, "\n\n<think>\n");
                     } else if (block.type === "tool_use") {
-                        appendContent(message, `\n\n<think>\nRunning \`${block.name}\`\n</think>\n\n`);
+                        // No buttons appear: they are gated on functionPending, which
+                        // only a permission control_request sets
+                        inToolBlock = true;
+                        appendContent(message, `\n\n\`\`\`command\n${block.name}: `);
                     }
                 } else if (event.type === "content_block_delta") {
                     const delta = event.delta ?? {};
@@ -118,10 +122,17 @@ ApiStrategy {
                         appendContent(message, delta.text ?? "");
                     } else if (delta.type === "thinking_delta") {
                         appendContent(message, delta.thinking ?? "");
+                    } else if (delta.type === "input_json_delta" && inToolBlock) {
+                        appendContent(message, delta.partial_json ?? "");
                     }
-                } else if (event.type === "content_block_stop" && inThinkingBlock) {
-                    inThinkingBlock = false;
-                    appendContent(message, "\n</think>\n\n");
+                } else if (event.type === "content_block_stop") {
+                    if (inThinkingBlock) {
+                        inThinkingBlock = false;
+                        appendContent(message, "\n</think>\n\n");
+                    } else if (inToolBlock) {
+                        inToolBlock = false;
+                        appendContent(message, "\n```\n\n");
+                    }
                 }
                 return {};
             }
@@ -175,12 +186,17 @@ ApiStrategy {
             inThinkingBlock = false;
             appendContent(message, "\n</think>\n\n");
         }
+        if (inToolBlock) {
+            inToolBlock = false;
+            appendContent(message, "\n```\n\n");
+        }
         return {};
     }
 
     function reset() {
         pendingRequest = null;
         inThinkingBlock = false;
+        inToolBlock = false;
         interruptRequested = false;
     }
 }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -153,32 +153,11 @@ ApiStrategy {
         message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, tool.ordinal, swap);
     }
 
+    // Tools that take a command show it as the fence body; the rest show their whole input,
+    // so the body stays valid JSON for delegates that parse it back
     function commandSummary(tool) {
-        if (tool.input !== undefined) return tool.input?.command ?? JSON.stringify(tool.input ?? {});
-        return partialStringField(tool.inputJson, "command") ?? tool.inputJson;
-    }
-
-    // Value of a string field in incomplete JSON, tolerating a cut mid-escape
-    function partialStringField(json, field) {
-        const start = json.match(new RegExp(`"${field}"\\s*:\\s*"`));
-        if (!start) return null;
-        let out = "";
-        for (let i = start.index + start[0].length; i < json.length; i++) {
-            const c = json[i];
-            if (c === '"') break;
-            if (c !== '\\') { out += c; continue; }
-            const esc = json[++i];
-            if (esc === undefined) break;
-            if (esc === 'n') out += '\n';
-            else if (esc === 't') out += '\t';
-            else if (esc === 'u') {
-                const hex = json.slice(i + 1, i + 5);
-                if (hex.length < 4) break;
-                out += String.fromCharCode(parseInt(hex, 16));
-                i += 4;
-            } else out += esc;
-        }
-        return out;
+        const input = tool.input ?? CF.StringUtils.parsePartialJson(tool.inputJson) ?? {};
+        return input.command ?? JSON.stringify(input);
     }
 
     function parseResponseLine(line, message) {

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -92,10 +92,16 @@ ApiStrategy {
     function buildPermissionResponse(permissionRequest, allow, updatedInput): string {
         // A denial still comes back as an error tool_result; recording the decision here
         // stops that result from relabelling the fence as failed
+        // A question is spent once answered, never run: leaving it "running" would have the
+        // turn's own cleanup rewrite the fence the service just filled with the answers
         const tool = pendingTools[permissionRequest.toolUseId];
         if (tool) {
-            tool.state = allow ? "running" : "denied";
-            if (allow) tool.startedAt = Date.now();
+            if (!allow) tool.state = "denied";
+            else if (tool.name === "AskUserQuestion") tool.state = "answered";
+            else {
+                tool.state = "running";
+                tool.startedAt = Date.now();
+            }
         }
         return JSON.stringify({
             type: "control_response",

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -156,8 +156,10 @@ ApiStrategy {
     // Tools that take a command show it as the fence body; the rest show their whole input,
     // so the body stays valid JSON for delegates that parse it back
     function commandSummary(tool) {
-        const input = tool.input ?? CF.StringUtils.parsePartialJson(tool.inputJson) ?? {};
-        return input.command ?? JSON.stringify(input);
+        const input = tool.input ?? CF.StringUtils.parsePartialJson(tool.inputJson);
+        if (!input) return tool.lastSummary ?? "{}";
+        tool.lastSummary = input.command ?? JSON.stringify(input);
+        return tool.lastSummary;
     }
 
     function parseResponseLine(line, message) {

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -103,7 +103,8 @@ ApiStrategy {
         }
         if (request.sessionId.length > 0) {
             command += ` --resume '${CF.StringUtils.shellSingleQuoteEscape(request.sessionId)}'`;
-        } else if (request.systemPrompt.length > 0) {
+        }
+        if (request.systemPrompt.length > 0) {
             command += ` --append-system-prompt '${CF.StringUtils.shellSingleQuoteEscape(request.systemPrompt)}'`;
         }
         // exec so the stop button's kill reaches claude itself, not just the wrapping bash

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -22,6 +22,8 @@ ApiStrategy {
     // The permission request can trail the block's stop, so each tool waits out its own delay
     // before taking the label; one that settles inside the delay never shows it at all
     property int promotionDelay: 150
+    // Kept small: the whole log is laid out at once when expanded, and it is saved with the chat
+    property int maxOutputLines: 200
     property var promotionQueue: []
     property var promotionMessage: null
     property Timer promotionTimer: Timer {
@@ -34,6 +36,7 @@ ApiStrategy {
                 const tool = pendingTools[entry.id];
                 if (tool && tool.state === "streaming") {
                     tool.state = "running";
+                    tool.startedAt = now;
                     rewriteFence(promotionMessage, tool);
                 }
                 return false;
@@ -90,7 +93,10 @@ ApiStrategy {
         // A denial still comes back as an error tool_result; recording the decision here
         // stops that result from relabelling the fence as failed
         const tool = pendingTools[permissionRequest.toolUseId];
-        if (tool) tool.state = allow ? "running" : "denied";
+        if (tool) {
+            tool.state = allow ? "running" : "denied";
+            if (allow) tool.startedAt = Date.now();
+        }
         return JSON.stringify({
             type: "control_response",
             response: {
@@ -153,7 +159,46 @@ ApiStrategy {
     }
 
     function fenceText(tool) {
-        return `\`\`\`command:${tool.name}:${tool.state}\n${commandSummary(tool)}\n\`\`\``;
+        return `\`\`\`command:${tool.name}:${tool.state}${timingToken(tool)}\n${commandSummary(tool)}${outputSection(tool)}\n\`\`\``;
+    }
+
+    // When it started while it runs, how long it took once it is over. Carried in the info
+    // string because the delegate is rebuilt on every rewrite, so a clock it started itself
+    // would restart with it. Neither token is a state or the tool name, so the fence still
+    // parses as before
+    function timingToken(tool) {
+        if (tool.elapsedSeconds !== undefined) return `:d${tool.elapsedSeconds}`;
+        if (tool.startedAt !== undefined) return `:t${tool.startedAt}`;
+        return "";
+    }
+
+    // Backtick runs in output would close the fence early and shift every later ordinal, so
+    // they get an invisible break; a separator of its own would do the same to the split
+    function outputSection(tool) {
+        if (!(tool.output?.length > 0)) return "";
+        const safe = tool.output
+            .replace(new RegExp(CF.StringUtils.commandOutputSeparator, "g"), "")
+            .replace(/```/g, "``\u200b`");
+        return `\n${CF.StringUtils.commandOutputSeparator}\n${safe}`;
+    }
+
+    function captureTiming(tool) {
+        if (tool.startedAt === undefined) return;
+        tool.elapsedSeconds = Math.floor((Date.now() - tool.startedAt) / 1000);
+    }
+
+    function captureOutput(tool, block) {
+        if (tool.name !== "Bash" && !block.is_error) return;
+        const content = block.content;
+        const text = Array.isArray(content)
+            ? content.filter(part => part.type === "text").map(part => part.text).join("\n")
+            : (content ?? "");
+        // Kept as the command printed it, blank lines and all; only the length is bounded,
+        // and whatever went wrong is at the end, so the head is what a long log loses
+        const lines = String(text).split("\n");
+        const kept = lines.slice(-maxOutputLines);
+        if (kept.length < lines.length) kept.unshift("…");
+        tool.output = kept.join("\n");
     }
 
     // By ordinal rather than by offset: a fence settling earlier in the message shifts
@@ -246,6 +291,8 @@ ApiStrategy {
                         if (!tool || ["denied", "answered"].includes(tool.state)
                             || tool.name === "AskUserQuestion") continue;
                         tool.state = block.is_error ? "failed" : "done";
+                        captureTiming(tool);
+                        captureOutput(tool, block);
                         rewriteFence(message, tool);
                     }
                 }
@@ -319,6 +366,7 @@ ApiStrategy {
             const tool = pendingTools[id];
             if (!["streaming", "running"].includes(tool.state)) return;
             tool.state = tool.state === "running" ? "failed" : leftover;
+            captureTiming(tool);
             rewriteFence(message, tool);
         });
         return {};

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -12,9 +12,10 @@ ApiStrategy {
     // The request captured by buildRequestData: {model, messages, systemPrompt, filePath, sessionId}
     property var pendingRequest: null
     property bool inThinkingBlock: false
-    // Tool calls are buffered while streaming and rendered once: on the permission
-    // request, or on the tool result for auto-approved ones. Entries are registered at
-    // content_block_start because the permission request can beat the block's stop event
+    // Command fences render at content_block_start and are rewritten in place while the
+    // input streams; the open fence is always the message tail, so a rewrite is just a
+    // slice at the recorded offsets. Entries stay registered after the block stops
+    // because the permission request refers back to them (and can even beat the stop)
     property string currentToolId: ""
     property var pendingTools: ({})
     property bool interruptRequested: false
@@ -98,15 +99,60 @@ ApiStrategy {
         message.rawContent += text;
     }
 
-    function appendCommandFence(message, name, input, requestApproval) {
-        if (requestApproval) {
-            // The same splitter the renderer uses, so the ordinal can't desync from it
-            message.pendingCommandIndex = CF.StringUtils.splitMarkdownBlocks(message.content)
-                .filter(b => b.type === "code" && b.lang === "command").length;
+    // The same splitter the renderer uses, so ordinals can't desync from it
+    function commandFenceCount(content) {
+        return CF.StringUtils.splitMarkdownBlocks(content)
+            .filter(b => b.type === "code" && b.lang === "command").length;
+    }
+
+    function registerTool(id, name, message) {
+        const tool = {
+            name: name,
+            inputJson: "",
+            open: true,
+            ordinal: commandFenceCount(message.content),
+            fenceStart: message.content.length,
+            rawFenceStart: message.rawContent.length,
+        };
+        pendingTools[id] = tool;
+        rewriteFence(message, tool);
+        return tool;
+    }
+
+    // Valid only while the fence is the message tail: from registerTool until the
+    // block's stop event (tool.open), plus the stop event's own final rewrite
+    function rewriteFence(message, tool) {
+        const fence = `\n\n\`\`\`command\n${tool.name}: ${commandSummary(tool)}\n\`\`\`\n\n`;
+        message.content = message.content.slice(0, tool.fenceStart) + fence;
+        message.rawContent = message.rawContent.slice(0, tool.rawFenceStart) + fence;
+    }
+
+    function commandSummary(tool) {
+        if (tool.input !== undefined) return tool.input?.command ?? JSON.stringify(tool.input ?? {});
+        return partialStringField(tool.inputJson, "command") ?? tool.inputJson;
+    }
+
+    // Value of a string field in incomplete JSON, tolerating a cut mid-escape
+    function partialStringField(json, field) {
+        const start = json.match(new RegExp(`"${field}"\\s*:\\s*"`));
+        if (!start) return null;
+        let out = "";
+        for (let i = start.index + start[0].length; i < json.length; i++) {
+            const c = json[i];
+            if (c === '"') break;
+            if (c !== '\\') { out += c; continue; }
+            const esc = json[++i];
+            if (esc === undefined) break;
+            if (esc === 'n') out += '\n';
+            else if (esc === 't') out += '\t';
+            else if (esc === 'u') {
+                const hex = json.slice(i + 1, i + 5);
+                if (hex.length < 4) break;
+                out += String.fromCharCode(parseInt(hex, 16));
+                i += 4;
+            } else out += esc;
         }
-        const header = requestApproval ? `**${Translation.tr("Command execution request")}**\n\n` : "";
-        const summary = input?.command ?? JSON.stringify(input ?? {});
-        appendContent(message, `\n\n${header}\`\`\`command\n${name}: ${summary}\n\`\`\`\n\n`);
+        return out;
     }
 
     function parseResponseLine(line, message) {
@@ -128,7 +174,7 @@ ApiStrategy {
                         appendContent(message, "\n\n<think>\n");
                     } else if (block.type === "tool_use") {
                         currentToolId = block.id ?? "";
-                        pendingTools[currentToolId] = { name: block.name ?? "", inputJson: "" };
+                        registerTool(currentToolId, block.name ?? "", message);
                     }
                 } else if (event.type === "content_block_delta") {
                     const delta = event.delta ?? {};
@@ -138,7 +184,10 @@ ApiStrategy {
                         appendContent(message, delta.thinking ?? "");
                     } else if (delta.type === "input_json_delta") {
                         const tool = pendingTools[currentToolId];
-                        if (tool) tool.inputJson += delta.partial_json ?? "";
+                        if (tool) {
+                            tool.inputJson += delta.partial_json ?? "";
+                            rewriteFence(message, tool);
+                        }
                     }
                 } else if (event.type === "content_block_stop") {
                     if (inThinkingBlock) {
@@ -147,25 +196,13 @@ ApiStrategy {
                     } else {
                         const tool = pendingTools[currentToolId];
                         if (tool) {
-                            try { tool.input = JSON.parse(tool.inputJson); } catch (e) {}
+                            if (tool.input === undefined) {
+                                try { tool.input = JSON.parse(tool.inputJson); } catch (e) {}
+                            }
+                            rewriteFence(message, tool);
+                            tool.open = false;
                         }
                         currentToolId = "";
-                    }
-                }
-                return {};
-            }
-
-            // A tool result is the first sign an auto-approved call ran; gated calls
-            // already rendered their fence with the permission request
-            if (dataJson.type === "user") {
-                const blocks = dataJson.message?.content;
-                if (Array.isArray(blocks)) {
-                    for (const block of blocks) {
-                        if (block.type !== "tool_result") continue;
-                        const tool = pendingTools[block.tool_use_id];
-                        if (!tool) continue;
-                        delete pendingTools[block.tool_use_id];
-                        appendCommandFence(message, tool.name, tool.input, false);
                     }
                 }
                 return {};
@@ -174,9 +211,14 @@ ApiStrategy {
             if (dataJson.type === "control_request") {
                 const request = dataJson.request ?? {};
                 if (request.subtype === "can_use_tool") {
-                    // This call's fence renders here; its tool result must not render another
-                    delete pendingTools[request.tool_use_id];
-                    appendCommandFence(message, request.tool_name ?? "", request.input ?? {}, true);
+                    let tool = pendingTools[request.tool_use_id];
+                    if (!tool) tool = registerTool(request.tool_use_id, request.tool_name ?? "", message);
+                    if (tool.open) {
+                        // The request can beat the block's stop event; its input is authoritative
+                        tool.input = request.input ?? {};
+                        rewriteFence(message, tool);
+                    }
+                    message.pendingCommandIndex = tool.ordinal;
                     message.functionName = request.tool_name ?? "";
                     message.functionPending = true;
                     return { permissionRequest: { requestId: dataJson.request_id, input: request.input ?? {} } };

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -12,10 +12,9 @@ ApiStrategy {
     // The request captured by buildRequestData: {model, messages, systemPrompt, filePath, sessionId}
     property var pendingRequest: null
     property bool inThinkingBlock: false
-    // Command fences render at content_block_start and are rewritten in place while the
-    // input streams; the open fence is always the message tail, so a rewrite is just a
-    // slice at the recorded offsets. Entries stay registered after the block stops
-    // because the permission request refers back to them (and can even beat the stop)
+    // Command fences render at content_block_start and are rewritten in place by ordinal
+    // while the input streams. Entries stay registered after the block stops because the
+    // permission request refers back to them (and can even beat the stop)
     property string currentToolId: ""
     property var pendingTools: ({})
     property bool interruptRequested: false
@@ -120,42 +119,35 @@ ApiStrategy {
         const tool = {
             name: name,
             inputJson: "",
-            open: true,
             // Nothing exists to run or approve yet; the state settles once the input is in
             state: "streaming",
             // This fence is about to be appended, so the fences already there are its ordinal
             ordinal: CF.StringUtils.commandFences(message.content).length,
-            fenceStart: message.content.length,
-            rawFenceStart: message.rawContent.length,
         };
         pendingTools[id] = tool;
-        rewriteFence(message, tool);
+        appendContent(message, `\n\n${fenceText(tool)}\n\n`);
         return tool;
     }
 
-    // Valid only while the fence is the message tail: from registerTool until the
-    // block's stop event (tool.open), plus the stop event's own final rewrite
-    function rewriteFence(message, tool) {
-        const fence = `\n\n\`\`\`command:${tool.name}:${tool.state}\n${commandSummary(tool)}\n\`\`\`\n\n`;
-        message.content = message.content.slice(0, tool.fenceStart) + fence;
-        message.rawContent = message.rawContent.slice(0, tool.rawFenceStart) + fence;
+    function fenceText(tool) {
+        return `\`\`\`command:${tool.name}:${tool.state}\n${commandSummary(tool)}\n\`\`\``;
     }
 
-    // Results land after the block's stop event, by which point the fence is no longer
-    // the message tail, so the state token is swapped in place by ordinal instead
-    function setFenceState(message, tool) {
-        const swap = fence => CF.StringUtils.withCommandFenceState(fence, tool.state);
-        message.content = CF.StringUtils.editCommandFence(message.content, tool.ordinal, swap);
-        message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, tool.ordinal, swap);
+    // By ordinal rather than by offset: a fence settling earlier in the message shifts
+    // every later one, and several tool calls can be in flight at once
+    function rewriteFence(message, tool) {
+        const render = () => fenceText(tool);
+        message.content = CF.StringUtils.editCommandFence(message.content, tool.ordinal, render);
+        message.rawContent = CF.StringUtils.editCommandFence(message.rawContent, tool.ordinal, render);
     }
 
     // Tools that take a command show it as the fence body; the rest show their whole input,
-    // so the body stays valid JSON for delegates that parse it back
+    // so the body stays valid JSON for delegates that parse it back. Never empty: a blank
+    // body makes the fence invisible to commandFences and shifts every later ordinal
     function commandSummary(tool) {
         const input = tool.input ?? CF.StringUtils.parsePartialJson(tool.inputJson);
-        if (!input) return tool.lastSummary ?? "{}";
-        tool.lastSummary = input.command ?? JSON.stringify(input);
-        return tool.lastSummary;
+        if (input) tool.lastSummary = input.command ?? JSON.stringify(input);
+        return (tool.lastSummary?.length > 0) ? tool.lastSummary : "{}";
     }
 
     function parseResponseLine(line, message) {
@@ -203,7 +195,6 @@ ApiStrategy {
                                 try { tool.input = JSON.parse(tool.inputJson); } catch (e) {}
                             }
                             rewriteFence(message, tool);
-                            tool.open = false;
                         }
                         currentToolId = "";
                     }
@@ -225,7 +216,7 @@ ApiStrategy {
                         if (!tool || ["denied", "answered"].includes(tool.state)
                             || tool.name === "AskUserQuestion") continue;
                         tool.state = block.is_error ? "failed" : "done";
-                        setFenceState(message, tool);
+                        rewriteFence(message, tool);
                     }
                 }
                 return {};
@@ -239,13 +230,9 @@ ApiStrategy {
                     // Nothing runs until the user decides; tools that need no approval never
                     // reach here and go straight from streaming to their result
                     tool.state = "pending";
-                    if (tool.open) {
-                        // The request can beat the block's stop event; its input is authoritative
-                        tool.input = request.input ?? {};
-                        rewriteFence(message, tool);
-                    } else {
-                        setFenceState(message, tool);
-                    }
+                    // The request can beat the block's stop event; its input is authoritative
+                    tool.input = request.input ?? {};
+                    rewriteFence(message, tool);
                     message.pendingCommandIndex = tool.ordinal;
                     message.functionName = request.tool_name ?? "";
                     message.functionPending = true;
@@ -301,8 +288,7 @@ ApiStrategy {
             const tool = pendingTools[id];
             if (tool.state !== "streaming") return;
             tool.state = leftover;
-            if (tool.open) rewriteFence(message, tool);
-            else setFenceState(message, tool);
+            rewriteFence(message, tool);
         });
         return {};
     }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -64,17 +64,29 @@ ApiStrategy {
         });
     }
 
-    function buildPermissionResponse(permissionRequest, allow: bool): string {
+    function buildPermissionResponse(permissionRequest, allow, updatedInput): string {
         return JSON.stringify({
             type: "control_response",
             response: {
                 subtype: "success",
                 request_id: permissionRequest.requestId,
                 response: allow
-                    ? { behavior: "allow", updatedInput: permissionRequest.input }
+                    ? { behavior: "allow", updatedInput: updatedInput ?? permissionRequest.input }
                     : { behavior: "deny", message: "User rejected this command" }
             }
         });
+    }
+
+    // Encodes the AskUserQuestion answer contract for updatedInput: {questions, answers}
+    // keyed by question text, multiSelect labels joined with ", ", skipped questions
+    // (no selection) omitted
+    function buildQuestionAnswers(questions, selections): var {
+        const answers = {};
+        for (const q of questions) {
+            const answer = (selections[q.question] ?? []).join(", ");
+            if (answer.length > 0) answers[q.question] = answer;
+        }
+        return { questions: questions, answers: answers };
     }
 
     function finalizeScriptContent(scriptContent: string): string {

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -116,19 +116,14 @@ ApiStrategy {
         message.rawContent += text;
     }
 
-    // The same splitter the renderer uses, so ordinals can't desync from it
-    function commandFenceCount(content) {
-        return CF.StringUtils.splitMarkdownBlocks(content)
-            .filter(b => b.type === "code" && b.lang?.split(":")[0] === "command").length;
-    }
-
     function registerTool(id, name, message) {
         const tool = {
             name: name,
             inputJson: "",
             open: true,
             state: "running",
-            ordinal: commandFenceCount(message.content),
+            // This fence is about to be appended, so the fences already there are its ordinal
+            ordinal: CF.StringUtils.commandFences(message.content).length,
             fenceStart: message.content.length,
             rawFenceStart: message.rawContent.length,
         };

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -18,6 +18,29 @@ ApiStrategy {
     property string currentToolId: ""
     property var pendingTools: ({})
     property bool interruptRequested: false
+    // A tool whose input is complete is running, unless it turns out to want approval first.
+    // The permission request can trail the block's stop, so each tool waits out its own delay
+    // before taking the label; one that settles inside the delay never shows it at all
+    property int promotionDelay: 150
+    property var promotionQueue: []
+    property var promotionMessage: null
+    property Timer promotionTimer: Timer {
+        interval: 50
+        repeat: true
+        onTriggered: {
+            const now = Date.now();
+            promotionQueue = promotionQueue.filter(entry => {
+                if (now < entry.due) return true;
+                const tool = pendingTools[entry.id];
+                if (tool && tool.state === "streaming") {
+                    tool.state = "running";
+                    rewriteFence(promotionMessage, tool);
+                }
+                return false;
+            });
+            if (promotionQueue.length === 0) stop();
+        }
+    }
 
     function buildEndpoint(model: AiModel): string { return "" }
     function buildAuthorizationHeader(apiKeyEnvVarName: string): string { return "" }
@@ -150,6 +173,12 @@ ApiStrategy {
         return (tool.lastSummary?.length > 0) ? tool.lastSummary : "{}";
     }
 
+    function queuePromotion(id, message) {
+        promotionQueue = promotionQueue.concat([{ id: id, due: Date.now() + promotionDelay }]);
+        promotionMessage = message;
+        if (!promotionTimer.running) promotionTimer.start();
+    }
+
     function parseResponseLine(line, message) {
         try {
             const dataJson = JSON.parse(line);
@@ -195,6 +224,7 @@ ApiStrategy {
                                 try { tool.input = JSON.parse(tool.inputJson); } catch (e) {}
                             }
                             rewriteFence(message, tool);
+                            queuePromotion(currentToolId, message);
                         }
                         currentToolId = "";
                     }
@@ -280,14 +310,15 @@ ApiStrategy {
             inThinkingBlock = false;
             appendContent(message, "\n</think>\n\n");
         }
-        // An interrupt can also land mid-input, before the tool ever asked for approval, leaving a
-        // fence claiming to still be streaming for good. Stopping the turn refuses it; ending any
-        // other way means it never got to run
+        // An interrupt can also land mid-input or mid-execution, leaving a fence unsettled for
+        // good. Stopping the turn refuses one that never started; a killed run reads as failed
+        promotionTimer.stop();
+        promotionQueue = [];
         const leftover = interruptRequested ? "denied" : "failed";
         Object.keys(pendingTools).forEach(id => {
             const tool = pendingTools[id];
-            if (tool.state !== "streaming") return;
-            tool.state = leftover;
+            if (!["streaming", "running"].includes(tool.state)) return;
+            tool.state = tool.state === "running" ? "failed" : leftover;
             rewriteFence(message, tool);
         });
         return {};
@@ -299,5 +330,8 @@ ApiStrategy {
         currentToolId = "";
         pendingTools = ({});
         interruptRequested = false;
+        promotionTimer.stop();
+        promotionQueue = [];
+        promotionMessage = null;
     }
 }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -102,7 +102,7 @@ ApiStrategy {
     // The same splitter the renderer uses, so ordinals can't desync from it
     function commandFenceCount(content) {
         return CF.StringUtils.splitMarkdownBlocks(content)
-            .filter(b => b.type === "code" && b.lang === "command").length;
+            .filter(b => b.type === "code" && b.lang?.split(":")[0] === "command").length;
     }
 
     function registerTool(id, name, message) {
@@ -122,7 +122,7 @@ ApiStrategy {
     // Valid only while the fence is the message tail: from registerTool until the
     // block's stop event (tool.open), plus the stop event's own final rewrite
     function rewriteFence(message, tool) {
-        const fence = `\n\n\`\`\`command\n${tool.name}: ${commandSummary(tool)}\n\`\`\`\n\n`;
+        const fence = `\n\n\`\`\`command:${tool.name}\n${commandSummary(tool)}\n\`\`\`\n\n`;
         message.content = message.content.slice(0, tool.fenceStart) + fence;
         message.rawContent = message.rawContent.slice(0, tool.rawFenceStart) + fence;
     }

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -1,0 +1,186 @@
+import QtQuick
+import qs.modules.common.functions as CF
+
+/**
+ * Claude via the Claude Code CLI (`claude -p`) run as a local process:
+ * finalizeScriptContent() discards the assembled curl script, input goes over stdin
+ * as stream-json, and conversation continuity uses CLI sessions (--resume).
+ */
+ApiStrategy {
+    isCli: true
+    // The request captured by buildRequestData: {model, messages, systemPrompt, filePath, sessionId}
+    property var pendingRequest: null
+    property bool inThinkingBlock: false
+    property bool interruptRequested: false
+
+    function buildEndpoint(model: AiModel): string { return "" }
+    function buildAuthorizationHeader(apiKeyEnvVarName: string): string { return "" }
+
+    function buildRequestData(model: AiModel, messages, systemPrompt: string, temperature: real, tools, filePath: string) {
+        // Resume the newest session found in the chat; none means a fresh one
+        const sessionId = messages.map(m => m.cliSessionId).filter(id => id && id.length > 0).pop() ?? "";
+        pendingRequest = ({
+            model: model,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            filePath: filePath,
+            sessionId: sessionId,
+        });
+        return {};
+    }
+
+    // Written to the process's stdin by the service right after launch; stdin then
+    // stays open for permission responses
+    function buildStdinPayload(): string {
+        const request = pendingRequest;
+        // Resuming: only the newest message is sent, the session carries the rest.
+        // Fresh session: serialize the whole chat so context survives model switches and loaded chats
+        let prompt = request.sessionId.length > 0
+            ? (request.messages[request.messages.length - 1]?.rawContent ?? "")
+            : request.messages.map(m => `${m.role}: ${m.rawContent}`).join("\n\n");
+        if (request.filePath && request.filePath.length > 0) {
+            prompt += `\n\n[Attached file: ${request.filePath}]`;
+        }
+        return JSON.stringify({
+            type: "user",
+            message: { role: "user", content: [{ type: "text", text: prompt }] }
+        });
+    }
+
+    // The CLI stops the turn gracefully and records it in the session, unlike a signal
+    function buildInterruptRequest(): string {
+        interruptRequested = true;
+        return JSON.stringify({
+            type: "control_request",
+            request_id: "interrupt",
+            request: { subtype: "interrupt" }
+        });
+    }
+
+    function buildPermissionResponse(permissionRequest, allow: bool): string {
+        return JSON.stringify({
+            type: "control_response",
+            response: {
+                subtype: "success",
+                request_id: permissionRequest.requestId,
+                response: allow
+                    ? { behavior: "allow", updatedInput: permissionRequest.input }
+                    : { behavior: "deny", message: "User rejected this command" }
+            }
+        });
+    }
+
+    function finalizeScriptContent(scriptContent: string): string {
+        const request = pendingRequest;
+        // stdio permission prompts let the shell approve/deny gated tool calls over stdin
+        let command = "claude -p --input-format stream-json --output-format stream-json"
+            + " --include-partial-messages --verbose --permission-prompt-tool stdio";
+        if (request.model.model.length > 0) {
+            command += ` --model '${CF.StringUtils.shellSingleQuoteEscape(request.model.model)}'`;
+        }
+        if (request.sessionId.length > 0) {
+            command += ` --resume '${CF.StringUtils.shellSingleQuoteEscape(request.sessionId)}'`;
+        } else if (request.systemPrompt.length > 0) {
+            command += ` --append-system-prompt '${CF.StringUtils.shellSingleQuoteEscape(request.systemPrompt)}'`;
+        }
+        // exec so the stop button's kill reaches claude itself, not just the wrapping bash
+        return "#!/usr/bin/env bash\nexec " + command + "\n";
+    }
+
+    function appendContent(message, text) {
+        message.content += text;
+        message.rawContent += text;
+    }
+
+    function parseResponseLine(line, message) {
+        try {
+            const dataJson = JSON.parse(line);
+
+            if (dataJson.type === "system" && dataJson.subtype === "init") {
+                message.cliSessionId = dataJson.session_id ?? "";
+                return {};
+            }
+
+            // Live chunks; complete "assistant" snapshots are ignored to avoid duplication
+            if (dataJson.type === "stream_event") {
+                const event = dataJson.event ?? {};
+                if (event.type === "content_block_start") {
+                    const block = event.content_block ?? {};
+                    if (block.type === "thinking") {
+                        inThinkingBlock = true;
+                        appendContent(message, "\n\n<think>\n");
+                    } else if (block.type === "tool_use") {
+                        appendContent(message, `\n\n<think>\nRunning \`${block.name}\`\n</think>\n\n`);
+                    }
+                } else if (event.type === "content_block_delta") {
+                    const delta = event.delta ?? {};
+                    if (delta.type === "text_delta") {
+                        appendContent(message, delta.text ?? "");
+                    } else if (delta.type === "thinking_delta") {
+                        appendContent(message, delta.thinking ?? "");
+                    }
+                } else if (event.type === "content_block_stop" && inThinkingBlock) {
+                    inThinkingBlock = false;
+                    appendContent(message, "\n</think>\n\n");
+                }
+                return {};
+            }
+
+            if (dataJson.type === "control_request") {
+                const request = dataJson.request ?? {};
+                if (request.subtype === "can_use_tool") {
+                    const inputSummary = request.input?.command
+                        ?? JSON.stringify(request.input ?? {});
+                    // The ```command fence triggers the chat's approve/reject buttons
+                    appendContent(message, `\n\n**Command execution request**\n\n\`\`\`command\n${request.tool_name}: ${inputSummary}\n\`\`\``);
+                    message.functionName = request.tool_name ?? "";
+                    message.functionPending = true;
+                    return { permissionRequest: { requestId: dataJson.request_id, input: request.input ?? {} } };
+                }
+                return {};
+            }
+
+            if (dataJson.type === "result") {
+                // A self-requested interrupt also reports is_error (with an internal
+                // diagnostic), but the session stays valid and resumable
+                if (dataJson.is_error && !interruptRequested) {
+                    // error_during_execution results carry errors[] instead of result
+                    const errorText = dataJson.result ?? dataJson.errors?.join("\n") ?? "Unknown error";
+                    appendContent(message, `**Error**: ${errorText}`);
+                    // A failed session (e.g. an expired --resume target) must not be resumed
+                    // again: dropping the ids makes the next request start fresh
+                    message.cliSessionId = "";
+                    pendingRequest?.messages?.forEach(m => { m.cliSessionId = "" });
+                }
+                const usage = dataJson.usage ?? {};
+                const input = (usage.input_tokens ?? 0)
+                    + (usage.cache_read_input_tokens ?? 0)
+                    + (usage.cache_creation_input_tokens ?? 0);
+                const output = usage.output_tokens ?? 0;
+                return {
+                    finished: true,
+                    tokenUsage: { input: input, output: output, total: input + output }
+                };
+            }
+        } catch (e) {
+            // Non-JSON output is shown as-is
+            appendContent(message, line);
+        }
+        return {};
+    }
+
+    function onRequestFinished(message: AiMessageData): var {
+        // An interrupt can land mid-thinking; the dangling tag would swallow the rest of the message
+        if (inThinkingBlock) {
+            inThinkingBlock = false;
+            appendContent(message, "\n</think>\n\n");
+        }
+        return {};
+    }
+
+    function reset() {
+        pendingRequest = null;
+        inThinkingBlock = false;
+        interruptRequested = false;
+    }
+}

--- a/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
+++ b/dots/.config/quickshell/ii/services/ai/ClaudeCliStrategy.qml
@@ -121,7 +121,8 @@ ApiStrategy {
             name: name,
             inputJson: "",
             open: true,
-            state: "running",
+            // Nothing exists to run or approve yet; the state settles once the input is in
+            state: "streaming",
             // This fence is about to be appended, so the fences already there are its ordinal
             ordinal: CF.StringUtils.commandFences(message.content).length,
             fenceStart: message.content.length,
@@ -217,8 +218,12 @@ ApiStrategy {
                     for (const block of blocks) {
                         if (block.type !== "tool_result") continue;
                         const tool = pendingTools[block.tool_use_id];
-                        // AskUserQuestion keeps its own delegate and :answered end state
-                        if (!tool || tool.state !== "running" || tool.name === "AskUserQuestion") continue;
+                        // A decision the user already made stands: a denial's error result must not
+                        // relabel the fence, and AskUserQuestion keeps its own :answered end state.
+                        // Anything else settles here, including tools that needed no approval and
+                        // so never left :streaming
+                        if (!tool || ["denied", "answered"].includes(tool.state)
+                            || tool.name === "AskUserQuestion") continue;
                         tool.state = block.is_error ? "failed" : "done";
                         setFenceState(message, tool);
                     }
@@ -231,8 +236,8 @@ ApiStrategy {
                 if (request.subtype === "can_use_tool") {
                     let tool = pendingTools[request.tool_use_id];
                     if (!tool) tool = registerTool(request.tool_use_id, request.tool_name ?? "", message);
-                    // Nothing runs until the user decides; tools that need no approval
-                    // never reach here and stay "running"
+                    // Nothing runs until the user decides; tools that need no approval never
+                    // reach here and go straight from streaming to their result
                     tool.state = "pending";
                     if (tool.open) {
                         // The request can beat the block's stop event; its input is authoritative

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -611,5 +611,8 @@
   "Use varying shapes for password characters": "Use varying shapes for password characters",
   "Battery full": "Battery full",
   "Pin": "Pin",
-  "Unpin": "Unpin"
+  "Unpin": "Unpin",
+  "Local CLI | Anthropic's %1 model via the Claude Code CLI": "Local CLI | Anthropic's %1 model via the Claude Code CLI",
+  "No model": "No model",
+  "None": "None"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -615,5 +615,18 @@
   "Online | Claude Code CLI\nAnthropic's %1 model": "Online | Claude Code CLI\nAnthropic's %1 model",
   "No model": "No model",
   "None": "None",
-  "Command execution request": "Command execution request"
+  "Command execution request": "Command execution request",
+  "Question": "Question",
+  "Questions": "Questions",
+  "dismissed": "dismissed",
+  "Other...": "Other...",
+  "Submit": "Submit",
+  "Dismiss": "Dismiss",
+  "No model selected. Pick one with `%1`": "No model selected. Pick one with `%1`",
+  "pending": "pending",
+  "running": "running",
+  "done": "done",
+  "failed": "failed",
+  "denied": "denied",
+  "answered": "answered"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -614,5 +614,6 @@
   "Unpin": "Unpin",
   "Online | Claude Code CLI\nAnthropic's %1 model": "Online | Claude Code CLI\nAnthropic's %1 model",
   "No model": "No model",
-  "None": "None"
+  "None": "None",
+  "Command execution request": "Command execution request"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -628,5 +628,6 @@
   "done": "done",
   "failed": "failed",
   "denied": "denied",
-  "answered": "answered"
+  "answered": "answered",
+  "unanswered": "unanswered"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -628,6 +628,7 @@
   "done": "done",
   "failed": "failed",
   "answered": "answered",
-  "unanswered": "unanswered",
-  "rejected": "rejected"
+  "rejected": "rejected",
+  "Type your own answer": "Type your own answer",
+  "Your own answer": "Your own answer"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -612,7 +612,7 @@
   "Battery full": "Battery full",
   "Pin": "Pin",
   "Unpin": "Unpin",
-  "Local CLI | Anthropic's %1 model via the Claude Code CLI": "Local CLI | Anthropic's %1 model via the Claude Code CLI",
+  "Online | Claude Code CLI\nAnthropic's %1 model": "Online | Claude Code CLI\nAnthropic's %1 model",
   "No model": "No model",
   "None": "None"
 }

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -627,7 +627,7 @@
   "running": "running",
   "done": "done",
   "failed": "failed",
-  "denied": "denied",
   "answered": "answered",
-  "unanswered": "unanswered"
+  "unanswered": "unanswered",
+  "rejected": "rejected"
 }


### PR DESCRIPTION
## Describe your changes

- Adds claude cli support if `claude` is installed, cli is auto-detected and shown as an option in the left sidebar (only when non-local models are enabled)
- Also adds question block component for when claude asks questions
- Used claude code to implement, not sure if you guys are fans of that, I did look over and test the code though

<img width="431" height="269" alt="image" src="https://github.com/user-attachments/assets/1cb019b1-eefc-4faf-a1f3-50f6d8fc6b0f" />

## Is it ready? Questions/feedback needed?
- The claude cli part works, I don't have any API keys though, so I wasn't able to test the other API models, because did have to change the shared code a bit
- The claude cli implementation is using the existing `ApiStrategy` workflow which arguable is kind of a bad workaround, but would have to do a decently sized refactor otherwise, so I didn't do it in this branch