### PR TITLE
Reduce Quickshell CPU use during title churn

### DIFF
--- a/dots/.config/quickshell/ii/services/HyprlandData.qml
+++ b/dots/.config/quickshell/ii/services/HyprlandData.qml
@@ -83,13 +83,24 @@ Singleton {
         updateAll();
     }
 
+    Timer {
+        id: windowTitleUpdateDebounce
+        interval: 250
+        repeat: false
+        onTriggered: root.updateWindowList()
+    }
+
     Connections {
         target: Hyprland
 
         function onRawEvent(event) {
             // console.log("Hyprland raw event:", event.name);
+            if (["windowtitle", "windowtitlev2"].includes(event.name)) {
+                windowTitleUpdateDebounce.restart();
+                return;
+            }
             if (["openlayer", "closelayer", "screencast"].includes(event.name)) return;
-            updateAll()
+            updateAll();
         }
     }
 


### PR DESCRIPTION
## Describe your changes

Debounce `windowtitle` and `windowtitlev2` events for 250 ms and refresh only the client/window list after title activity settles.

Previously every title event called `updateAll()`, which refreshed clients, monitors, layers, workspaces, and the active workspace. Applications that update their title frequently therefore caused repeated `hyprctl` process launches and QML state churn.

Live verification with the same ~20 title events per second:

- Before: 45.8% Quickshell CPU
- After: 8.8% Quickshell CPU
- Reduction: 80.8%

Checks:

- `git diff --check`
- Source and deployed configuration byte parity
- Clean Quickshell restart and two matched runtime benchmarks
- Patched configuration loaded with no `HyprlandData.qml` syntax/runtime errors

The installed Qt 5 `qmllint` exits 255 without diagnostics on unchanged Quickshell control files as well, so it could not provide a meaningful static-lint gate.

The trailing debounce preserves eventual title updates while avoiding full Hyprland model refreshes during continuous title churn.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Implementation and live validation are complete. This is opened as a draft for maintainer feedback; the remaining tradeoff is that continuously changing titles update after they pause for 250 ms.