### PR TITLE
fix(music-detection): parse result using `jq`

### DIFF
--- a/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
+++ b/dots/.config/quickshell/ii/scripts/musicRecognition/recognize-music.sh
@@ -14,7 +14,7 @@ while getopts "i:t:s:" opt; do
   esac
 done
 
-if ! command -v songrec >/dev/null 2>&1; then
+if ! command -v songrec >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
@@ -43,13 +43,22 @@ trap cleanup EXIT
 songrec listen --audio-device "$AUDIO_DEVICE" --request-interval "$INTERVAL" --json --disable-mpris > "$FIFO" &
 SONGREC_PID=$!
 
-( sleep "$TOTAL_DURATION" && kill "$SONGREC_PID" 2>/dev/null ) &
-
-while IFS= read -r line; do
-    if echo "$line" | grep -q '"matches": \['; then
-        echo "$line"
+exec 3< "$FIFO"
+SECONDS=0
+while (( SECONDS < TOTAL_DURATION )); do
+    REMAINING_DURATION=$((TOTAL_DURATION - SECONDS))
+    if ! IFS= read -r -t "$REMAINING_DURATION" line <&3; then
+        break
+    fi
+    if printf '%s\n' "$line" | jq -e '
+        (.matches | type == "array" and length > 0) and
+        (.track.title | type == "string" and length > 0) and
+        (.track.subtitle | type == "string" and length > 0) and
+        (.track.url | type == "string" and length > 0)
+    ' >/dev/null 2>&1; then
+        printf '%s\n' "$line"
         exit 0
     fi
-done < "$FIFO"
+done
 
 exit 0


### PR DESCRIPTION
## Describe your changes

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

`songrec` doesn't prettify their JSON output, so `grep -q '"matches": \['` never matches. Since `jq` is already a dependency for this setup, it's best to just use it for future-proof parsing.

## Is it ready? Questions/feedback needed?

It is.
