### PR TITLE
fix(quickshell): optimize bluetooth device handling and fix crashes

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/models/quickToggles/BluetoothToggle.qml
+++ b/dots/.config/quickshell/ii/modules/common/models/quickToggles/BluetoothToggle.qml
@@ -17,7 +17,9 @@ QuickToggleModel {
     available: BluetoothStatus.available
     toggled: BluetoothStatus.enabled
     mainAction: () => {
-        Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter?.enabled
+        if (Bluetooth.defaultAdapter) {
+            Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter.enabled;
+        }
     }
     hasMenu: true
 }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -126,14 +126,33 @@ Item {
     }
 
     ToggleDialog {
+        id: bluetoothToggleDialog
         shownPropertyString: "showBluetoothDialog"
         dialog: BluetoothDialog {}
         onShownChanged: {
             if (!shown) {
-                Bluetooth.defaultAdapter.discovering = false;
+                if (Bluetooth.defaultAdapter) Bluetooth.defaultAdapter.discovering = false;
+                BluetoothStatus.expandedAddress = "";
             } else {
-                Bluetooth.defaultAdapter.enabled = true;
-                Bluetooth.defaultAdapter.discovering = true;
+                if (Bluetooth.defaultAdapter) {
+                    Bluetooth.defaultAdapter.enabled = true;
+                    Bluetooth.defaultAdapter.discovering = true;
+                }
+                BluetoothStatus.scheduleUpdate(true);
+            }
+        }
+        Component.onCompleted: {
+            if (!shown && Bluetooth.defaultAdapter) {
+                Bluetooth.defaultAdapter.discovering = false;
+            }
+        }
+
+        Connections {
+            target: Bluetooth
+            function onDefaultAdapterChanged() {
+                if (!bluetoothToggleDialog.shown && Bluetooth.defaultAdapter) {
+                    Bluetooth.defaultAdapter.discovering = false;
+                }
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
@@ -8,11 +8,11 @@ import QtQuick.Layouts
 DialogListItem {
     id: root
     required property var device
-    property bool expanded: false
+    property bool expanded: BluetoothStatus.expandedAddress !== "" && BluetoothStatus.expandedAddress === (root.device?.address ?? "")
     pointingHandCursor: !expanded
 
-    onClicked: expanded = !expanded
-    altAction: () => expanded = !expanded
+    onClicked: BluetoothStatus.expandedAddress = expanded ? "" : (root.device?.address ?? "")
+    altAction: () => BluetoothStatus.expandedAddress = expanded ? "" : (root.device?.address ?? "")
     
     component ActionButton: DialogButton {
         colBackground: Appearance.colors.colPrimary

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/bluetoothDevices/BluetoothDialog.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/bluetoothDevices/BluetoothDialog.qml
@@ -43,9 +43,7 @@ WindowDialog {
         spacing: 0
         animateAppearance: false
 
-        model: ScriptModel {
-            values: BluetoothStatus.friendlyDeviceList
-        }
+        model: BluetoothStatus.friendlyDeviceList
         delegate: BluetoothDeviceItem {
             required property BluetoothDevice modelData
             device: modelData

--- a/dots/.config/quickshell/ii/modules/ii/sidebarRight/quickToggles/classicStyle/BluetoothToggle.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarRight/quickToggles/classicStyle/BluetoothToggle.qml
@@ -15,7 +15,9 @@ QuickToggleButton {
     toggled: BluetoothStatus.enabled
     buttonIcon: BluetoothStatus.connected ? "bluetooth_connected" : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
     onClicked: {
-        Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter?.enabled
+        if (Bluetooth.defaultAdapter) {
+            Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter.enabled;
+        }
     }
     altAction: () => {
         Quickshell.execDetached(["bash", "-c", `${Config.options.apps.bluetooth}`])

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothControl.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothControl.qml
@@ -17,10 +17,14 @@ Item {
     id: root
 
     Component.onCompleted: {
-        if (Bluetooth.defaultAdapter.enabled) Bluetooth.defaultAdapter.discovering = true;
+        if (Bluetooth.defaultAdapter?.enabled) {
+            Bluetooth.defaultAdapter.discovering = true;
+        }
+        BluetoothStatus.scheduleUpdate(true);
     }
     Component.onDestruction: {
-        Bluetooth.defaultAdapter.discovering = false;
+        if (Bluetooth.defaultAdapter) Bluetooth.defaultAdapter.discovering = false;
+        BluetoothStatus.expandedAddress = "";
     }
 
     WPanelPageColumn {
@@ -84,9 +88,7 @@ Item {
                     clip: true
                     spacing: 4
 
-                    model: ScriptModel {
-                        values: BluetoothStatus.friendlyDeviceList
-                    }
+                    model: BluetoothStatus.friendlyDeviceList
                     delegate: BluetoothDeviceItem {
                         required property BluetoothDevice modelData
                         device: modelData
@@ -117,7 +119,7 @@ Item {
                 enabled: !Bluetooth.defaultAdapter?.discovering && Bluetooth.defaultAdapter?.enabled
 
                 onClicked: {
-                    Bluetooth.defaultAdapter.discovering = true;
+                    if (Bluetooth.defaultAdapter) Bluetooth.defaultAdapter.discovering = true;
                 }
 
                 contentItem: FluentIcon {

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothDeviceItem.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/bluetooth/BluetoothDeviceItem.qml
@@ -14,6 +14,8 @@ import qs.modules.waffle.actionCenter
 ExpandableChoiceButton {
     id: root
     required property BluetoothDevice device
+    expanded: BluetoothStatus.expandedAddress !== "" && BluetoothStatus.expandedAddress === (root.device?.address ?? "")
+    onClicked: BluetoothStatus.expandedAddress = expanded ? "" : (root.device?.address ?? "")
 
     contentItem: RowLayout {
         id: contentItem

--- a/dots/.config/quickshell/ii/modules/waffle/actionCenter/nightLight/NightLightControl.qml
+++ b/dots/.config/quickshell/ii/modules/waffle/actionCenter/nightLight/NightLightControl.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import Quickshell
-import Quickshell.Bluetooth
 import qs
 import qs.services
 import qs.services.network
@@ -15,14 +14,6 @@ import qs.modules.waffle.actionCenter
 
 Item {
     id: root
-
-    Component.onCompleted: {
-        if (Bluetooth.defaultAdapter.enabled)
-            Bluetooth.defaultAdapter.discovering = true;
-    }
-    Component.onDestruction: {
-        Bluetooth.defaultAdapter.discovering = false;
-    }
 
     WPanelPageColumn {
         anchors.fill: parent

--- a/dots/.config/quickshell/ii/services/BluetoothStatus.qml
+++ b/dots/.config/quickshell/ii/services/BluetoothStatus.qml
@@ -11,27 +11,140 @@ Singleton {
 
     readonly property bool available: Bluetooth.adapters.values.length > 0
     readonly property bool enabled: Bluetooth.defaultAdapter?.enabled ?? false
-    readonly property BluetoothDevice firstActiveDevice: Bluetooth.defaultAdapter?.devices.values.find(device => device.connected) ?? null
-    readonly property int activeDeviceCount: Bluetooth.defaultAdapter?.devices.values.filter(device => device.connected).length ?? 0
-    readonly property bool connected: Bluetooth.devices.values.some(d => d.connected)
+
+    property list<var> connectedDevices: []
+    property list<var> pairedButNotConnectedDevices: []
+    property list<var> unpairedDevices: []
+    property list<var> friendlyDeviceList: []
+
+    readonly property BluetoothDevice firstActiveDevice: connectedDevices.length > 0 ? connectedDevices[0] : null
+    readonly property int activeDeviceCount: connectedDevices.length
+    readonly property bool connected: activeDeviceCount > 0
+
+    onAvailableChanged: scheduleUpdate(true)
+    onEnabledChanged: scheduleUpdate(true)
+
+    Connections {
+        target: Bluetooth
+        function onDefaultAdapterChanged() {
+            root.scheduleUpdate(true);
+        }
+    }
+
+    readonly property var macRegex: /^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$/
 
     function sortFunction(a, b) {
-        // Ones with meaningful names before MAC addresses
-        const macRegex = /^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$/;
-        const aIsMac = macRegex.test(a.name);
-        const bIsMac = macRegex.test(b.name);
-        if (aIsMac !== bIsMac)
-            return aIsMac ? 1 : -1;
+        if (!a || !b) return 0;
+        const nameA = a.name || "";
+        const nameB = b.name || "";
+        const aIsMacOrEmpty = !nameA || root.macRegex.test(nameA);
+        const bIsMacOrEmpty = !nameB || root.macRegex.test(nameB);
+        if (aIsMacOrEmpty !== bIsMacOrEmpty)
+            return aIsMacOrEmpty ? 1 : -1;
 
         // Alphabetical by name
-        return a.name.localeCompare(b.name);
+        return nameA.localeCompare(nameB);
     }
-    property list<var> connectedDevices: Bluetooth.devices.values.filter(d => d.connected).sort(sortFunction)
-    property list<var> pairedButNotConnectedDevices: Bluetooth.devices.values.filter(d => d.paired && !d.connected).sort(sortFunction)
-    property list<var> unpairedDevices: Bluetooth.devices.values.filter(d => !d.paired && !d.connected).sort(sortFunction)
-    property list<var> friendlyDeviceList: [
-        ...connectedDevices,
-        ...pairedButNotConnectedDevices,
-        ...unpairedDevices
-    ]
+
+    property string expandedAddress: ""
+    onExpandedAddressChanged: {
+        if (expandedAddress === "" && pendingUpdate) {
+            pendingUpdate = false;
+            updateFriendlyDeviceList();
+        }
+    }
+
+    function areDeviceListsEqual(a, b) {
+        if (a === b) return true;
+        if (!a || !b || a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) return false;
+        }
+        return true;
+    }
+
+    property bool pendingUpdate: false
+
+    Timer {
+        id: updateThrottleTimer
+        interval: 1000
+        repeat: false
+        onTriggered: {
+            if (root.expandedAddress !== "") {
+                root.pendingUpdate = true;
+                updateThrottleTimer.start();
+                return;
+            }
+            root.updateFriendlyDeviceList();
+            if (root.pendingUpdate) {
+                root.pendingUpdate = false;
+                updateThrottleTimer.start();
+            }
+        }
+    }
+
+    function scheduleUpdate(immediate = false) {
+        if (immediate) {
+            updateThrottleTimer.stop();
+            pendingUpdate = false;
+            root.updateFriendlyDeviceList();
+            return;
+        }
+        if (updateThrottleTimer.running) {
+            pendingUpdate = true;
+        } else {
+            updateThrottleTimer.start();
+        }
+    }
+
+    Connections {
+        target: Bluetooth.devices
+        function onValuesChanged() {
+            root.scheduleUpdate(false);
+        }
+    }
+
+    Instantiator {
+        model: Bluetooth.devices
+
+        Connections {
+            required property BluetoothDevice modelData
+            target: modelData
+
+            function onConnectedChanged() {
+                root.scheduleUpdate(true);
+            }
+            function onPairedChanged() {
+                root.scheduleUpdate(true);
+            }
+        }
+    }
+
+    function updateFriendlyDeviceList() {
+        if (!available || !enabled) {
+            if (connectedDevices.length > 0) connectedDevices = [];
+            if (pairedButNotConnectedDevices.length > 0) pairedButNotConnectedDevices = [];
+            if (unpairedDevices.length > 0) unpairedDevices = [];
+            if (friendlyDeviceList.length > 0) friendlyDeviceList = [];
+            return;
+        }
+        const devices = Bluetooth.devices.values;
+        const connected = devices.filter(d => d && d.connected).sort(sortFunction);
+        const paired = devices.filter(d => d && d.paired && !d.connected).sort(sortFunction);
+        const unpaired = devices.filter(d => d && !d.paired && !d.connected).sort(sortFunction);
+        const friendly = [...connected, ...paired, ...unpaired];
+
+        if (!areDeviceListsEqual(connectedDevices, connected))
+            connectedDevices = connected;
+        if (!areDeviceListsEqual(pairedButNotConnectedDevices, paired))
+            pairedButNotConnectedDevices = paired;
+        if (!areDeviceListsEqual(unpairedDevices, unpaired))
+            unpairedDevices = unpaired;
+        if (!areDeviceListsEqual(friendlyDeviceList, friendly))
+            friendlyDeviceList = friendly;
+    }
+
+    Component.onCompleted: {
+        updateFriendlyDeviceList();
+    }
 }


### PR DESCRIPTION
In an environment with a lot of bluetooth devices, filtering the device list can cause excessive CPU usage. I observed this at a university campus (~500 bt devices), one CPU core was pegged at 100% continuously due to this. This PR resolves this by updating the list at most once per second. We also implement some related fixes and improvements.

## Describe your changes

#### Performance

* Throttle sorting during discovery: On `main`, `BluetoothStatus` reactively re-filtered and sorted the device list on every `Bluetooth.devices.values` signal. During active discovery, this caused continuous CPU usage. List updates are now throttled to at most once every 1000ms.
* Avoid unnecessary model reassignments: Added a shallow equality check (`areDeviceListsEqual`) so `friendlyDeviceList` is only reassigned when the actual list contents change, preventing unnecessary delegate rebuilds.

#### Stability

* Fix Qt 6.11 crash (`ScriptModel`): In `BluetoothDialog` and `BluetoothControl`, replaced `ScriptModel { values: ... }` with direct binding `model: BluetoothStatus.friendlyDeviceList`. In Qt 6.11, reordering items within a `ScriptModel` causes a segfault in `QQmlDelegateModel::_q_itemsMoved`.
* Null-safety guards: Added optional chaining / guards (`Bluetooth.defaultAdapter?.`) across QuickToggles and Action Center controls to prevent errors when no Bluetooth adapter is present.
* Clean active device properties: Derived `firstActiveDevice`, `activeDeviceCount`, and `connected` from `connectedDevices` to avoid redundant filtering and null dereferences.

#### State & Lifecycle

* Stop discovery on close: Ensured discovery stops when closing the Action Center / Bluetooth dialog or when the default adapter initializes.
* Removed stray code: Removed accidental Bluetooth discovery triggers that were present in `NightLightControl.qml`.
* Preserve expanded item: Lifted `expandedAddress` into `BluetoothStatus` so an expanded device card does not collapse or jump while discovery is running.
* Immediate updates for connection/pairing: Used an `Instantiator` over `Bluetooth.devices` so connection and pairing state transitions update immediately rather than waiting for discovery throttling.
* MAC sorting regex: Updated `macRegex` to recognize colons (`AA:BB:CC:...`) in addition to hyphens, ensuring unnamed devices are consistently placed below named devices.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Tested and works well on my machine. Additional testing from others would be appreciated.


