### PR TITLE
fix(qs): rename notifications.monitor to forceMonitor in Config.qml and add null safety

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -399,7 +399,7 @@ Singleton {
 
             property JsonObject notifications: JsonObject {
                 property int timeout: 7000
-                property JsonObject monitor: JsonObject {
+                property JsonObject forceMonitor: JsonObject {
                     property bool enable: false
                     property string name: "" // Name of the monitor to show notifications on, like "eDP-1". Find out with 'hyprctl monitors' command
                 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -131,7 +131,7 @@ Item { // Bar content region
         BarGroup {
             id: middleCenterGroup
             anchors.verticalCenter: parent.verticalCenter
-            padding: workspacesWidget.widgetPadding
+            padding: workspacesWidget.widgetPadding ?? 4
 
             Workspaces {
                 id: workspacesWidget

--- a/dots/.config/quickshell/ii/modules/ii/bar/Workspaces.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/Workspaces.qml
@@ -31,6 +31,7 @@ ButtonMouseArea {
     property real workspaceIconOpacityShrinked: 1
     property real workspaceIconMarginShrinked: -4
     property int workspaceIndexInGroup: (monitor?.activeWorkspace?.id - 1) % wsModel.shownCount
+    property real widgetPadding: 0
     property real specialTextSize: workspaceButtonWidth * 0.5
 
     Layout.alignment: vertical ? Qt.AlignHCenter : Qt.AlignVCenter

--- a/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
@@ -14,7 +14,7 @@ Scope {
     PanelWindow {
         id: root
         visible: (Notifications.popupList.length > 0) && !GlobalStates.screenLocked
-        screen: Quickshell.screens.find(s => Config.options.notifications.forceMonitor.enable ? s.name === Config.options.notifications.forceMonitor.name : s.name === Hyprland.focusedMonitor?.name) ?? null
+        screen: Quickshell.screens.find(s => (Config.options?.notifications?.forceMonitor?.enable ?? false) ? s.name === Config.options.notifications.forceMonitor.name : s.name === Hyprland.focusedMonitor?.name) ?? null
 
         WlrLayershell.namespace: "quickshell:notificationPopup"
         WlrLayershell.layer: WlrLayer.Overlay


### PR DESCRIPTION
Closes #3593

## Describe your changes
- **Config schema alignment**: renamed property JsonObject monitor: to property JsonObject forceMonitor: in dots/.config/quickshell/ii/modules/common/Config.qml to match the rename from commit
  9e1568f (NotificationPopup.qml and InterfaceConfig.qml).
- **Startup crash (null safety)**: adds optional chaining in NotificationPopup.qml ((Config.options?.notifications?.forceMonitor?.enable ?? false)) for older user's config with
  "monitor" dont trigger TypeError: Cannot read property 'enable' of undefined.
- **Workspace padding fallback**: Adds widgetPadding ?? 4 in BarContent.qml and property real widgetPadding: 0 in Workspaces.qml to avoid the 'Unable to assign [undefined] to double warning.'

## Is it ready? Questions/feedback needed?
Yes, ready to merge. 
tested locally by reloading quickshell (pkill qs; qs -c ii) with clean startup logs.